### PR TITLE
Update Zend_Rest_Route::assemble signature

### DIFF
--- a/library/Zend/Rest/Route.php
+++ b/library/Zend/Rest/Route.php
@@ -239,9 +239,10 @@ class Zend_Rest_Route extends Zend_Controller_Router_Route_Module
      * @param array $data An array of variable and value pairs used as parameters
      * @param bool $reset Weither to reset the current params
      * @param bool $encode Weither to return urlencoded string
+     * @param bool $partial
      * @return string Route path with user submitted parameters
      */
-    public function assemble($data = array(), $reset = false, $encode = true)
+    public function assemble($data = array(), $reset = false, $encode = true, $partial = false)
     {
         if (!$this->_keysSet) {
             if (null === $this->_request) {


### PR DESCRIPTION
This is a step in the direction of making more of this work with php 7.2.

It gets rid of the `Declaration of Zend_Rest_Route::assemble($data = Array, $reset = false, $encode = true) must be compatible with Zend_Controller_Router_Route_Module::assemble($data = Array, $reset = false, $encode = true, $partial = false)` exception thrown when loading the rest module. It is backwards compatible with previously supported versions of php.

I'll probably have some more changes pertaining to php 7.2 since it is finally becoming the standard on most distros. Are you accepting patches on/maintaining this fork?