### PR TITLE
mail > SMTP: fixed configuration management

### DIFF
--- a/library/Zend/Mail/Protocol/Smtp.php
+++ b/library/Zend/Mail/Protocol/Smtp.php
@@ -153,7 +153,7 @@ class Zend_Mail_Protocol_Smtp extends Zend_Mail_Protocol_Abstract
             }
         }
 
-        parent::__construct($host, $port);
+        parent::__construct($host, $port, $config);
     }
 
 


### PR DESCRIPTION
Hi, man.

I've realized only now that [my previous pull request](https://github.com/Shardj/zf1-future/pull/124) does not allow to correctly handle the new configuration parameters I've added (`resources.mail.transport.verify_peer` and `resources.mail.transport.verify_peer_name`): `Zend_Mail_Protocol_Abstract` can indeed use them, but I did not instruct its child classes to pass those parameters to the parent.
I've fixed the glitch: now `Zend_Mail_Protocol_Smtp` really passes `$config` to the parent constructor.

Thanks in advance!

Francesco