### PR TITLE
Update DbTable.php

### DIFF
--- a/library/Zend/Session/SaveHandler/DbTable.php
+++ b/library/Zend/Session/SaveHandler/DbTable.php
@@ -347,9 +347,10 @@ class Zend_Session_SaveHandler_DbTable
         if (count($rows)) {
             $data[$this->_lifetimeColumn] = $this->_getLifetime($rows->current());
 
-            if ($this->update($data, $this->_getPrimary($id, self::PRIMARY_TYPE_WHERECLAUSE))) {
-                $return = true;
-            }
+            $this->update($data, $this->_getPrimary($id, self::PRIMARY_TYPE_WHERECLAUSE)); //will return number of rows affected
+      
+            $return = true; //always return true on update, even if 0 rows were effected (unchanged data with same timestamp)
+            
         } else {
             $data[$this->_lifetimeColumn] = $this->_lifetime;
 


### PR DESCRIPTION
The write() method returned false if the session data was not altered, which lead to a warning. This happens if two request for a session are fired at the same time (eg. file calls using the same session). 
Zend_Db_Adapter_Abstract->update() returns the number of affected rows and if the data does not change, it is 0.

Zend Framework 1 reaches its End of Life (EOL) and is no longer maintained.
No Pull Requests will be accepted.

https://framework.zend.com/blog/2016-06-28-zf1-eol.html
