### PR TITLE
Avoid repeating identical error messages

### DIFF
--- a/library/Zend/Form/Element.php
+++ b/library/Zend/Form/Element.php
@@ -2276,6 +2276,7 @@ class Zend_Form_Element implements Zend_Validate_Interface
                 foreach ($value as $val) {
                     $aggregateMessages[] = str_replace('%value%', $val, $message);
                 }
+                $aggregateMessages = array_unique($aggregateMessages); //prevent repeating the identical error message for multichoice-items
                 if (count($aggregateMessages)) {
                     if ($this->_concatJustValuesInErrorMessage) {
                         $values = implode($this->getErrorMessageSeparator(), $value);


### PR DESCRIPTION
If an error message is available for a Zend_Form_Element_Multiselect element, the identical message is repeated for each item of the multiselect element. To avoid this, we can only display the unique error messages per element.