### PR TITLE
fix psalm issue (InvalidDocblock)

### DIFF
--- a/library/Zend/XmlRpc/Fault.php
+++ b/library/Zend/XmlRpc/Fault.php
@@ -140,7 +140,7 @@ class Zend_XmlRpc_Fault
     /**
      * Retrieve fault message
      *
-     * @param string
+     * @param string $message
      * @return Zend_XmlRpc_Fault
      */
     public function setMessage($message)


### PR DESCRIPTION
 InvalidDocblock -  ..../library/Zend/XmlRpc/Fault.php:146:5 - Badly-formatted @param in docblock for Zend_XmlRpc_Fault::setMessage (see https://psalm.dev/008)