### PR TITLE
Allow unit testing with PHP 7.2

### DIFF
--- a/library/Zend/Session.php
+++ b/library/Zend/Session.php
@@ -199,7 +199,7 @@ class Zend_Session extends Zend_Session_Abstract
     public static function setOptions(array $userOptions = array())
     {
         // set default options on first run only (before applying user settings)
-        if (!self::$_defaultOptionsSet) {
+        if (!self::$_defaultOptionsSet && !self::$_unitTestEnabled) {
             foreach (self::$_defaultOptions as $defaultOptionName => $defaultOptionValue) {
                 if (isset(self::$_defaultOptions[$defaultOptionName])) {
                     ini_set("session.$defaultOptionName", $defaultOptionValue);


### PR DESCRIPTION
This small fix will avoid errors with PHP 7.2 in unit tests caused by the following ini_set.