### PR TITLE
Backport of fix for CVE-2021-3007 in Zend_Http_Response_Stream

### DIFF
--- a/library/Zend/Http/Response/Stream.php
+++ b/library/Zend/Http/Response/Stream.php
@@ -227,7 +227,7 @@ class Zend_Http_Response_Stream extends Zend_Http_Response
             fclose($this->stream);
             $this->stream = null;
         }
-        if($this->_cleanup) {
+        if($this->_cleanup && is_string($this->stream_name) && file_exists($this->stream_name)) {
             @unlink($this->stream_name);
         }
     }

--- a/tests/Zend/Http/ResponseTest.php
+++ b/tests/Zend/Http/ResponseTest.php
@@ -20,10 +20,14 @@
  * @version    $Id$
  */
 
+use Zend\Http\StreamObject;
+
 /**
  * Zend_Http_Response
  */
 require_once 'Zend/Http/Response.php';
+
+require_once __DIR__ . '/StreamObject.php';
 
 /**
  * Zend_Http_Response unit tests
@@ -38,8 +42,18 @@ require_once 'Zend/Http/Response.php';
  */
 class Zend_Http_ResponseTest extends PHPUnit_Framework_TestCase
 {
+    /** @var null|string */
+    private $tempFile;
+
     public function setUp()
     { }
+
+    public function tearDown()
+    {
+        if ($this->tempFile !== null && file_exists($this->tempFile)) {
+            unlink($this->tempFile);
+        }
+    }
 
     public function testGzipResponse ()
     {
@@ -171,6 +185,23 @@ class Zend_Http_ResponseTest extends PHPUnit_Framework_TestCase
         $this->assertTrue($response->isRedirect(), 'Response is a redirection, but isRedirect() returned false');
         $this->assertFalse($response->isError(), 'Response is a redirection, but isError() returned true');
         $this->assertFalse($response->isSuccessful(), 'Response is a redirection, but isSuccessful() returned true');
+    }
+
+    /**
+     * @see https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-3007
+     */
+    public function testDestructionDoesNothingIfStreamIsNotAResourceAndStreamNameIsNotAString()
+    {
+        $this->tempFile = tempnam(sys_get_temp_dir(), 'lhrs');
+        $streamObject = new StreamObject($this->tempFile);
+
+        $response = new Zend_Http_Response_Stream(200, array());
+        $response->setCleanup(true);
+        $response->setStreamName($streamObject);
+
+        unset($response);
+
+        $this->assertFileExists($this->tempFile);
     }
 
     public function test200Ok()

--- a/tests/Zend/Http/StreamObject.php
+++ b/tests/Zend/Http/StreamObject.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Zend\Http;
+
+class StreamObject
+{
+    private $tempFile;
+
+    public function __construct($tempFile)
+    {
+        $this->tempFile = $tempFile;
+    }
+
+    public function __toString()
+    {
+        return $this->tempFile;
+    }
+}


### PR DESCRIPTION
- https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-3007
- https://github.com/laminas/laminas-http/commit/eab608e10896270416aae7ffce36cc48072aa796

Only the actual fix was brought over as I didn't see an applicable unit test to extend for ZF1.