### PR TITLE
Refactor nested ternary expression

### DIFF
--- a/library/Zend/Service/Console/Command.php
+++ b/library/Zend/Service/Console/Command.php
@@ -220,7 +220,7 @@ class Zend_Service_Console_Command
 
 			for ($hi = 0; $hi < count($handlers); $hi++) {
 				$handler = $handlers[$hi];
-				$handlerDescription = isset($handlerDescriptions[$hi]) ? $handlerDescriptions[$hi] : isset($handlerDescriptions[0]) ? $handlerDescriptions[0] : '';
+				$handlerDescription = $handlerDescriptions[$hi] ?? $handlerDescriptions[0] ?? '';
 				$handlerDescription = str_replace('\r\n', "\r\n", $handlerDescription);
 				$handlerDescription = str_replace('\n', "\n", $handlerDescription);
 


### PR DESCRIPTION
Nested ternary expressions are deprecated as of PHP 7.4. I've replaced it with a null coalescing expression as it's more easy to read.

See: https://wiki.php.net/rfc/ternary_associativity