### PR TITLE
Add replace in composer.json for zf1 dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,5 +33,8 @@
     },
     "archive": {
         "exclude": ["/demos", "/documentation", "/tests"]
+    },
+    "replace": {
+        "zendframework/zendframework1": "1.*"
     }
 }


### PR DESCRIPTION
ZF1 dependencies (i.e. zf1 doctrine) require the original zf1 package. This PR adds `replace` to composer.json to make sure regular zf1 is not included in the vendor.
