### PR TITLE
Fix count() Warnings on bin/zf create

### DIFF
--- a/library/Zend/Tool/Project/Profile/Resource/Container.php
+++ b/library/Zend/Tool/Project/Profile/Resource/Container.php
@@ -383,7 +383,7 @@ class Zend_Tool_Project_Profile_Resource_Container implements RecursiveIterator,
      */
     public function hasChildren()
     {
-        return (count($this->_subResources > 0)) ? true : false;
+        return (count($this->_subResources) > 0) ? true : false;
     }
 
     /**


### PR DESCRIPTION
Shardj#15

PHP Warning: count(): Parameter must be an array or an object that implements Countable in .\zf1-future\library\Zend\Tool\Project\Profile\Resource\Container.php on line 386
