### PR TITLE
Fix php 7.4 deprecation curly brakets access on strings

### DIFF
--- a/library/Zend/Barcode/Object/Upce.php
+++ b/library/Zend/Barcode/Object/Upce.php
@@ -84,8 +84,8 @@ class Zend_Barcode_Object_Upce extends Zend_Barcode_Object_Ean13
     public function getText()
     {
         $text = parent::getText();
-        if ($text{0} != 1) {
-            $text{0} = 0;
+        if ($text[0] != 1) {
+            $text[0] = 0;
         }
         return $text;
     }
@@ -222,8 +222,8 @@ class Zend_Barcode_Object_Upce extends Zend_Barcode_Object_Ean13
     public function getChecksum($text)
     {
         $text = $this->_addLeadingZeros($text, true);
-        if ($text{0} != 1) {
-            $text{0} = 0;
+        if ($text[0] != 1) {
+            $text[0] = 0;
         }
         return parent::getChecksum($text);
     }

--- a/library/Zend/Filter/Compress/Zip.php
+++ b/library/Zend/Filter/Compress/Zip.php
@@ -237,7 +237,7 @@ class Zend_Filter_Compress_Zip extends Zend_Filter_Compress_CompressAbstract
             for ($i = 0; $i < $zip->numFiles; $i++) {
                 $statIndex = $zip->statIndex($i);
                 $currName = $statIndex['name'];
-                if (($currName{0} == '/') ||
+                if (($currName[0] == '/') ||
                     (substr($currName, 0, 2) == '..') ||
                     (substr($currName, 0, 4) == './..')
                     )

--- a/library/Zend/Json/Decoder.php
+++ b/library/Zend/Json/Decoder.php
@@ -552,7 +552,7 @@ class Zend_Json_Decoder
             return mb_convert_encoding($utf16, 'UTF-8', 'UTF-16');
         }
 
-        $bytes = (ord($utf16{0}) << 8) | ord($utf16{1});
+        $bytes = (ord($utf16[0]) << 8) | ord($utf16[1]);
 
         switch (true) {
             case ((0x7F & $bytes) == $bytes):

--- a/library/Zend/Json/Encoder.php
+++ b/library/Zend/Json/Encoder.php
@@ -558,17 +558,17 @@ class Zend_Json_Encoder
             case 2:
                 // return a UTF-16 character from a 2-byte UTF-8 char
                 // see: http://www.cl.cam.ac.uk/~mgk25/unicode.html#utf-8
-                return chr(0x07 & (ord($utf8{0}) >> 2))
-                     . chr((0xC0 & (ord($utf8{0}) << 6))
-                         | (0x3F & ord($utf8{1})));
+                return chr(0x07 & (ord($utf8[0]) >> 2))
+                     . chr((0xC0 & (ord($utf8[0]) << 6))
+                         | (0x3F & ord($utf8[1])));
 
             case 3:
                 // return a UTF-16 character from a 3-byte UTF-8 char
                 // see: http://www.cl.cam.ac.uk/~mgk25/unicode.html#utf-8
-                return chr((0xF0 & (ord($utf8{0}) << 4))
-                         | (0x0F & (ord($utf8{1}) >> 2)))
-                     . chr((0xC0 & (ord($utf8{1}) << 6))
-                         | (0x7F & ord($utf8{2})));
+                return chr((0xF0 & (ord($utf8[0]) << 4))
+                         | (0x0F & (ord($utf8[1]) >> 2)))
+                     . chr((0xC0 & (ord($utf8[1]) << 6))
+                         | (0x7F & ord($utf8[2])));
         }
 
         // ignoring UTF-32 for now, sorry

--- a/library/Zend/Tool/Project/Context/Zf/ApplicationConfigFile.php
+++ b/library/Zend/Tool/Project/Context/Zf/ApplicationConfigFile.php
@@ -139,7 +139,7 @@ class Zend_Tool_Project_Context_Zf_ApplicationConfigFile extends Zend_Tool_Proje
             $newLines[] = $contentLine;
             if ($insideSection) {
                 // if its blank, or a section heading
-                if (isset($contentLines[$contentLineIndex + 1]{0}) && $contentLines[$contentLineIndex + 1]{0} == '[') {
+                if (isset($contentLines[$contentLineIndex + 1][0]) && $contentLines[$contentLineIndex + 1][0] == '[') {
                     $newLines[] = $key . ' = ' . $value;
                     $insideSection = null;
                 } else if (!isset($contentLines[$contentLineIndex + 1])){

--- a/library/Zend/View/Helper/Navigation/Sitemap.php
+++ b/library/Zend/View/Helper/Navigation/Sitemap.php
@@ -253,10 +253,10 @@ class Zend_View_Helper_Navigation_Sitemap
     {
         $href = $page->getHref();
 
-        if (!isset($href{0})) {
+        if (!isset($href[0])) {
             // no href
             return '';
-        } elseif ($href{0} == '/') {
+        } elseif ($href[0] == '/') {
             // href is relative to root; use serverUrl helper
             $url = $this->getServerUrl() . $href;
         } elseif (preg_match('/^[a-z]+:/im', (string) $href)) {

--- a/library/Zend/Wildfire/Plugin/FirePhp.php
+++ b/library/Zend/Wildfire/Plugin/FirePhp.php
@@ -742,7 +742,7 @@ class Zend_Wildfire_Plugin_FirePhp implements Zend_Wildfire_Plugin_Interface
 
                 $name = $raw_name = $just_name;
 
-                if ($name{0} == "\0") {
+                if ($name[0] == "\0") {
                     $parts = explode("\0", $name);
                     $name = $parts[2];
                 }


### PR DESCRIPTION
https://www.php.net/manual/en/migration74.deprecated.php#migration74.deprecated.core.array-string-access-curly-brace

Should be working on older versions of php just fine.