### PR TITLE
Zend Version error array_pop only variables can be passed by reference

### DIFF
--- a/library/Zend/Version.php
+++ b/library/Zend/Version.php
@@ -81,9 +81,9 @@ final class Zend_Version
             $content = file_get_contents('https://api.github.com/repos/Shardj/zf1-future/releases/latest', false, $context);
 
             if (false !== $content) {
-                $releaseName = json_decode($content, true)['name'];
+                $releaseName = explode('-', json_decode($content, true)['name']);
 
-                self::$_latestVersion = array_pop(explode('-', $releaseName));
+                self::$_latestVersion = array_pop($releaseName);
             }
         }
 


### PR DESCRIPTION
array_pop() - only variables can be passed by reference