### PR TITLE
Remove redundant @method annotation

### DIFF
--- a/library/Zend/View/Helper/HeadMeta.php
+++ b/library/Zend/View/Helper/HeadMeta.php
@@ -41,7 +41,6 @@ require_once 'Zend/View/Helper/Placeholder/Container/Standalone.php';
  * @method $this prependHttpEquiv($keyValue, $content, $conditionalHttpEquiv)
  * @method $this prependName($keyValue, $content, $conditionalName)
  * @method $this prependProperty($property, $content, $modifiers)
- * @method $this setCharset($charset)
  * @method $this setHttpEquiv($keyValue, $content, $modifiers)
  * @method $this setName($keyValue, $content, $modifiers)
  * @method $this setProperty($property, $content, $modifiers)


### PR DESCRIPTION
Method setCharset is declared regular (non-automagic), the @method annotation therefor is redundant.