### PR TITLE
Compatability for PHPUnit 9.0.1

### DIFF
--- a/library/Zend/Test/PHPUnit/ControllerTestCase.php
+++ b/library/Zend/Test/PHPUnit/ControllerTestCase.php
@@ -120,7 +120,7 @@ abstract class Zend_Test_PHPUnit_ControllerTestCase extends PHPUnit_Framework_Te
      *
      * Calls {@link bootstrap()} by default
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->bootstrap();
     }

--- a/library/Zend/Test/PHPUnit/ControllerTestCase.php
+++ b/library/Zend/Test/PHPUnit/ControllerTestCase.php
@@ -120,7 +120,7 @@ abstract class Zend_Test_PHPUnit_ControllerTestCase extends PHPUnit_Framework_Te
      *
      * Calls {@link bootstrap()} by default
      */
-    protected function setUp()
+    public function setUp(): void
     {
         $this->bootstrap();
     }


### PR DESCRIPTION
Fixes
```PHP Fatal error:  Declaration of Zend_Test_PHPUnit_ControllerTestCase::setUp() must be compatible with PHPUnit\Framework\TestCase::setUp()```