### PR TITLE
[NEW FEATURE] mail: added verify_peer and verify_peer_name parameters

### DIFF
--- a/library/Zend/Mail/Protocol/Abstract.php
+++ b/library/Zend/Mail/Protocol/Abstract.php
@@ -96,6 +96,20 @@ abstract class Zend_Mail_Protocol_Abstract
 
 
     /**
+     * Indicates that verification of SSL certificate is required.
+     * @var bool
+     */
+    protected $_verifyPeer = true;
+
+
+    /**
+     * Indicates that verification of peer name is required.
+     * @var bool
+     */
+    protected $_verifyPeerName = true;
+
+
+    /**
      * Last request sent to server
      * @var string
      */
@@ -127,12 +141,13 @@ abstract class Zend_Mail_Protocol_Abstract
     /**
      * Constructor.
      *
-     * @param  string  $host OPTIONAL Hostname of remote connection (default: 127.0.0.1)
-     * @param  integer $port OPTIONAL Port number (default: null)
+     * @param  string  $host   OPTIONAL Hostname of remote connection (default: 127.0.0.1)
+     * @param  integer $port   OPTIONAL Port number (default: null)
+     * @param  array   $config OPTIONAL Further parameters
      * @throws Zend_Mail_Protocol_Exception
      * @return void
      */
-    public function __construct($host = '127.0.0.1', $port = null)
+    public function __construct($host = '127.0.0.1', $port = null, array $config = [])
     {
         $this->_validHost = new Zend_Validate();
         $this->_validHost->addValidator(new Zend_Validate_Hostname(Zend_Validate_Hostname::ALLOW_ALL));
@@ -147,6 +162,13 @@ abstract class Zend_Mail_Protocol_Abstract
 
         $this->_host = $host;
         $this->_port = $port;
+
+        if (array_key_exists('verify_peer', $config)) {
+            $this->_verifyPeer = in_array(strtolower((string)$config['verify_peer']), ['true', 'yes', '1']);
+        }
+        if (array_key_exists('verify_peer_name', $config)) {
+            $this->_verifyPeerName = in_array(strtolower((string)$config['verify_peer_name']), ['true', 'yes', '1']);
+        }
     }
 
 
@@ -283,6 +305,22 @@ abstract class Zend_Mail_Protocol_Abstract
              */
             require_once 'Zend/Mail/Protocol/Exception.php';
             throw new Zend_Mail_Protocol_Exception('Could not set stream timeout');
+        }
+
+        if (($result = $this->_setStreamContextVerifyPeer($this->_verifyPeer)) === false) {
+            /**
+             * @see Zend_Mail_Protocol_Exception
+             */
+            require_once 'Zend/Mail/Protocol/Exception.php';
+            throw new Zend_Mail_Protocol_Exception('Could not set stream context verify_peer value');
+        }
+
+        if (($result = $this->_setStreamContextVerifyPeerName($this->_verifyPeerName)) === false) {
+            /**
+             * @see Zend_Mail_Protocol_Exception
+             */
+            require_once 'Zend/Mail/Protocol/Exception.php';
+            throw new Zend_Mail_Protocol_Exception('Could not set stream context verify_peer_name value');
         }
 
         return $result;
@@ -442,6 +480,28 @@ abstract class Zend_Mail_Protocol_Abstract
      */
     protected function _setStreamTimeout($timeout)
     {
-       return stream_set_timeout($this->_socket, $timeout);
+        return stream_set_timeout($this->_socket, $timeout);
+    }
+
+    /**
+     * Set stream SSL context verify_peer value
+     *
+     * @param bool $value
+     * @return boolean
+     */
+    protected function _setStreamContextVerifyPeer($value)
+    {
+        return stream_context_set_option($this->_socket, 'ssl', 'verify_peer', $value);
+    }
+
+    /**
+     * Set stream SSL context verify_peer_name value
+     *
+     * @param bool $value
+     * @return boolean
+     */
+    protected function _setStreamContextVerifyPeerName($value)
+    {
+        return stream_context_set_option($this->_socket, 'ssl', 'verify_peer_name', $value);
     }
 }


### PR DESCRIPTION
I've added these two parameters (mapping PHP's [SSL context options](https://www.php.net/manual/en/context.ssl.php) with same names):
```ini
resources.mail.transport.verify_peer = true/false/1/0
resources.mail.transport.verify_peer_name = true/false/1/0
```

in order to avoid this error with self-signed certificates:
```
stream_socket_enable_crypto(): SSL operation failed with code 1. OpenSSL Error messages:
error:14090086:SSL routines:ssl3_get_server_certificate:certificate verify failed (/path/to/shardj/zf1-future/library/Zend/Mail/Protocol/Smtp.php:<line containing stream_socket_enable_crypto>)
```

Reference: https://stackoverflow.com/questions/32211301/ssl-error-ssl3-get-server-certificatecertificate-verify-failed#32366242