### PR TITLE
Fixing PSR-0 notices

### DIFF
--- a/library/Zend/Application/Resource/Useragent.php
+++ b/library/Zend/Application/Resource/Useragent.php
@@ -26,7 +26,7 @@
  * @copyright  Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
-class Zend_Application_Resource_UserAgent extends Zend_Application_Resource_ResourceAbstract
+class UserAgent extends Zend_Application_Resource_ResourceAbstract
 {
     /**
      * @var Zend_Http_UserAgent

--- a/library/Zend/Gdata/Analytics/Extension/Goal.php
+++ b/library/Zend/Gdata/Analytics/Extension/Goal.php
@@ -30,7 +30,7 @@ require_once 'Zend/Gdata/Extension.php';
  * @package    Zend_Gdata
  * @subpackage Analytics
  */
-class Zend_Gdata_Analytics_Goal extends Zend_Gdata_Extension
+class Goal extends Zend_Gdata_Extension
 {
     protected $_rootNamespace = 'ga';
     protected $_rootElement = 'goal';

--- a/library/Zend/Tool/Framework/Provider/DocblockManifestable.php
+++ b/library/Zend/Tool/Framework/Provider/DocblockManifestable.php
@@ -25,6 +25,6 @@
  * @copyright  Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
-interface Zend_Tool_Framework_Provider_DocblockManifestInterface
+interface DocblockManifestInterface
 {
 }

--- a/library/Zend/Validate/Barcode/Intelligentmail.php
+++ b/library/Zend/Validate/Barcode/Intelligentmail.php
@@ -30,7 +30,7 @@ require_once 'Zend/Validate/Barcode/AdapterAbstract.php';
  * @copyright  Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
-class Zend_Validate_Barcode_IntelligentMail extends Zend_Validate_Barcode_AdapterAbstract
+class IntelligentMail extends Zend_Validate_Barcode_AdapterAbstract
 {
     /**
      * Allowed barcode lengths


### PR DESCRIPTION
While doing composer update on our production nodes we got a few PSR-0 warnings from composer. For those, who don't know, PSR-0 is autoloading standard. And one of requirements for it is that class names must correlate to directory structure, so as namespace. 

So instead of "class Zend_Application_Resource_UserAgent" it should be "class UserAgent".
Zend_Application_Resource_ bit could be namespace \Zend\Application\Resource, but in this case it doesn't have any namespace, so PSR will not complain.

I have checked these 4 classes and it doesn't seem like they are called anywhere in Zend layer, so it should work just fine.