### PR TITLE
Update ControllerTestCase.php

### DIFF
--- a/library/Zend/Test/PHPUnit/ControllerTestCase.php
+++ b/library/Zend/Test/PHPUnit/ControllerTestCase.php
@@ -44,7 +44,7 @@ require_once 'Zend/Registry.php';
  * @copyright  Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
-abstract class Zend_Test_PHPUnit_ControllerTestCase extends PHPUnit_Framework_TestCase
+abstract class Zend_Test_PHPUnit_ControllerTestCase extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var mixed Bootstrap file path or callback


### PR DESCRIPTION
changed the zend controller to use new namespaced phpunit classes.

I guess anyone who uses php7 and above will use a newer phpunit version

Zend Framework 1 reaches its End of Life (EOL) and is no longer maintained.
No Pull Requests will be accepted.

https://framework.zend.com/blog/2016-06-28-zf1-eol.html
