### PR TITLE
Prevent conflict with roave/securityadvisories

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,6 +35,6 @@
         "exclude": ["/demos", "/documentation", "/tests"]
     },
     "replace": {
-        "zendframework/zendframework1": "1.*"
+        "zendframework/zendframework1": ">=1.12.20"
     }
 }


### PR DESCRIPTION
Solving the following problem

``` 
 Problem 1
    - Conclusion: don't install shardj/zf1-future 1.17.0
    - Conclusion: don't install shardj/zf1-future 1.16.2
    - Conclusion: don't install shardj/zf1-future 1.16.1
    - Conclusion: don't install shardj/zf1-future 1.16.0
    - Conclusion: don't install shardj/zf1-future 1.15.2
    - Conclusion: don't install shardj/zf1-future 1.15.1
    - shardj/zf1-future 1.15.0 conflicts with roave/security-advisories[dev-master].
    - shardj/zf1-future 1.15.0 conflicts with roave/security-advisories[dev-master].
    - shardj/zf1-future 1.15.0 conflicts with roave/security-advisories[dev-master].
    - Installation request for shardj/zf1-future ^1.15 -> satisfiable by shardj/zf1-future[1.15.0, 1.15.1, 1.15.2, 1.16.0, 1.16.1, 1.16.2, 1.17.0].
    - Installation request for roave/security-advisories dev-master -> satisfiable by roave/security-advisories[dev-master].
```

Also see comment: https://github.com/Shardj/zf1-future/commit/a4437324e6d705b46017489d241a9d9ae9ef4192