### PR TITLE
compatibility with older php versions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ vendor/*
 composer.lock
 bin/dbunit
 bin/phpunit
+.php_cs.cache

--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -1,0 +1,12 @@
+<?php
+
+$finder = PhpCsFixer\Finder::create()
+    ->notPath('tests/Zend/Loader/_files/ParseError.php')
+    ->in('.');
+
+return PhpCsFixer\Config::create()
+    ->setFinder($finder)
+    ->setRules([
+        'array_syntax' => ['syntax' => 'long'],
+        'list_syntax' => ['syntax' => 'long'],
+    ]);

--- a/composer.json
+++ b/composer.json
@@ -9,8 +9,7 @@
     "homepage": "http://framework.zend.com/",
     "license": "BSD-3-Clause",
     "require": {
-        "php": ">=7.1",
-        "ext-json": "*"
+        "php": ">=5.4"
     },
     "autoload": {
         "psr-0": {

--- a/library/Zend/Validate/File/Count.php
+++ b/library/Zend/Validate/File/Count.php
@@ -254,7 +254,7 @@ class Zend_Validate_File_Count extends Zend_Validate_Abstract
             $this->addFile($value);
         }
 
-        $this->_count = count($this->_files === null ? [] : $this->_files);
+        $this->_count = count($this->_files === null ? array() : $this->_files);
         if (($this->_max !== null) && ($this->_count > $this->_max)) {
             return $this->_throw($file, self::TOO_MANY);
         }

--- a/library/Zend/Version.php
+++ b/library/Zend/Version.php
@@ -69,14 +69,14 @@ final class Zend_Version
         if (null === self::$_latestVersion) {
             self::$_latestVersion = 'not available';
 
-            $opts = [
-                'http' => [
+            $opts = array(
+                'http' => array(
                     'method' => 'GET',
-                    'header' => [
+                    'header' => array(
                         'User-Agent: PHP'
-                    ]
-                ]
-            ];
+                    )
+                )
+            );
             $context = stream_context_create($opts);
             $content = file_get_contents('https://api.github.com/repos/Shardj/zf1-future/releases/latest', false, $context);
 

--- a/library/Zend/XmlRpc/Value.php
+++ b/library/Zend/XmlRpc/Value.php
@@ -486,13 +486,13 @@ abstract class Zend_XmlRpc_Value
      */
     protected static function _extractTypeAndValue(SimpleXMLElement $xml, &$type, &$value)
     {
-        [$type, $value] = [key($xml), current($xml)];
+        list($type, $value) = array(key($xml), current($xml));
 
         if (!$type and $value === null) {
             $namespaces = array('ex' => 'http://ws.apache.org/xmlrpc/namespaces/extensions');
             foreach ($namespaces as $namespaceName => $namespaceUri) {
                 $namespaceXml = $xml->children($namespaceUri);
-                [$type, $value] = [key($namespaceXml), current($namespaceXml)];
+                list($type, $value) = array(key($namespaceXml), current($namespaceXml));
                 if ($type !== null) {
                     $type = $namespaceName . ':' . $type;
                     break;


### PR DESCRIPTION
As discussed in https://github.com/Shardj/zf1-future/issues/50
I've added a PhpCsFixer config, that only fixes the backwards incompatibilities.
Also removed ext-json, because 99% of the framework doesn't use it, and original zf1 does not require it.