### PR TITLE
Fix curly brace array access

### DIFF
--- a/library/Zend/Validate/Isbn.php
+++ b/library/Zend/Validate/Isbn.php
@@ -167,7 +167,7 @@ class Zend_Validate_Isbn extends Zend_Validate_Abstract
                 $isbn10 = str_replace($this->_separator, '', $value);
                 $sum    = 0;
                 for ($i = 0; $i < 9; $i++) {
-                    $sum += (10 - $i) * $isbn10{$i};
+                    $sum += (10 - $i) * $isbn10[$i];
                 }
 
                 // checksum
@@ -185,9 +185,9 @@ class Zend_Validate_Isbn extends Zend_Validate_Abstract
                 $sum    = 0;
                 for ($i = 0; $i < 12; $i++) {
                     if ($i % 2 == 0) {
-                        $sum += $isbn13{$i};
+                        $sum += $isbn13[$i];
                     } else {
-                        $sum += 3 * $isbn13{$i};
+                        $sum += 3 * $isbn13[$i];
                     }
                 }
                 // checksum

--- a/tests/Zend/CodeGenerator/Php/FileTest.php
+++ b/tests/Zend/CodeGenerator/Php/FileTest.php
@@ -287,7 +287,7 @@ EOS;
 
         $targetLength = strlen('require_once \'SampleClass.php\';');
         $this->assertEquals($targetLength, strlen($lines[2]));
-        $this->assertEquals(';', $lines[2]{$targetLength-1});
+        $this->assertEquals(';', $lines[2][$targetLength-1]);
     }
 
     /**


### PR DESCRIPTION
When using PHP 7.4 the array access via curly braces is deprecated. So I fixed it for whole project.
https://wiki.php.net/rfc/deprecate_curly_braces_array_access