### PR TITLE
Update Atom.php

### DIFF
--- a/library/Zend/Feed/Entry/Atom.php
+++ b/library/Zend/Feed/Entry/Atom.php
@@ -103,7 +103,7 @@ class Zend_Feed_Entry_Atom extends Zend_Feed_Entry_Abstract
                 // Redirect
                 case 3:
                     $deleteUri = $response->getHeader('Location');
-                    continue;
+                    break;
                 // Error
                 default:
                     /**


### PR DESCRIPTION
Break from switch-case to retry redirected URI regarding deletion.

This issue arised during switching from the zendframework/zendframework1 to your fork in order to update to a newer PHP version.
One of our features relies on the Feed-component of zend, where this line creates a PHP warning.

By logic, the switch case tries to act on a 3xx-response by taking the given "Location" header's new URI and then re-running the logic to see how the deletion works out with the new, redirected URI. However, unfortunately, the "continue" seems to be with regards to the outer "do while(true)" loop, but doesn't have the intended effect. From the, from the warning suggested, "break" or "continue 2" options, "break" seems more accurately represent the intended logic.


Zend Framework 1 reaches its End of Life (EOL) and is no longer maintained.
No Pull Requests will be accepted.

https://framework.zend.com/blog/2016-06-28-zf1-eol.html