### PR TITLE
fix: Fatal error: Cannot unset $this in ./library/Zend/Service/WindowsAzure/Storage/Batch.php on line 108

### DIFF
--- a/library/Zend/Service/WindowsAzure/Storage/Batch.php
+++ b/library/Zend/Service/WindowsAzure/Storage/Batch.php
@@ -105,7 +105,6 @@ class Zend_Service_WindowsAzure_Storage_Batch
         unset($this->_operations);
         $this->_storageClient->setCurrentBatch(null);
         $this->_storageClient = null;
-        unset($this);
     }
 
 	/**


### PR DESCRIPTION
```
Fatal error: Cannot unset $this in ./vendor/shardj/zf1-future/library/Zend/Service/WindowsAzure/Storage/Batch.php on line 108
Errors parsing ./vendor/shardj/zf1-future/library/Zend/Service/WindowsAzure/Storage/Batch.php
```

unset($this) is a useless statement, doesn't do anything