### PR TITLE
Remove converting `127.0.0.1` to `(local)` 

### DIFF
--- a/library/Zend/Db/Adapter/Pdo/Sqlsrv.php
+++ b/library/Zend/Db/Adapter/Pdo/Sqlsrv.php
@@ -93,9 +93,6 @@ class Zend_Db_Adapter_Pdo_Sqlsrv extends Zend_Db_Adapter_Pdo_Abstract
             }
 
             if(isset($dsn['host'])) {
-                if($dsn['host'] == '127.0.0.1') {
-                    $dsn['host'] = '(local)';
-                }
                 $dsn['Server'] = $dsn['host'];
                 unset($dsn['host']);
             }


### PR DESCRIPTION
Remove converting `127.0.0.1` to `(local)` because of incompatibilities on UNIX systems in combination with Docker

On UNIX based System (also Mac) a connection to a MSSQL database with Pdo_Sqlsrv is only possible when using `127.0.0.1`. It does not work with `localhost` or `(local)`. When removing those lines of code my connection works perfectly when `127.0.0.1` is configured.

https://github.com/microsoft/msphpsql/issues/1014
https://github.com/microsoft/msphpsql/issues/323