### PR TITLE
Fixes #139 Consider ints as valid floats again.

### DIFF
--- a/library/Zend/Validate/Float.php
+++ b/library/Zend/Validate/Float.php
@@ -115,11 +115,8 @@ class Zend_Validate_Float extends Zend_Validate_Abstract
             return false;
         }
 
-        if (is_float($value)) {
+        if (is_int($value) || is_float($value)) {
             return true;
-        } elseif (is_int($value)) {
-            $this->_error(self::NOT_FLOAT);
-            return false;
         }
 
         $this->_setValue($value);


### PR DESCRIPTION
4695007f4 included an API breaking change that considered ints not to be floats
whereas previously this was considered valid.