### PR TITLE
Several fixes for usage with php 7.3 

### DIFF
--- a/library/Zend/Loader.php
+++ b/library/Zend/Loader.php
@@ -130,10 +130,14 @@ class Zend_Loader
         /**
          * Try finding for the plain filename in the include_path.
          */
+        // "@":
+        // - Avoid error-logs full of PHP Warnings due to autoloads from class-exists()-checks.
+        // - If a class does not exist that we really need, error will be thrown anyway.
+        // - Fatal errors from the included files are still thrown anyway.
         if ($once) {
-            include_once $filename;
+            @include_once $filename;
         } else {
-            include $filename;
+            @include $filename;
         }
 
         /**

--- a/library/Zend/Session.php
+++ b/library/Zend/Session.php
@@ -368,7 +368,7 @@ class Zend_Session extends Zend_Session_Abstract
             return;
         }
         
-        if (!self::sessionExists()) { // session_set_cookie_params(): Cannot change session cookie parameters when session is active
+        if (!self::$_sessionStarted) { // session_set_cookie_params(): Cannot change session cookie parameters when session is active
             $cookieParams = session_get_cookie_params();
             session_set_cookie_params(
                     $seconds,

--- a/library/Zend/Session.php
+++ b/library/Zend/Session.php
@@ -278,6 +278,7 @@ class Zend_Session extends Zend_Session_Abstract
             array(&$saveHandler, 'destroy'),
             array(&$saveHandler, 'gc')
             );
+        register_shutdown_function('session_write_close');
 
         if (!$result) {
             throw new Zend_Session_Exception('Unable to set session handler');

--- a/library/Zend/Session/SaveHandler/DbTable.php
+++ b/library/Zend/Session/SaveHandler/DbTable.php
@@ -337,8 +337,6 @@ class Zend_Session_SaveHandler_DbTable
      */
     public function write($id, $data)
     {
-        $return = false;
-
         $data = array($this->_modifiedColumn => time(),
                       $this->_dataColumn     => (string) $data);
 
@@ -348,17 +346,17 @@ class Zend_Session_SaveHandler_DbTable
             $data[$this->_lifetimeColumn] = $this->_getLifetime($rows->current());
 
             if ($this->update($data, $this->_getPrimary($id, self::PRIMARY_TYPE_WHERECLAUSE))) {
-                $return = true;
+                return true;
             }
         } else {
             $data[$this->_lifetimeColumn] = $this->_lifetime;
 
             if ($this->insert(array_merge($this->_getPrimary($id, self::PRIMARY_TYPE_ASSOC), $data))) {
-                $return = true;
+                return true;
             }
         }
 
-        return $return;
+        return false;
     }
 
     /**
@@ -369,13 +367,8 @@ class Zend_Session_SaveHandler_DbTable
      */
     public function destroy($id)
     {
-        $return = false;
-
-        if ($this->delete($this->_getPrimary($id, self::PRIMARY_TYPE_WHERECLAUSE))) {
-            $return = true;
-        }
-
-        return $return;
+        $this->delete($this->_getPrimary($id, self::PRIMARY_TYPE_WHERECLAUSE));
+        return true; //always return true, since if nothing can be deleted, it is already deleted and thats OK.
     }
 
     /**

--- a/library/Zend/Test/PHPUnit/ControllerTestCase.php
+++ b/library/Zend/Test/PHPUnit/ControllerTestCase.php
@@ -37,14 +37,14 @@ require_once 'Zend/Registry.php';
 /**
  * Functional testing scaffold for MVC applications
  *
- * @uses       PHPUnit_Framework_TestCase
+ * @uses       PHPUnit\Framework\TestCase
  * @category   Zend
  * @package    Zend_Test
  * @subpackage PHPUnit
  * @copyright  Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
-abstract class Zend_Test_PHPUnit_ControllerTestCase extends PHPUnit_Framework_TestCase
+abstract class Zend_Test_PHPUnit_ControllerTestCase extends PHPUnit\Framework\TestCase
 {
     /**
      * @var mixed Bootstrap file path or callback
@@ -120,7 +120,7 @@ abstract class Zend_Test_PHPUnit_ControllerTestCase extends PHPUnit_Framework_Te
      *
      * Calls {@link bootstrap()} by default
      */
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->bootstrap();
     }


### PR DESCRIPTION
- Avoid error-logs full of PHP Warnings due to autoloads from class-exists()-checks
- session errors
- Fix Test class path