### PR TITLE
set zf1 replace version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,6 +35,6 @@
         "exclude": ["/demos", "/documentation", "/tests"]
     },
     "replace": {
-        "zendframework/zendframework1": "1.12.20"
+        "zendframework/zendframework1": "self.version"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -35,6 +35,6 @@
         "exclude": ["/demos", "/documentation", "/tests"]
     },
     "replace": {
-        "zendframework/zendframework1": "1.*"
+        "zendframework/zendframework1": "1.12.20"
     }
 }


### PR DESCRIPTION
in order to be in compliance with Roave/SecurityAdvisories I have set the zf1 version to an acceptable version. 
Could someone check if this version is still in compliance with the original requirement for the dependant packages please?