### PR TITLE
Address iconv_substr incompatibility between php 5.x and 7.x

### DIFF
--- a/library/Zend/Locale/Format.php
+++ b/library/Zend/Locale/Format.php
@@ -925,7 +925,7 @@ class Zend_Locale_Format
                             $result['day']    = $splitted[0][$cnt];
                         }
                     } else {
-                        $result['day'] = iconv_substr($splitted[0][0], $split, 2);
+                        $result['day'] = (iconv_substr($splitted[0][0], $split, 2)?: false);
                         $split += 2;
                     }
                     ++$cnt;
@@ -936,7 +936,7 @@ class Zend_Locale_Format
                             $result['month']  = $splitted[0][$cnt];
                         }
                     } else {
-                        $result['month'] = iconv_substr($splitted[0][0], $split, 2);
+                        $result['month'] = (iconv_substr($splitted[0][0], $split, 2)?: false);
                         $split += 2;
                     }
                     ++$cnt;
@@ -953,7 +953,7 @@ class Zend_Locale_Format
                             $result['year']   = $splitted[0][$cnt];
                         }
                     } else {
-                        $result['year']   = iconv_substr($splitted[0][0], $split, $length);
+                        $result['year']   = (iconv_substr($splitted[0][0], $split, $length)?: false);
                         $split += $length;
                     }
 
@@ -965,7 +965,7 @@ class Zend_Locale_Format
                             $result['hour']   = $splitted[0][$cnt];
                         }
                     } else {
-                        $result['hour']   = iconv_substr($splitted[0][0], $split, 2);
+                        $result['hour']   = (iconv_substr($splitted[0][0], $split, 2)?: false);
                         $split += 2;
                     }
                     ++$cnt;
@@ -976,7 +976,7 @@ class Zend_Locale_Format
                             $result['minute'] = $splitted[0][$cnt];
                         }
                     } else {
-                        $result['minute'] = iconv_substr($splitted[0][0], $split, 2);
+                        $result['minute'] = (iconv_substr($splitted[0][0], $split, 2)?: false);
                         $split += 2;
                     }
                     ++$cnt;
@@ -987,7 +987,7 @@ class Zend_Locale_Format
                             $result['second'] = $splitted[0][$cnt];
                         }
                     } else {
-                        $result['second'] = iconv_substr($splitted[0][0], $split, 2);
+                        $result['second'] = (iconv_substr($splitted[0][0], $split, 2)?: false);
                         $split += 2;
                     }
                     ++$cnt;


### PR DESCRIPTION
(PHP 5, PHP 7)
iconv_substr — Cut out part of a string

Description
iconv_substr ( string $str , int $offset [, int $length = iconv_strlen($str, $charset) [, string $charset = ini_get("iconv.internal_encoding") ]] ) : string
...
Version    Description
7.0.11    If str is equal to offset characters long, an empty string will be returned. Prior to this version, FALSE was returned in this case.

Because of the above change, ZF1 fails to successfully initialise a DateTime object when necessary information is missing from the value provided leading to unhandled exception.