### PR TITLE
Remove offsetExists from Zend_Registry to silence deprecation warning

### DIFF
--- a/library/Zend/Registry.php
+++ b/library/Zend/Registry.php
@@ -195,15 +195,4 @@ class Zend_Registry extends ArrayObject
         parent::__construct($array, $flags);
     }
 
-    /**
-     * @param string $index
-     * @returns mixed
-     *
-     * Workaround for http://bugs.php.net/bug.php?id=40442 (ZF-960).
-     */
-    public function offsetExists($index)
-    {
-        return array_key_exists($index, $this);
-    }
-
 }


### PR DESCRIPTION
Remove offsetExists from Zend_Registry to silence array_key_exists on object deprecation warning

The method offsetExists was a workaround for a SPL bug which was fixed in April 2007, see http://bugs.php.net/bug.php?id=40442