### PR TITLE
Update Date::setOptions() -> fix phpdoc

### DIFF
--- a/library/Zend/Date.php
+++ b/library/Zend/Date.php
@@ -233,7 +233,7 @@ class Zend_Date extends Zend_Date_DateObject
      *
      * @param  array  $options  Options to set
      * @throws Zend_Date_Exception
-     * @return Options array if no option was given
+     * @return array|void if no option was given
      */
     public static function setOptions(array $options = array())
     {


### PR DESCRIPTION
@return Options is invalid (no such class etc).
Method either returns an array or void.

Zend Framework 1 reaches its End of Life (EOL) and is no longer maintained.
No Pull Requests will be accepted.

https://framework.zend.com/blog/2016-06-28-zf1-eol.html
