### PR TITLE
Added auto translate for Form Element getDescription

### DIFF
--- a/library/Zend/Form/Element.php
+++ b/library/Zend/Form/Element.php
@@ -735,6 +735,11 @@ class Zend_Form_Element implements Zend_Validate_Interface
      */
     public function getDescription()
     {
+        $translator = $this->getTranslator();
+        if (null !== $translator) {
+            return $translator->translate($this->_description);
+        }
+
         return $this->_description;
     }
 


### PR DESCRIPTION
Added auto translate to Form Element getDescription(). This is the exact same pattern used in Form Element getLabel(). Appears to be an oversight by the original ZF1 team. Pattern should not break any existing code. Comments appreciated.