### PR TITLE
The type attribute is unnecessary for JavaScript resources.

### DIFF
--- a/library/Zend/View/Helper/HeadScript.php
+++ b/library/Zend/View/Helper/HeadScript.php
@@ -433,7 +433,12 @@ class Zend_View_Helper_HeadScript extends Zend_View_Helper_Placeholder_Container
         $addScriptEscape = !(isset($item->attributes['noescape']) && filter_var($item->attributes['noescape'], FILTER_VALIDATE_BOOLEAN));
 
         $type = ($this->_autoEscape) ? $this->_escape($item->type) : $item->type;
-        $html  = '<script type="' . $type . '"' . $attrString . '>';
+        if ($this->view->doctype()->isHtml5() && $type === 'text/javascript') {
+            $html  = '<script' . $attrString . '>';
+        } else {
+            $html  = '<script type="' . $type . '"' . $attrString . '>';
+        }
+
         if (!empty($item->source)) {
             $html .= PHP_EOL ;
 


### PR DESCRIPTION
https://validator.w3.org/ will display warning if type="text/javascript" is present for script tag for html5 document.