### PR TITLE
Count all keys with strictly non-null values

### DIFF
--- a/library/Zend/Db/Table/Abstract.php
+++ b/library/Zend/Db/Table/Abstract.php
@@ -1307,7 +1307,7 @@ abstract class Zend_Db_Table_Abstract
             if (is_array($keyValues) || $keyValues instanceof Countable) {
                 $keyValuesCount = count($keyValues);
             } else {
-                $keyValuesCount = $keyValues == null ? 0 : 1;
+                $keyValuesCount = $keyValues === null ? 0 : 1;
             }
             // Coerce the values to an array.
             // Don't simply typecast to array, because the values


### PR DESCRIPTION
Cater for values like empty strings and zeros when checking scalar types.

Currently, attempting to find a primary or composite key that has an empty string or zero value will throw exception 'Zend_Db_Table_Exception' with message 'Missing value(s) for the primary key' in vendor/shardj/zf1-future/library/Zend/Db/Table/Abstract.php:1322