### PR TITLE
Handling \Throwable in error controller

### DIFF
--- a/library/Zend/Controller/Dispatcher/Standard.php
+++ b/library/Zend/Controller/Dispatcher/Standard.php
@@ -306,7 +306,7 @@ class Zend_Controller_Dispatcher_Standard extends Zend_Controller_Dispatcher_Abs
 
         try {
             $controller->dispatch($action);
-        } catch (Exception $e) {
+        } catch (\Throwable $e) {
             // Clean output buffer on error
             $curObLevel = ob_get_level();
             if ($curObLevel > $obLevel) {

--- a/library/Zend/Controller/Plugin/Broker.php
+++ b/library/Zend/Controller/Plugin/Broker.php
@@ -235,7 +235,7 @@ class Zend_Controller_Plugin_Broker extends Zend_Controller_Plugin_Abstract
         foreach ($this->_plugins as $plugin) {
             try {
                 $plugin->routeStartup($request);
-            } catch (Exception $e) {
+            } catch (\Throwable $e) {
                 if (Zend_Controller_Front::getInstance()->throwExceptions()) {
                     throw new Zend_Controller_Exception($e->getMessage() . $e->getTraceAsString(), $e->getCode(), $e);
                 } else {
@@ -258,7 +258,7 @@ class Zend_Controller_Plugin_Broker extends Zend_Controller_Plugin_Abstract
         foreach ($this->_plugins as $plugin) {
             try {
                 $plugin->routeShutdown($request);
-            } catch (Exception $e) {
+            } catch (\Throwable $e) {
                 if (Zend_Controller_Front::getInstance()->throwExceptions()) {
                     throw new Zend_Controller_Exception($e->getMessage() . $e->getTraceAsString(), $e->getCode(), $e);
                 } else {
@@ -285,7 +285,7 @@ class Zend_Controller_Plugin_Broker extends Zend_Controller_Plugin_Abstract
         foreach ($this->_plugins as $plugin) {
             try {
                 $plugin->dispatchLoopStartup($request);
-            } catch (Exception $e) {
+            } catch (\Throwable $e) {
                 if (Zend_Controller_Front::getInstance()->throwExceptions()) {
                     throw new Zend_Controller_Exception($e->getMessage() . $e->getTraceAsString(), $e->getCode(), $e);
                 } else {
@@ -307,7 +307,7 @@ class Zend_Controller_Plugin_Broker extends Zend_Controller_Plugin_Abstract
         foreach ($this->_plugins as $plugin) {
             try {
                 $plugin->preDispatch($request);
-            } catch (Exception $e) {
+            } catch (\Throwable $e) {
                 if (Zend_Controller_Front::getInstance()->throwExceptions()) {
                     throw new Zend_Controller_Exception($e->getMessage() . $e->getTraceAsString(), $e->getCode(), $e);
                 } else {
@@ -331,7 +331,7 @@ class Zend_Controller_Plugin_Broker extends Zend_Controller_Plugin_Abstract
         foreach ($this->_plugins as $plugin) {
             try {
                 $plugin->postDispatch($request);
-            } catch (Exception $e) {
+            } catch (\Throwable $e) {
                 if (Zend_Controller_Front::getInstance()->throwExceptions()) {
                     throw new Zend_Controller_Exception($e->getMessage() . $e->getTraceAsString(), $e->getCode(), $e);
                 } else {
@@ -353,7 +353,7 @@ class Zend_Controller_Plugin_Broker extends Zend_Controller_Plugin_Abstract
        foreach ($this->_plugins as $plugin) {
            try {
                 $plugin->dispatchLoopShutdown();
-            } catch (Exception $e) {
+            } catch (\Throwable $e) {
                 if (Zend_Controller_Front::getInstance()->throwExceptions()) {
                     throw new Zend_Controller_Exception($e->getMessage() . $e->getTraceAsString(), $e->getCode(), $e);
                 } else {

--- a/library/Zend/Controller/Response/Abstract.php
+++ b/library/Zend/Controller/Response/Abstract.php
@@ -39,7 +39,7 @@ abstract class Zend_Controller_Response_Abstract
 
     /**
      * Exception stack
-     * @var Throwable
+     * @var Throwable[]
      */
     protected $_exceptions = array();
 

--- a/tests/Zend/Controller/_files/ErrorController.php
+++ b/tests/Zend/Controller/_files/ErrorController.php
@@ -1,0 +1,14 @@
+<?php
+
+class ErrorController extends Zend_Controller_Action
+{
+    public function errorAction()
+    {
+        $errors = $this->_getParam('error_handler');
+
+        $this->getResponse()
+            ->setHttpResponseCode(500)
+            ->appendBody($errors->type . PHP_EOL)
+            ->appendBody($errors->exception->getMessage());
+    }
+}

--- a/tests/Zend/Controller/_files/IndexController.php
+++ b/tests/Zend/Controller/_files/IndexController.php
@@ -99,4 +99,20 @@ class IndexController extends Zend_Controller_Action
         $this->_response->appendBody('Reset action called');
     }
 
+    public function typeErrorAction()
+    {
+        $this->produceTypeError();
+        $this->_response->appendBody('Type error action called');
+    }
+
+    public function exceptionAction()
+    {
+        throw new \Exception('This is an exception message');
+        $this->_response->appendBody('Exception action called');
+    }
+
+    private function produceTypeError(): self
+    {
+        return new stdClass();
+    }
 }

--- a/tests/Zend/Controller/_files/Plugins/ThrowingPlugin.php
+++ b/tests/Zend/Controller/_files/Plugins/ThrowingPlugin.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace MyApp\Controller\Plugin;
+use stdClass;
+use Zend_Controller_Request_Abstract;
+
+require_once 'Zend/Controller/Action/Helper/Abstract.php';
+class ThrowingPlugin extends \Zend_Controller_Plugin_Abstract {
+
+    public function dispatchLoopStartup(Zend_Controller_Request_Abstract $request)
+    {
+        $this->produceTypeError();
+        throw new \Exception('Should not ever get here');
+    }
+
+    private function produceTypeError(): self
+    {
+        return new stdClass();
+    }
+}


### PR DESCRIPTION
There are multiple places where `Exception` is caught instead of `\Throwable`. This causes that if any such code inside those method throws `TypeError` such error is not handled in the expected way. There was already some code around action ErrorExceptions, but there was no code regarding ErrorExceptions from plugins. 

This PR replaces all those places and also adds test that checks that TypeException is correctly propagated. 