### PR TITLE
Fixes documentation builds

### DIFF
--- a/documentation/manual/Makefile
+++ b/documentation/manual/Makefile
@@ -15,9 +15,9 @@
 # @license    http://framework.zend.com/license/new-bsd     New BSD License
 #
 
-LANG=*
-DOCBOOK_DTD=http://framework.zend.com/docbook/xml/4.5/docbookx.dtd
-DOCBOOK_XSL=http://framework.zend.com/docbook-xsl/htmlhelp/htmlhelp.xsl
+LANG=en
+DOCBOOK_DTD=https://docbook.org/xml/4.5/docbookx.dtd
+DOCBOOK_XSL=https://cdn.docbook.org/release/xsl/current/htmlhelp/htmlhelp.xsl
 
 all: html
 

--- a/documentation/manual/ar/Makefile.in
+++ b/documentation/manual/ar/Makefile.in
@@ -38,9 +38,9 @@ FOP=@FOP@
 ECSRC=@ECSRC@
 HERE=@HERE@
 
-DOCBOOK_DTD?=http://framework.zend.com/docbook/xml/4.5/docbookx.dtd
-DOCBOOK_XSL?=http://framework.zend.com/docbook-xsl/htmlhelp/htmlhelp.xsl
-DOCBOOK_FO_XSL?=http://framework.zend.com/docbook-xsl/fo/docbook.xsl
+DOCBOOK_DTD?=https://docbook.org/xml/4.5/docbookx.dtd
+DOCBOOK_XSL?=https://cdn.docbook.org/release/xsl/current/html/chunk.xsl
+DOCBOOK_FO_XSL?=https://cdn.docbook.org/release/xsl/current/fo/docbook.xsl
 HTML_XSL=html.xsl
 MANUAL_XML=manual.xml
 MANUAL_PRINT1_XML=manual-print1.xml
@@ -58,8 +58,8 @@ html: html/index.html
 
 html/index.html: $(MANUAL_XML) $(HTML_XSL)
 	@echo "Rendering the whole manual with $(XSLTPROC)..."
-	$(XMLLINT) --xinclude --output _temp_manual.xml $(MANUAL_XML)
-	$(XSLTPROC) --xinclude --output html/index.html $(HTML_XSL) _temp_manual.xml
+	$(XMLLINT) --xinclude --noent --output _temp_manual.xml $(MANUAL_XML)
+	$(XSLTPROC) --xinclude --maxdepth 6000 --output html/index.html $(HTML_XSL) _temp_manual.xml
 	@echo "Copying manual figures (recursively)..."
 	-[ -d figures ] && cp -r figures html/
 

--- a/documentation/manual/ar/module_specs/Zend_Cache-Frontends.xml
+++ b/documentation/manual/ar/module_specs/Zend_Cache-Frontends.xml
@@ -1,7 +1,7 @@
 <sect1 id="zend.cache.frontends">
     <title>الـ frontends المتوفرة فى Zend_Cache</title>
 
-    <sect2 id="zend.cache.core">
+    <sect2 id="zend.cache.frontends.core">
         <title>Zend_Cache_Core</title>
         <sect3 id="zend.cache.core.introduction">
             <title>مقدمة</title>

--- a/documentation/manual/ar/module_specs/Zend_Filter.xml
+++ b/documentation/manual/ar/module_specs/Zend_Filter.xml
@@ -1,7 +1,7 @@
 <sect1 id="zend.filter.filter">
     <title>Zend_Filter</title>
 
-    <sect2 id="zend.filter.filter.introduction">
+    <sect2 id="zend.filter.introduction">
         <title>مقدمة</title>
         <para>
 
@@ -23,7 +23,7 @@
     ?>]]>
         </programlisting>
     </sect2>
-    <sect2 id="zend.filter.filter.usecases">
+    <sect2 id="zend.filter.usecases">
         <title>امثلة</title>
         <para>
         فى كل من الأمثة التالية , <literal>value$</literal> تمثل قيمة ذات بعد واحد .

--- a/documentation/manual/ar/module_specs/Zend_Service.xml
+++ b/documentation/manual/ar/module_specs/Zend_Service.xml
@@ -6,7 +6,7 @@
     </para>
     <para>
         توفر <code>Zend_Service</code> دعم لأى web service تعتمد على REST من خلال
-        <link linkend="zend.service.rest"><code>Zend_Service_Rest</code></link>.
+        <link linkend="zend.rest.client"><classname>Zend_Rest_Client</classname></link>.
     </para>
     <para>
         بالإضافة إلى امكانية الوراثة من <code>Zend_Service</code> و إستخدام

--- a/documentation/manual/bg/Makefile.in
+++ b/documentation/manual/bg/Makefile.in
@@ -38,9 +38,9 @@ FOP=@FOP@
 ECSRC=@ECSRC@
 HERE=@HERE@
 
-DOCBOOK_DTD?=http://framework.zend.com/docbook/xml/4.5/docbookx.dtd
-DOCBOOK_XSL?=http://framework.zend.com/docbook-xsl/htmlhelp/htmlhelp.xsl
-DOCBOOK_FO_XSL?=http://framework.zend.com/docbook-xsl/fo/docbook.xsl
+DOCBOOK_DTD?=https://docbook.org/xml/4.5/docbookx.dtd
+DOCBOOK_XSL?=https://cdn.docbook.org/release/xsl/current/html/chunk.xsl
+DOCBOOK_FO_XSL?=https://cdn.docbook.org/release/xsl/current/fo/docbook.xsl
 HTML_XSL=html.xsl
 MANUAL_XML=manual.xml
 MANUAL_PRINT1_XML=manual-print1.xml
@@ -58,8 +58,8 @@ html: html/index.html
 
 html/index.html: $(MANUAL_XML) $(HTML_XSL)
 	@echo "Rendering the whole manual with $(XSLTPROC)..."
-	$(XMLLINT) --xinclude --output _temp_manual.xml $(MANUAL_XML)
-	$(XSLTPROC) --xinclude --output html/index.html $(HTML_XSL) _temp_manual.xml
+	$(XMLLINT) --xinclude --noent --output _temp_manual.xml $(MANUAL_XML)
+	$(XSLTPROC) --xinclude --maxdepth 6000 --output html/index.html $(HTML_XSL) _temp_manual.xml
 	@echo "Copying manual figures (recursively)..."
 	-[ -d figures ] && cp -r figures html/
 

--- a/documentation/manual/cs/Makefile.in
+++ b/documentation/manual/cs/Makefile.in
@@ -38,9 +38,9 @@ FOP=@FOP@
 ECSRC=@ECSRC@
 HERE=@HERE@
 
-DOCBOOK_DTD?=http://framework.zend.com/docbook/xml/4.5/docbookx.dtd
-DOCBOOK_XSL?=http://framework.zend.com/docbook-xsl/htmlhelp/htmlhelp.xsl
-DOCBOOK_FO_XSL?=http://framework.zend.com/docbook-xsl/fo/docbook.xsl
+DOCBOOK_DTD?=https://docbook.org/xml/4.5/docbookx.dtd
+DOCBOOK_XSL?=https://cdn.docbook.org/release/xsl/current/html/chunk.xsl
+DOCBOOK_FO_XSL?=https://cdn.docbook.org/release/xsl/current/fo/docbook.xsl
 HTML_XSL=html.xsl
 MANUAL_XML=manual.xml
 MANUAL_PRINT1_XML=manual-print1.xml
@@ -58,8 +58,8 @@ html: html/index.html
 
 html/index.html: $(MANUAL_XML) $(HTML_XSL)
 	@echo "Rendering the whole manual with $(XSLTPROC)..."
-	$(XMLLINT) --xinclude --output _temp_manual.xml $(MANUAL_XML)
-	$(XSLTPROC) --xinclude --output html/index.html $(HTML_XSL) _temp_manual.xml
+	$(XMLLINT) --xinclude --noent --output _temp_manual.xml $(MANUAL_XML)
+	$(XSLTPROC) --xinclude --maxdepth 6000 --output html/index.html $(HTML_XSL) _temp_manual.xml
 	@echo "Copying manual figures (recursively)..."
 	-[ -d figures ] && cp -r figures html/
 

--- a/documentation/manual/de/Makefile.in
+++ b/documentation/manual/de/Makefile.in
@@ -38,9 +38,9 @@ FOP=@FOP@
 ECSRC=@ECSRC@
 HERE=@HERE@
 
-DOCBOOK_DTD?=http://framework.zend.com/docbook/xml/4.5/docbookx.dtd
-DOCBOOK_XSL?=http://framework.zend.com/docbook-xsl/htmlhelp/htmlhelp.xsl
-DOCBOOK_FO_XSL?=http://framework.zend.com/docbook-xsl/fo/docbook.xsl
+DOCBOOK_DTD?=https://docbook.org/xml/4.5/docbookx.dtd
+DOCBOOK_XSL?=https://cdn.docbook.org/release/xsl/current/html/chunk.xsl
+DOCBOOK_FO_XSL?=https://cdn.docbook.org/release/xsl/current/fo/docbook.xsl
 HTML_XSL=html.xsl
 MANUAL_XML=manual.xml
 MANUAL_PRINT1_XML=manual-print1.xml
@@ -58,8 +58,8 @@ html: html/index.html
 
 html/index.html: $(MANUAL_XML) $(HTML_XSL)
 	@echo "Rendering the whole manual with $(XSLTPROC)..."
-	$(XMLLINT) --xinclude --output _temp_manual.xml $(MANUAL_XML)
-	$(XSLTPROC) --xinclude --output html/index.html $(HTML_XSL) _temp_manual.xml
+	$(XMLLINT) --xinclude --noent --output _temp_manual.xml $(MANUAL_XML)
+	$(XSLTPROC) --xinclude --maxdepth 6000 --output html/index.html $(HTML_XSL) _temp_manual.xml
 	@echo "Copying manual figures (recursively)..."
 	-[ -d figures ] && cp -r figures html/
 

--- a/documentation/manual/de/module_specs/Zend_Currency-Additional.xml
+++ b/documentation/manual/de/module_specs/Zend_Currency-Additional.xml
@@ -123,7 +123,7 @@ var_dump($currency->getName('EUR'));
             <methodname>removeCache()</methodname>.
         </para>
 
-        <example id="zend.currency.usage.cache.example">
+        <example id="zend.currency.additional.cache.example">
             <title>Währungen cachen</title>
 
             <programlisting language="php"><![CDATA[

--- a/documentation/manual/de/module_specs/Zend_Gdata_Analytics.xml
+++ b/documentation/manual/de/module_specs/Zend_Gdata_Analytics.xml
@@ -15,7 +15,7 @@
         für weitere Informationen über die Google Analytics <acronym>API</acronym>.
     </para>
 
-    <sect2 id="zend.gdata.analytics">
+    <sect2 id="zend.gdata.analytics.accounts">
         <title>Account-Daten abfragen</title>
 
         <para>

--- a/documentation/manual/de/module_specs/Zend_View-Helpers-Doctype.xml
+++ b/documentation/manual/de/module_specs/Zend_View-Helpers-Doctype.xml
@@ -158,4 +158,5 @@ $doctypeHelper->doctype('XHTML1_RDFA');
       <?php endif; ?>
 >
 ]]></programlisting>
+    </example>
 </sect3>

--- a/documentation/manual/en/Makefile.in
+++ b/documentation/manual/en/Makefile.in
@@ -38,9 +38,9 @@ FOP=@FOP@
 ECSRC=@ECSRC@
 HERE=@HERE@
 
-DOCBOOK_DTD?=http://framework.zend.com/docbook/xml/4.5/docbookx.dtd
-DOCBOOK_XSL?=http://framework.zend.com/docbook-xsl/htmlhelp/htmlhelp.xsl
-DOCBOOK_FO_XSL?=http://framework.zend.com/docbook-xsl/fo/docbook.xsl
+DOCBOOK_DTD?=https://docbook.org/xml/4.5/docbookx.dtd
+DOCBOOK_XSL?=https://cdn.docbook.org/release/xsl/current/html/chunk.xsl
+DOCBOOK_FO_XSL?=https://cdn.docbook.org/release/xsl/current/fo/docbook.xsl
 HTML_XSL=html.xsl
 MANUAL_XML=manual.xml
 MANUAL_PRINT1_XML=manual-print1.xml
@@ -58,8 +58,8 @@ html: html/index.html
 
 html/index.html: $(MANUAL_XML) $(HTML_XSL)
 	@echo "Rendering the whole manual with $(XSLTPROC)..."
-	$(XMLLINT) --xinclude --output _temp_manual.xml $(MANUAL_XML)
-	$(XSLTPROC) --xinclude --output html/index.html $(HTML_XSL) _temp_manual.xml
+	$(XMLLINT) --xinclude --noent --output _temp_manual.xml $(MANUAL_XML)
+	$(XSLTPROC) --xinclude --maxdepth 6000 --output html/index.html $(HTML_XSL) _temp_manual.xml
 	@echo "Copying manual figures (recursively)..."
 	-[ -d figures ] && cp -r figures html/
 

--- a/documentation/manual/en/README
+++ b/documentation/manual/en/README
@@ -37,7 +37,7 @@ http://www.sagehill.net/docbookxsl/index.html
 http://docbook.org/tdg/en/html/part2.html DocBook tag reference
 
 
-To generat a CHM project file, you must install MsHtmlHelpWorkshop.
+To generate a CHM project file, you must install MsHtmlHelpWorkshop.
 
 To build the CHM file on the command line navigate to the directory
 in which the manual html files are built as described above
@@ -51,3 +51,10 @@ where "C:/path/to/workshop/" is the path to MsHtmlHelpWorkshop.
 This will build a "Zend_Framework_LANGUAGE.chm" file.
 
  You should now have an index in the file..
+
+ To generate an HTML version of the documentation optimizes for online
+ presentation, similar to what was published on the Zend Framework
+ website, use the html_site.xsl.in template in conjunction with the
+ chunking Docbook XSL stylesheet:
+
+ DOCBOOK_XSL=https://cdn.docbook.org/release/xsl/current/html/chunk.xsl

--- a/documentation/manual/en/html_site.xsl.in
+++ b/documentation/manual/en/html_site.xsl.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!DOCTYPE entities
-[    
+[
     <!-- Add translated specific definitions and snippets -->
     <!ENTITY % language-snippets SYSTEM "./ref/language-snippets.xml">
     %language-snippets;
@@ -11,8 +11,8 @@
     %language-snippets.default;
 ]>
 
-<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" 
-                xmlns:fo="http://www.w3.org/1999/XSL/Format"   
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+                xmlns:fo="http://www.w3.org/1999/XSL/Format"
 				version="1.0">
 
     <xsl:import href="@DOCBOOK_XSL@"/>
@@ -21,14 +21,18 @@
 	<xsl:param name="base.dir">./</xsl:param>
 	<xsl:param name="chunk.fast">1</xsl:param>
 	<xsl:param name="make.valid.html">1</xsl:param>
-	<xsl:param name="section.autolabel">1</xsl:param>
+	<xsl:param name="part.autolabel" select="0"/>
+	<xsl:param name="chapter.autolabel" select="0"/>
+	<xsl:param name="section.autolabel" select="0"/>
+	<xsl:param name="appendix.autolabel" select="0"/>
+	<xsl:param name="appendix.part" select="0"/>
 	<xsl:param name="generate.index">1</xsl:param>
 	<xsl:param name="section.label.includes.component.label">1</xsl:param>
 	<xsl:param name="chunker.output.indent">yes</xsl:param>
 	<xsl:param name="chunker.output.encoding">UTF-8</xsl:param>
-	<xsl:param name="chunk.first.sections">0</xsl:param>
+	<xsl:param name="chunk.first.sections">1</xsl:param>
 	<xsl:param name="chunk.tocs.and.lots">0</xsl:param>
-	<xsl:param name="html.extra.head.links">1</xsl:param>
+	<xsl:param name="html.extra.head.links">0</xsl:param>
 	<xsl:param name="generate.manifest">1</xsl:param>
 	<xsl:param name="admon.graphics">1</xsl:param>
 	<xsl:param name="admon.style"></xsl:param>
@@ -38,7 +42,16 @@
     <xsl:param name="htmlhelp.chm" select="'Zend_Framework_&lang;.chm'"/>
     <xsl:param name="htmlhelp.hhc.binary" select="0"/>
     <xsl:param name="htmlhelp.hhc.folders.instead.books" select="0"/>
-    <xsl:param name="toc.section.depth" select="4"/>
+    <xsl:param name="toc.section.depth">0</xsl:param>
+    <xsl:param name="toc.list.type">ul</xsl:param>
+    <xsl:param name="generate.toc">
+        book      toc,title
+        chapter   toc,title
+        part      toc,title
+        appendix  toc,title
+        sect1     toc
+        section   toc
+    </xsl:param>
 
     <xsl:template name="user.header.navigation">
       <!-- stuff put here appears before the top navigation area -->

--- a/documentation/manual/en/module_specs/Zend_Currency-Additional.xml
+++ b/documentation/manual/en/module_specs/Zend_Currency-Additional.xml
@@ -118,7 +118,7 @@ var_dump($currency->getName('EUR'));
             <methodname>clearCache()</methodname> and <methodname>removeCache()</methodname>.
         </para>
 
-        <example id="zend.currency.usage.cache.example">
+        <example id="zend.currency.additional.cache.example">
             <title>Caching currencies</title>
 
             <programlisting language="php"><![CDATA[

--- a/documentation/manual/en/module_specs/Zend_Loader-Classmap_Generator.xml
+++ b/documentation/manual/en/module_specs/Zend_Loader-Classmap_Generator.xml
@@ -14,7 +14,7 @@
 
         <para>
             Internally, it consumes both <link linkend="zend.console.getopt">Zend_Console_Getopt</link> (for parsing command-line
-            options) and <link linkend="zend.file.class-file-locater">Zend_File_ClassFileLocater</link> for
+            options) and <!-- This link ID does not exist in the docs, which fails the linter link linkend="zend.file.class-file-locator"-->Zend_File_ClassFileLocator<!--/link--> for
             recursively finding all PHP class files in a given tree.
         </para>
     </sect2>

--- a/documentation/manual/es/Makefile.in
+++ b/documentation/manual/es/Makefile.in
@@ -38,9 +38,9 @@ FOP=@FOP@
 ECSRC=@ECSRC@
 HERE=@HERE@
 
-DOCBOOK_DTD?=http://framework.zend.com/docbook/xml/4.5/docbookx.dtd
-DOCBOOK_XSL?=http://framework.zend.com/docbook-xsl/htmlhelp/htmlhelp.xsl
-DOCBOOK_FO_XSL?=http://framework.zend.com/docbook-xsl/fo/docbook.xsl
+DOCBOOK_DTD?=https://docbook.org/xml/4.5/docbookx.dtd
+DOCBOOK_XSL?=https://cdn.docbook.org/release/xsl/current/html/chunk.xsl
+DOCBOOK_FO_XSL?=https://cdn.docbook.org/release/xsl/current/fo/docbook.xsl
 HTML_XSL=html.xsl
 MANUAL_XML=manual.xml
 MANUAL_PRINT1_XML=manual-print1.xml
@@ -58,8 +58,8 @@ html: html/index.html
 
 html/index.html: $(MANUAL_XML) $(HTML_XSL)
 	@echo "Rendering the whole manual with $(XSLTPROC)..."
-	$(XMLLINT) --xinclude --output _temp_manual.xml $(MANUAL_XML)
-	$(XSLTPROC) --xinclude --output html/index.html $(HTML_XSL) _temp_manual.xml
+	$(XMLLINT) --xinclude --noent --output _temp_manual.xml $(MANUAL_XML)
+	$(XSLTPROC) --xinclude --maxdepth 6000 --output html/index.html $(HTML_XSL) _temp_manual.xml
 	@echo "Copying manual figures (recursively)..."
 	-[ -d figures ] && cp -r figures html/
 

--- a/documentation/manual/es/module_specs/Zend_Validate-Set.xml
+++ b/documentation/manual/es/module_specs/Zend_Validate-Set.xml
@@ -33,7 +33,11 @@
             en blanco como caracter válido. </para>
     </sect2>
 
-    <xi:include href="Zend_Validate-Barcode.xml"/>
+    <xi:include href="Zend_Validate-Barcode.xml">
+        <xi:fallback>
+            <xi:include href="../../en/module_specs/Zend_Validate-Barcode.xml"/>
+        </xi:fallback>
+    </xi:include>
 
     <sect2 id="zend.validate.set.between">
         <title>Between</title>
@@ -46,8 +50,16 @@
             mayor al mínimo y estrictamente menor al máximo. </para>
     </sect2>
 
-    <xi:include href="Zend_Validate-Callback.xml"/>
-    <xi:include href="Zend_Validate-CreditCard.xml"/>
+    <xi:include href="Zend_Validate-Callback.xml">
+        <xi:fallback>
+            <xi:include href="../../en/module_specs/Zend_Validate-Callback.xml"/>
+        </xi:fallback>
+    </xi:include>
+    <xi:include href="Zend_Validate-CreditCard.xml">
+        <xi:fallback>
+            <xi:include href="../../en/module_specs/Zend_Validate-CreditCard.xml"/>
+        </xi:fallback>
+    </xi:include>
 
     <sect2 id="zend.validate.set.ccnum">
         <title>Ccnum</title>
@@ -78,7 +90,9 @@
     </sect2>
 
     <xi:include href="Zend_Validate-Db.xml">
-        <xi:fallback href="../../en/module_specs/Zend_Validate-Db.xml"/>
+        <xi:fallback>
+            <xi:include href="../../en/module_specs/Zend_Validate-Db.xml"/>
+        </xi:fallback>
     </xi:include>
     <sect2 id="zend.validate.set.digits">
         <title>Digits</title>
@@ -87,8 +101,9 @@
     </sect2>
 
     <xi:include href="Zend_Validate-EmailAddress.xml">
-        <xi:fallback href="../../en/module_specs/Zend_Validate-EmailAddress.xml"
-        />
+        <xi:fallback>
+            <xi:include href="../../en/module_specs/Zend_Validate-EmailAddress.xml"/>
+        </xi:fallback>
     </xi:include>
     <sect2 id="zend.validate.set.float">
         <title>Float</title>
@@ -113,7 +128,11 @@
             y A-F). </para>
     </sect2>
 
-    <xi:include href="Zend_Validate-Hostname.xml"/>
+    <xi:include href="Zend_Validate-Hostname.xml">
+        <xi:fallback>
+            <xi:include href="../../en/module_specs/Zend_Validate-Hostname.xml"/>
+        </xi:fallback>
+    </xi:include>
 
     <sect2 id="zend.validate.set.iban">
         <title>Iban</title>
@@ -166,8 +185,11 @@ if ($validator->isValid($iban)) {
                 <varname>$valor</varname> . </para>
     </sect2>
 
-    <xi:include href="Zend_Validate-Identical.xml"/>
-    <xi:include href="Zend_Validate-InArray.xml"/>
+    <xi:include href="Zend_Validate-Identical.xml">
+        <xi:fallback>
+            <xi:include href="../../en/module_specs/Zend_Validate-Identical.xml"/>
+        </xi:fallback>
+    </xi:include>
 
     <sect2 id="zend.validate.set.int">
         <title>Int</title>
@@ -179,8 +201,16 @@ if ($validator->isValid($iban)) {
             give it while creating a instance of this validator. </para>
     </sect2>
 
-    <xi:include href="Zend_Validate-Ip.xml"/>
-     <xi:include href="Zend_Validate-Isbn.xml" />
+    <xi:include href="Zend_Validate-Ip.xml">
+        <xi:fallback>
+            <xi:include href="../../en/module_specs/Zend_Validate-Ip.xml"/>
+        </xi:fallback>
+    </xi:include>
+    <xi:include href="Zend_Validate-Isbn.xml">
+        <xi:fallback>
+            <xi:include href="../../en/module_specs/Zend_Validate-Isbn.xml"/>
+        </xi:fallback>
+    </xi:include>
 
     <sect2 id="zend.validate.set.less_than">
         <title>LessThan</title>
@@ -188,9 +218,17 @@ if ($validator->isValid($iban)) {
                 <varname>$valor</varname> es menor al límite máximo. </para>
     </sect2>
 
-    <xi:include href="Zend_Validate-NotEmpty.xml"/>
+    <xi:include href="Zend_Validate-NotEmpty.xml">
+        <xi:fallback>
+            <xi:include href="../../en/module_specs/Zend_Validate-NotEmpty.xml"/>
+        </xi:fallback>
+    </xi:include>
 
-    <xi:include href="Zend_Validate-PostCode.xml"/>
+    <xi:include href="Zend_Validate-PostCode.xml">
+        <xi:fallback>
+            <xi:include href="../../en/module_specs/Zend_Validate-PostCode.xml"/>
+        </xi:fallback>
+    </xi:include>
 
     <sect2 id="zend.validate.set.regex">
         <title>Regex</title>

--- a/documentation/manual/fa/Makefile.in
+++ b/documentation/manual/fa/Makefile.in
@@ -38,9 +38,9 @@ FOP=@FOP@
 ECSRC=@ECSRC@
 HERE=@HERE@
 
-DOCBOOK_DTD?=http://framework.zend.com/docbook/xml/4.5/docbookx.dtd
-DOCBOOK_XSL?=http://framework.zend.com/docbook-xsl/htmlhelp/htmlhelp.xsl
-DOCBOOK_FO_XSL?=http://framework.zend.com/docbook-xsl/fo/docbook.xsl
+DOCBOOK_DTD?=https://docbook.org/xml/4.5/docbookx.dtd
+DOCBOOK_XSL?=https://cdn.docbook.org/release/xsl/current/html/chunk.xsl
+DOCBOOK_FO_XSL?=https://cdn.docbook.org/release/xsl/current/fo/docbook.xsl
 HTML_XSL=html.xsl
 MANUAL_XML=manual.xml
 MANUAL_PRINT1_XML=manual-print1.xml
@@ -58,8 +58,8 @@ html: html/index.html
 
 html/index.html: $(MANUAL_XML) $(HTML_XSL)
 	@echo "Rendering the whole manual with $(XSLTPROC)..."
-	$(XMLLINT) --xinclude --output _temp_manual.xml $(MANUAL_XML)
-	$(XSLTPROC) --xinclude --output html/index.html $(HTML_XSL) _temp_manual.xml
+	$(XMLLINT) --xinclude --noent --output _temp_manual.xml $(MANUAL_XML)
+	$(XSLTPROC) --xinclude --maxdepth 6000 --output html/index.html $(HTML_XSL) _temp_manual.xml
 	@echo "Copying manual figures (recursively)..."
 	-[ -d figures ] && cp -r figures html/
 

--- a/documentation/manual/fr/Makefile.in
+++ b/documentation/manual/fr/Makefile.in
@@ -38,9 +38,9 @@ FOP=@FOP@
 ECSRC=@ECSRC@
 HERE=@HERE@
 
-DOCBOOK_DTD?=http://framework.zend.com/docbook/xml/4.5/docbookx.dtd
-DOCBOOK_XSL?=http://framework.zend.com/docbook-xsl/htmlhelp/htmlhelp.xsl
-DOCBOOK_FO_XSL?=http://framework.zend.com/docbook-xsl/fo/docbook.xsl
+DOCBOOK_DTD?=https://docbook.org/xml/4.5/docbookx.dtd
+DOCBOOK_XSL?=https://cdn.docbook.org/release/xsl/current/html/chunk.xsl
+DOCBOOK_FO_XSL?=https://cdn.docbook.org/release/xsl/current/fo/docbook.xsl
 HTML_XSL=html.xsl
 MANUAL_XML=manual.xml
 MANUAL_PRINT1_XML=manual-print1.xml
@@ -58,8 +58,8 @@ html: html/index.html
 
 html/index.html: $(MANUAL_XML) $(HTML_XSL)
 	@echo "Rendering the whole manual with $(XSLTPROC)..."
-	$(XMLLINT) --xinclude --output _temp_manual.xml $(MANUAL_XML)
-	$(XSLTPROC) --xinclude --output html/index.html $(HTML_XSL) _temp_manual.xml
+	$(XMLLINT) --xinclude --noent --output _temp_manual.xml $(MANUAL_XML)
+	$(XSLTPROC) --xinclude --maxdepth 6000 --output html/index.html $(HTML_XSL) _temp_manual.xml
 	@echo "Copying manual figures (recursively)..."
 	-[ -d figures ] && cp -r figures html/
 

--- a/documentation/manual/fr/module_specs/Zend_Service_Twitter.xml
+++ b/documentation/manual/fr/module_specs/Zend_Service_Twitter.xml
@@ -103,626 +103,888 @@ $response = $twitter->account->verifyCredentials();
     </sect2>
     <sect2 id="zend.service.twitter.account">
         <title>Account Methods</title>
+
         <itemizedlist>
             <listitem>
                 <para>
                     <methodname>verifyCredentials()</methodname> tests if supplied user
                     credentials are valid with minimal overhead.
                 </para>
+
                 <example id="zend.service.twitter.account.verifycredentails">
                     <title>Verifying credentials</title>
+
                     <programlisting language="php"><![CDATA[
-$twitter    = new Zend_Service_Twitter('myusername', 'mysecretpassword');
-$response   = $twitter->account->verifyCredentials();
+$twitter  = new Zend_Service_Twitter($options);
+$response = $twitter->account->verifyCredentials();
 ]]></programlisting>
                 </example>
             </listitem>
-            <listitem>
-                <para>
-                    <methodname>endSession()</methodname> signs users out of
-                    client-facing applications.
-                </para>
-                <example id="zend.service.twitter.account.endsession">
-                    <title>Sessions ending</title>
-                    <programlisting language="php"><![CDATA[
-$twitter    = new Zend_Service_Twitter('myusername', 'mysecretpassword');
-$response   = $twitter->account->endSession();
-]]></programlisting>
-                </example>
-            </listitem>
+        </itemizedlist>
+    </sect2>
+
+    <sect2 id="zend.service.twitter.application">
+        <title>Application Methods</title>
+
+        <itemizedlist>
             <listitem>
                 <para>
                     <methodname>rateLimitStatus()</methodname> returns the remaining number of
                     <acronym>API</acronym> requests available to the authenticating user
                     before the <acronym>API</acronym> limit is reached for the current hour.
                 </para>
-                <example id="zend.service.twitter.account.ratelimitstatus">
+
+                <example id="zend.service.twitter.application.ratelimitstatus">
                     <title>Rating limit status</title>
+
                     <programlisting language="php"><![CDATA[
-$twitter    = new Zend_Service_Twitter('myusername', 'mysecretpassword');
-$response   = $twitter->account->rateLimitStatus();
+$twitter  = new Zend_Service_Twitter($options);
+$response = $twitter->application->rateLimitStatus();
+$userTimelineLimit = $response->resources->statuses->{'/statuses/user_timeline'}->remaining;
 ]]></programlisting>
                 </example>
             </listitem>
         </itemizedlist>
     </sect2>
-    <sect2 id="zend.service.twitter.status">
-        <title>Status Methods</title>
-        <itemizedlist>
-            <listitem>
-                <para>
-                    <methodname>publicTimeline()</methodname> returns the 20 most recent statuses
-                    from non-protected users with a custom user icon. The public timeline is cached
-                    by Twitter for 60 seconds.
-                </para>
-                <example id="zend.service.twitter.status.publictimeline">
-                    <title>Retrieving public timeline</title>
-                    <programlisting language="php"><![CDATA[
-$twitter    = new Zend_Service_Twitter('myusername', 'mysecretpassword');
-$response   = $twitter->status->publicTimeline();
-]]></programlisting>
-                </example>
-            </listitem>
-            <listitem>
-                <para>
-                    <methodname>friendsTimeline()</methodname> returns the 20 most recent statuses
-                    posted by the authenticating user and that user's friends.
-                </para>
-                <example id="zend.service.twitter.status.friendstimeline">
-                    <title>Retrieving friends timeline</title>
-                    <programlisting language="php"><![CDATA[
-$twitter    = new Zend_Service_Twitter('myusername', 'mysecretpassword');
-$response   = $twitter->status->friendsTimeline();
-]]></programlisting>
-                </example>
-                <para>
-                    The <methodname>friendsTimeline()</methodname> method accepts an array of
-                    optional parameters to modify the query.
-                </para>
-                <itemizedlist>
-                    <listitem>
-                        <para>
-                            <code>since</code> narrows the returned results to just those statuses
-                            created after the specified date/time (up to 24 hours old).
-                        </para>
-                    </listitem>
-                    <listitem>
-                        <para>
-                            <code>page</code> specifies which page you want to return.
-                        </para>
-                    </listitem>
-                </itemizedlist>
-            </listitem>
-            <listitem>
-                <para>
-                    <methodname>userTimeline()</methodname> returns the 20 most recent statuses
-                    posted from the authenticating user.
-                </para>
-                <example id="zend.service.twitter.status.usertimeline">
-                    <title>Retrieving user timeline</title>
-                    <programlisting language="php"><![CDATA[
-$twitter    = new Zend_Service_Twitter('myusername', 'mysecretpassword');
-$response   = $twitter->status->userTimeline();
-]]></programlisting>
-                </example>
-                <para>
-                    The <methodname>userTimeline()</methodname> method accepts an array of optional
-                    parameters to modify the query.
-                </para>
-                <itemizedlist>
-                    <listitem>
-                        <para>
-                            <code>id</code> specifies the ID or screen name of the user for whom to
-                            return the friends_timeline.
-                        </para>
-                    </listitem>
-                    <listitem>
-                        <para>
-                            <code>since</code> narrows the returned results to just those statuses
-                            created after the specified date/time (up to 24 hours old).
-                        </para>
-                    </listitem>
-                    <listitem>
-                        <para>
-                            <code>page</code> specifies which page you want to return.
-                        </para>
-                    </listitem>
-                    <listitem>
-                        <para>
-                            <code>count</code> specifies the number of statuses to retrieve.
-                            May not be greater than 200.
-                        </para>
-                    </listitem>
-                </itemizedlist>
-            </listitem>
-            <listitem>
-                <para>
-                    <methodname>show()</methodname> returns a single status, specified by the
-                    <code>id</code> parameter below. The status' author will be returned inline.
-                </para>
-                <example id="zend.service.twitter.status.show">
-                    <title>Showing user status</title>
-                    <programlisting language="php"><![CDATA[
-$twitter    = new Zend_Service_Twitter('myusername', 'mysecretpassword');
-$response   = $twitter->status->show(1234);
-]]></programlisting>
-                </example>
-            </listitem>
-            <listitem>
-                <para>
-                    <methodname>update()</methodname> updates the authenticating user's status.
-                    This method requires that you pass in the status update that you want to post
-                    to Twitter.
-                </para>
-                <example id="zend.service.twitter.status.update">
-                    <title>Updating user status</title>
-                    <programlisting language="php"><![CDATA[
-$twitter    = new Zend_Service_Twitter('myusername', 'mysecretpassword');
-$response   = $twitter->status->update('My Great Tweet');
-]]></programlisting>
-                </example>
-                <para>
-                    The <methodname>update()</methodname> method accepts a second additional
-                    parameter.
-                </para>
-                <itemizedlist>
-                    <listitem>
-                        <para>
-                            <code>in_reply_to_status_id</code> specifies the ID of an existing
-                            status that the status to be posted is in reply to.
-                        </para>
-                    </listitem>
-                </itemizedlist>
-            </listitem>
-            <listitem>
-                <para>
-                    <methodname>replies()</methodname> returns the 20 most recent @replies (status
-                    updates prefixed with @username) for the authenticating user.
-                </para>
-                <example id="zend.service.twitter.status.replies">
-                    <title>Showing user replies</title>
-                    <programlisting language="php"><![CDATA[
-$twitter    = new Zend_Service_Twitter('myusername', 'mysecretpassword');
-$response   = $twitter->status->replies();
-]]></programlisting>
-                </example>
-                <para>
-                    The <methodname>replies()</methodname> method accepts an array of optional
-                    parameters to modify the query.
-                </para>
-                <itemizedlist>
-                    <listitem>
-                        <para>
-                            <code>since</code> narrows the returned results to just those statuses
-                            created after the specified date/time (up to 24 hours old).
-                        </para>
-                    </listitem>
-                    <listitem>
-                        <para>
-                            <code>page</code> specifies which page you want to return.
-                        </para>
-                    </listitem>
-                    <listitem>
-                        <para>
-                            <code>since_id</code> returns only statuses with an ID greater than
-                            (that is, more recent than) the specified ID.
-                        </para>
-                    </listitem>
-                </itemizedlist>
-            </listitem>
-            <listitem>
-                <para>
-                    <methodname>destroy()</methodname> destroys the status specified by the
-                    required <code>id</code> parameter.
-                </para>
-                <example id="zend.service.twitter.status.destroy">
-                    <title>Deleting user status</title>
-                    <programlisting language="php"><![CDATA[
-$twitter    = new Zend_Service_Twitter('myusername', 'mysecretpassword');
-$response   = $twitter->status->destroy(12345);
-]]></programlisting>
-                </example>
-            </listitem>
-        </itemizedlist>
-    </sect2>
-     <sect2 id="zend.service.twitter.user">
-        <title>User Methods</title>
-        <itemizedlist>
-            <listitem>
-                <para>
-                    <methodname>friends()</methodname>r eturns up to 100 of the authenticating
-                    user's friends who have most recently updated, each with current status inline.
-                </para>
-                <example id="zend.service.twitter.user.friends">
-                    <title>Retrieving user friends</title>
-                    <programlisting language="php"><![CDATA[
-$twitter    = new Zend_Service_Twitter('myusername', 'mysecretpassword');
-$response   = $twitter->user->friends();
-]]></programlisting>
-                </example>
-                <para>
-                    The <methodname>friends()</methodname> method accepts an array of optional
-                    parameters to modify the query.
-                </para>
-                <itemizedlist>
-                    <listitem>
-                        <para>
-                            <code>id</code> specifies the ID or screen name of the user for whom to
-                            return a list of friends.
-                        </para>
-                    </listitem>
-                    <listitem>
-                        <para>
-                            <code>since</code> narrows the returned results to just those statuses
-                            created after the specified date/time (up to 24 hours old).
-                        </para>
-                    </listitem>
-                    <listitem>
-                        <para>
-                            <code>page</code> specifies which page you want to return.
-                        </para>
-                    </listitem>
-                </itemizedlist>
-            </listitem>
-            <listitem>
-                <para>
-                    <methodname>followers()</methodname> returns the authenticating user's
-                    followers, each with current status inline.
-                </para>
-                <example id="zend.service.twitter.user.followers">
-                    <title>Retrieving user followers</title>
-                    <programlisting language="php"><![CDATA[
-$twitter    = new Zend_Service_Twitter('myusername', 'mysecretpassword');
-$response   = $twitter->user->followers();
-]]></programlisting>
-                </example>
-                <para>
-                    The <methodname>followers()</methodname> method accepts an array of optional
-                    parameters to modify the query.
-                </para>
-                <itemizedlist>
-                    <listitem>
-                        <para>
-                            <code>id</code> specifies the ID or screen name of the user for whom to
-                            return a list of followers.
-                        </para>
-                    </listitem>
-                    <listitem>
-                        <para>
-                            <code>page</code> specifies which page you want to return.
-                        </para>
-                    </listitem>
-                </itemizedlist>
-            </listitem>
-            <listitem>
-                <para>
-                    <methodname>show()</methodname> returns extended information of a given user,
-                    specified by ID or screen name as per the required <code>id</code>
-                    parameter below.
-                </para>
-                <example id="zend.service.twitter.user.show">
-                    <title>Showing user informations</title>
-                    <programlisting language="php"><![CDATA[
-$twitter    = new Zend_Service_Twitter('myusername', 'mysecretpassword');
-$response   = $twitter->user->show('myfriend');
-]]></programlisting>
-                </example>
-            </listitem>
-        </itemizedlist>
-    </sect2>
-    <sect2 id="zend.service.twitter.directmessage">
-        <title>Direct Message Methods</title>
-        <itemizedlist>
-            <listitem>
-                <para>
-                    <methodname>messages()</methodname> returns a list of the 20 most recent direct
-                    messages sent to the authenticating user.
-                </para>
-                <example id="zend.service.twitter.directmessage.messages">
-                    <title>Retrieving recent direct messages received</title>
-                    <programlisting language="php"><![CDATA[
-$twitter    = new Zend_Service_Twitter('myusername', 'mysecretpassword');
-$response   = $twitter->directMessage->messages();
-]]></programlisting>
-                </example>
-                <para>
-                    The <methodname>message()</methodname> method accepts an array of optional
-                    parameters to modify the query.
-                </para>
-                <itemizedlist>
-                    <listitem>
-                        <para>
-                            <code>since_id</code> returns only direct messages with an ID greater
-                            than (that is, more recent than) the specified ID.
-                        </para>
-                    </listitem>
-                    <listitem>
-                        <para>
-                            <code>since</code> narrows the returned results to just those statuses
-                            created after the specified date/time (up to 24 hours old).
-                        </para>
-                    </listitem>
-                    <listitem>
-                        <para>
-                            <code>page</code> specifies which page you want to return.
-                        </para>
-                    </listitem>
-                </itemizedlist>
-            </listitem>
-            <listitem>
-                <para>
-                    <methodname>sent()</methodname> returns a list of the 20 most recent direct
-                    messages sent by the authenticating user.
-                </para>
-                <example id="zend.service.twitter.directmessage.sent">
-                    <title>Retrieving recent direct messages sent</title>
-                    <programlisting language="php"><![CDATA[
-$twitter    = new Zend_Service_Twitter('myusername', 'mysecretpassword');
-$response   = $twitter->directMessage->sent();
-]]></programlisting>
-                </example>
-                <para>
-                    The <methodname>sent()</methodname> method accepts an array of optional
-                    parameters to modify the query.
-                </para>
-                <itemizedlist>
-                    <listitem>
-                        <para>
-                            <code>since_id</code> returns only direct messages with an ID greater
-                            than (that is, more recent than) the specified ID.
-                        </para>
-                    </listitem>
-                    <listitem>
-                        <para>
-                            <code>since</code> narrows the returned results to just those statuses
-                            created after the specified date/time (up to 24 hours old).
-                        </para>
-                    </listitem>
-                    <listitem>
-                        <para>
-                            <code>page</code> specifies which page you want to return.
-                        </para>
-                    </listitem>
-                </itemizedlist>
-            </listitem>
-            <listitem>
-                <para>
-                    <methodname>new()</methodname> sends a new direct message to the specified user
-                    from the authenticating user. Requires both the user and text parameters below.
-                </para>
-                <example id="zend.service.twitter.directmessage.new">
-                    <title>Sending direct message</title>
-                    <programlisting language="php"><![CDATA[
-$twitter    = new Zend_Service_Twitter('myusername', 'mysecretpassword');
-$response   = $twitter->directMessage->new('myfriend', 'mymessage');
-]]></programlisting>
-                </example>
-            </listitem>
-            <listitem>
-                <para>
-                    <methodname>destroy()</methodname> destroys the direct message specified in the
-                    required <code>id</code> parameter. The authenticating user must be the
-                    recipient of the specified direct message.
-                </para>
-                <example id="zend.service.twitter.directmessage.destroy">
-                    <title>Deleting direct message</title>
-                    <programlisting language="php"><![CDATA[
-$twitter    = new Zend_Service_Twitter('myusername', 'mysecretpassword');
-$response   = $twitter->directMessage->destroy(123548);
-]]></programlisting>
-                </example>
-            </listitem>
-        </itemizedlist>
-    </sect2>
-    <sect2 id="zend.service.twitter.friendship">
-        <title>Friendship Methods</title>
-        <itemizedlist>
-            <listitem>
-                <para>
-                    <methodname>create()</methodname> befriends the user specified in the
-                    <code>id</code> parameter with the authenticating user.
-                </para>
-                <example id="zend.service.twitter.friendship.create">
-                    <title>Creating friend</title>
-                    <programlisting language="php"><![CDATA[
-$twitter    = new Zend_Service_Twitter('myusername', 'mysecretpassword');
-$response   = $twitter->friendship->create('mynewfriend');
-]]></programlisting>
-                </example>
-            </listitem>
-            <listitem>
-                <para>
-                    <methodname>destroy()</methodname> discontinues friendship with the user
-                    specified in the <code>id</code> parameter and the authenticating user.
-                </para>
-                <example id="zend.service.twitter.friendship.destroy">
-                    <title>Deleting friend</title>
-                    <programlisting language="php"><![CDATA[
-$twitter    = new Zend_Service_Twitter('myusername', 'mysecretpassword');
-$response   = $twitter->friendship->destroy('myoldfriend');
-]]></programlisting>
-                </example>
-            </listitem>
-            <listitem>
-                <para>
-                    <methodname>exists()</methodname> tests if a friendship exists between the
-                    user specified in the <code>id</code> parameter and the authenticating user.
-                </para>
-                <example id="zend.service.twitter.friendship.exists">
-                    <title>Checking friend existence</title>
-                    <programlisting language="php"><![CDATA[
-$twitter    = new Zend_Service_Twitter('myusername', 'mysecretpassword');
-$response   = $twitter->friendship->exists('myfriend');
-]]></programlisting>
-                </example>
-            </listitem>
-        </itemizedlist>
-    </sect2>
-    <sect2 id="zend.service.twitter.favorite">
-        <title>Favorite Methods</title>
-        <itemizedlist>
-            <listitem>
-                <para>
-                    <methodname>favorites()</methodname> returns the 20 most recent favorite
-                    statuses for the authenticating user or user specified by the
-                    <code>id</code> parameter.
-                </para>
-                <example id="zend.service.twitter.favorite.favorites">
-                    <title>Retrieving favorites</title>
-                    <programlisting language="php"><![CDATA[
-$twitter    = new Zend_Service_Twitter('myusername', 'mysecretpassword');
-$response   = $twitter->favorite->favorites();
-]]></programlisting>
-                </example>
-                <para>
-                    The <methodname>favorites()</methodname> method accepts an array of optional
-                    parameters to modify the query.
-                </para>
-                <itemizedlist>
-                    <listitem>
-                        <para>
-                            <code>id</code> specifies the ID or screen name of the user for whom to
-                            request a list of favorite statuses.
-                        </para>
-                    </listitem>
-                    <listitem>
-                        <para>
-                            <code>page</code> specifies which page you want to return.
-                        </para>
-                    </listitem>
-                </itemizedlist>
-            </listitem>
-            <listitem>
-                <para>
-                    <methodname>create()</methodname> favorites the status specified in the
-                    <code>id</code> parameter as the authenticating user.
-                </para>
-                <example id="zend.service.twitter.favorite.create">
-                    <title>Creating favorites</title>
-                    <programlisting language="php"><![CDATA[
-$twitter    = new Zend_Service_Twitter('myusername', 'mysecretpassword');
-$response   = $twitter->favorite->create(12351);
-]]></programlisting>
-                </example>
-            </listitem>
-            <listitem>
-                <para>
-                    <methodname>destroy()</methodname> un-favorites the status specified in the
-                    <code>id</code> parameter as the authenticating user.
-                </para>
-                <example id="zend.service.twitter.favorite.destroy">
-                    <title>Deleting favorites</title>
-                    <programlisting language="php"><![CDATA[
-$twitter    = new Zend_Service_Twitter('myusername', 'mysecretpassword');
-$response   = $twitter->favorite->destroy(12351);
-]]></programlisting>
-                </example>
-            </listitem>
-        </itemizedlist>
-    </sect2>
-    <sect2 id="zend.service.twitter.block">
+
+    <sect2 id="zend.service.twitter.blocks">
         <title>Block Methods</title>
+
         <itemizedlist>
-            <listitem>
-                <para>
-                    <methodname>exists()</methodname> checks if the authenticating user is blocking
-                    a target user and can optionally return the blocked user's object if a
-                    block does exists.
-                </para>
-                <example id="zend.service.twitter.block.exists">
-                    <title>Checking if block exists</title>
-                    <programlisting language="php"><![CDATA[
-$twitter = new Zend_Service_Twitter('myusername', 'mysecretpassword');
-// returns true or false
-$response = $twitter->block->exists('blockeduser');
-// returns the blocked user's info if the user is blocked
-$response2 = $twitter->block->exists('blockeduser', true);
-]]></programlisting>
-                </example>
-                <para>
-                    The <methodname>favorites()</methodname> method accepts a second
-                    optional parameter.
-                </para>
-                <itemizedlist>
-                    <listitem>
-                        <para>
-                            <code>returnResult</code> specifies whether or not return the user
-                            object instead of just <constant>TRUE</constant> or
-                            <constant>FALSE</constant>.
-                        </para>
-                    </listitem>
-                </itemizedlist>
-            </listitem>
             <listitem>
                 <para>
                     <methodname>create()</methodname> blocks the user specified in the
                     <code>id</code> parameter as the authenticating user and destroys a friendship
-                    to the blocked user if one exists. Returns the blocked user in the requested
-                    format when successful.
+                    to the blocked user if one exists. Returns the blocked user when successful.
                 </para>
-                <example id="zend.service.twitter.block.create">
+
+                <example id="zend.service.twitter.blocks.create">
                     <title>Blocking a user</title>
+
                     <programlisting language="php"><![CDATA[
-$twitter    = new Zend_Service_Twitter('myusername', 'mysecretpassword');
-$response   = $twitter->block->create('usertoblock);
+$twitter  = new Zend_Service_Twitter($options);
+$response = $twitter->blocks->create('usertoblock');
 ]]></programlisting>
                 </example>
             </listitem>
+
             <listitem>
                 <para>
                     <methodname>destroy()</methodname> un-blocks the user specified in the
                     <code>id</code> parameter for the authenticating user. Returns the un-blocked
                     user in the requested format when successful.
                 </para>
-                <example id="zend.service.twitter.block.destroy">
+
+                <example id="zend.service.twitter.blocks.destroy">
                     <title>Removing a block</title>
+
                     <programlisting language="php"><![CDATA[
-$twitter    = new Zend_Service_Twitter('myusername', 'mysecretpassword');
-$response   = $twitter->block->destroy('blockeduser');
+$twitter  = new Zend_Service_Twitter($options);
+$response = $twitter->blocks->destroy('blockeduser');
 ]]></programlisting>
                 </example>
             </listitem>
+
             <listitem>
                 <para>
-                    <methodname>blocking()</methodname> returns an array of user objects that the
+                    <methodname>ids()</methodname> returns an array of user identifiers that the
                     authenticating user is blocking.
                 </para>
-                <example id="zend.service.twitter.block.blocking">
-                    <title>Who are you blocking</title>
+
+                <example id="zend.service.twitter.blocks.ids">
+                    <title>Who are you blocking (identifiers only)</title>
+
                     <programlisting language="php"><![CDATA[
-$twitter = new Zend_Service_Twitter('myusername', 'mysecretpassword');
-// return the full user list from the first page
-$response = $twitter->block->blocking();
-// return an array of numeric user IDs from the second page
-$response2 = $twitter->block->blocking(2, true);
+$twitter  = new Zend_Service_Twitter($options);
+$response = $twitter->blocks->ids();
 ]]></programlisting>
                 </example>
+            </listitem>
+
+            <listitem>
                 <para>
-                    The <methodname>favorites()</methodname> method accepts two optional parameters.
+                    <methodname>list()</methodname> returns an array of user objects that the
+                    authenticating user is blocking.
                 </para>
+
+                <example id="zend.service.twitter.blocks.list">
+                    <title>Who are you blocking</title>
+
+                    <programlisting language="php"><![CDATA[
+$twitter  = new Zend_Service_Twitter($options);
+$response = $twitter->blocks->list();
+]]></programlisting>
+                </example>
+            </listitem>
+        </itemizedlist>
+    </sect2>
+
+    <sect2 id="zend.service.twitter.directmessages">
+        <title>Direct Message Methods</title>
+
+        <itemizedlist>
+            <listitem>
+                <para>
+                    <methodname>messages()</methodname> returns a list of the 20 most recent direct
+                    messages sent to the authenticating user.
+                </para>
+
+                <example id="zend.service.twitter.directmessages.messages">
+                    <title>Retrieving recent direct messages received</title>
+
+                    <programlisting language="php"><![CDATA[
+$twitter  = new Zend_Service_Twitter($options);
+$response = $twitter->directMessages->messages();
+]]></programlisting>
+                </example>
+
+                <para>
+                    The <methodname>messages()</methodname> method accepts an array of optional
+                    parameters to modify the query.
+                </para>
+
                 <itemizedlist>
                     <listitem>
                         <para>
-                            <code>page</code> specifies which page ou want to return. A single page
-                            contains 20 IDs.
+                            <code>since_id</code> narrows the returned results to just those
+                            statuses after the specified identifier (up to 24 hours old).
                         </para>
                     </listitem>
+
                     <listitem>
                         <para>
-                            <code>returnUserIds</code> specifies whether to return an array of
-                            numeric user IDs the authenticating user is blocking instead of an
-                            array of user objects.
+                            <code>max_id</code> narrows the returned results to just those
+                            statuses earlier than the specified identifier.
+                        </para>
+                    </listitem>
+
+                    <listitem>
+                        <para>
+                            <code>count</code> specifies the number of statuses to return, up to 200.
+                        </para>
+                    </listitem>
+
+                    <listitem>
+                        <para>
+                            <code>skip_status</code>, when set to boolean true, "t", or 1 will skip
+                            including a user's most recent status in the results.
+                        </para>
+                    </listitem>
+
+                    <listitem>
+                        <para>
+                            <code>include_entities</code> controls whether or not entities, which
+                            includes URLs, mentioned users, and hashtags, will be returned.
+                        </para>
+                    </listitem>
+                </itemizedlist>
+            </listitem>
+
+            <listitem>
+                <para>
+                    <methodname>sent()</methodname> returns a list of the 20 most recent direct
+                    messages sent by the authenticating user.
+                </para>
+
+                <example id="zend.service.twitter.directmessages.sent">
+                    <title>Retrieving recent direct messages sent</title>
+
+                    <programlisting language="php"><![CDATA[
+$twitter  = new Zend_Service_Twitter($options);
+$response = $twitter->directMessages->sent();
+]]></programlisting>
+                </example>
+
+                <para>
+                    The <methodname>sent()</methodname> method accepts an array of optional
+                    parameters to modify the query.
+                </para>
+
+                <itemizedlist>
+                    <listitem>
+                        <para>
+                            <code>count</code> specifies the number of statuses to return, up to 20.
+                        </para>
+                    </listitem>
+
+                    <listitem>
+                        <para>
+                            <code>page</code> specifies the page of results to return, based on the
+                            <code>count</code> provided.
+                        </para>
+                    </listitem>
+
+                    <listitem>
+                        <para>
+                            <code>since_id</code> narrows the returned results to just those
+                            statuses after the specified identifier (up to 24 hours old).
+                        </para>
+                    </listitem>
+
+                    <listitem>
+                        <para>
+                            <code>max_id</code> narrows the returned results to just those
+                            statuses earlier than the specified identifier.
+                        </para>
+                    </listitem>
+
+                    <listitem>
+                        <para>
+                            <code>include_entities</code> controls whether or not entities, which
+                            includes URLs, mentioned users, and hashtags, will be returned.
+                        </para>
+                    </listitem>
+                </itemizedlist>
+            </listitem>
+
+            <listitem>
+                <para>
+                    <methodname>new()</methodname> sends a new direct message to the specified user
+                    from the authenticating user. Requires both the user and text parameters below.
+                </para>
+
+                <example id="zend.service.twitter.directmessages.new">
+                    <title>Sending a direct message</title>
+
+                    <programlisting language="php"><![CDATA[
+$twitter  = new Zend_Service_Twitter($options);
+$response = $twitter->directMessages->new('myfriend', 'mymessage');
+]]></programlisting>
+                </example>
+            </listitem>
+
+            <listitem>
+                <para>
+                    <methodname>destroy()</methodname> destroys the direct message specified in the
+                    required <code>id</code> parameter. The authenticating user must be the
+                    recipient of the specified direct message.
+                </para>
+
+                <example id="zend.service.twitter.directmessages.destroy">
+                    <title>Deleting a direct message</title>
+
+                    <programlisting language="php"><![CDATA[
+$twitter  = new Zend_Service_Twitter($options);
+$response = $twitter->directMessages->destroy(123548);
+]]></programlisting>
+                </example>
+            </listitem>
+        </itemizedlist>
+    </sect2>
+
+    <sect2 id="zend.service.twitter.favorites">
+        <title>Favorites Methods</title>
+
+        <itemizedlist>
+            <listitem>
+                <para>
+                    <methodname>list()</methodname> returns the 20 most recent favorite
+                    statuses for the authenticating user or user specified by the
+                    <code>user_id</code> or <code>screen_name</code> parameter.
+                </para>
+
+                <example id="zend.service.twitter.favorites.list">
+                    <title>Retrieving favorites</title>
+
+                    <programlisting language="php"><![CDATA[
+$twitter  = new Zend_Service_Twitter($options);
+$response = $twitter->favorites->list();
+]]></programlisting>
+                </example>
+
+                <para>
+                    The <methodname>list()</methodname> method accepts an array of optional
+                    parameters to modify the query.
+                </para>
+
+                <itemizedlist>
+                    <listitem>
+                        <para>
+                            <code>user_id</code> specifies the ID of the user for whom to return the
+                            timeline.
+                        </para>
+                    </listitem>
+
+                    <listitem>
+                        <para>
+                            <code>screen_name</code> specifies the screen name of the user for
+                            whom to return the timeline.
+                        </para>
+                    </listitem>
+
+                    <listitem>
+                        <para>
+                            <code>since_id</code> narrows the returned results to just those
+                            statuses after the specified identifier (up to 24 hours old).
+                        </para>
+                    </listitem>
+
+                    <listitem>
+                        <para>
+                            <code>max_id</code> narrows the returned results to just those
+                            statuses earlier than the specified identifier.
+                        </para>
+                    </listitem>
+
+                    <listitem>
+                        <para>
+                            <code>count</code> specifies the number of statuses to return, up to 200.
+                        </para>
+                    </listitem>
+
+                    <listitem>
+                        <para>
+                            <code>include_entities</code> controls whether or not entities, which
+                            includes URLs, mentioned users, and hashtags, will be returned.
+                        </para>
+                    </listitem>
+                </itemizedlist>
+            </listitem>
+
+            <listitem>
+                <para>
+                    <methodname>create()</methodname> favorites the status specified in the
+                    <code>id</code> parameter as the authenticating user.
+                </para>
+
+                <example id="zend.service.twitter.favorites.create">
+                    <title>Creating a favorite</title>
+
+                    <programlisting language="php"><![CDATA[
+$twitter  = new Zend_Service_Twitter($options);
+$response = $twitter->favorites->create(12351);
+]]></programlisting>
+                </example>
+            </listitem>
+
+            <listitem>
+                <para>
+                    <methodname>destroy()</methodname> un-favorites the status specified in the
+                    <code>id</code> parameter as the authenticating user.
+                </para>
+
+                <example id="zend.service.twitter.favorites.destroy">
+                    <title>Deleting favorites</title>
+
+                    <programlisting language="php"><![CDATA[
+$twitter  = new Zend_Service_Twitter($options);
+$response = $twitter->favorites->destroy(12351);
+]]></programlisting>
+                </example>
+            </listitem>
+        </itemizedlist>
+    </sect2>
+
+    <sect2 id="zend.service.twitter.friendships">
+        <title>Friendship Methods</title>
+
+        <itemizedlist>
+            <listitem>
+                <para>
+                    <methodname>create()</methodname> befriends the user specified in the
+                    <code>id</code> parameter with the authenticating user.
+                </para>
+
+                <example id="zend.service.twitter.friendships.create">
+                    <title>Creating a friend</title>
+
+                    <programlisting language="php"><![CDATA[
+$twitter  = new Zend_Service_Twitter($options);
+$response = $twitter->friendships->create('mynewfriend');
+]]></programlisting>
+                </example>
+            </listitem>
+
+            <listitem>
+                <para>
+                    <methodname>destroy()</methodname> discontinues friendship with the user
+                    specified in the <code>id</code> parameter and the authenticating user.
+                </para>
+
+                <example id="zend.service.twitter.friendships.destroy">
+                    <title>Deleting a friend</title>
+
+                    <programlisting language="php"><![CDATA[
+$twitter  = new Zend_Service_Twitter($options);
+$response = $twitter->friendships->destroy('myoldfriend');
+]]></programlisting>
+                </example>
+            </listitem>
+        </itemizedlist>
+    </sect2>
+
+    <sect2 id="zend.service.twitter.search">
+        <title>Search Methods</title>
+
+        <itemizedlist>
+            <listitem>
+                <para>
+                    <methodname>tweets()</methodname> returns a list of tweets matching the criteria
+                    specified in <varname>$query</varname>. By default, 15 will be returned, but
+                    this value may be changed using the <varname>count</varname> option.
+                </para>
+
+                <example id="zend.service.twitter.search.tweets">
+                    <title>Searching for tweets</title>
+
+                    <programlisting language="php"><![CDATA[
+$twitter  = new Zend_Service_Twitter($options);
+$response = $twitter->search->tweets('#zendframework');
+]]></programlisting>
+                </example>
+
+                <para>
+                    The <methodname>tweets()</methodname> method accepts an optional second
+                    argument, an array of optional parameters to modify the query.
+                </para>
+
+                <itemizedlist>
+                    <listitem>
+                        <para>
+                            <code>since_id</code> narrows the returned results to just those
+                            statuses after the specified identifier (up to 24 hours old).
+                        </para>
+                    </listitem>
+
+                    <listitem>
+                        <para>
+                            <code>max_id</code> narrows the returned results to just those
+                            statuses earlier than the specified identifier.
+                        </para>
+                    </listitem>
+
+                    <listitem>
+                        <para>
+                            <code>count</code> specifies the number of statuses to return, up to 200.
+                        </para>
+                    </listitem>
+
+                    <listitem>
+                        <para>
+                            <code>include_entities</code> controls whether or not entities, which
+                            includes URLs, mentioned users, and hashtags, will be returned.
+                        </para>
+                    </listitem>
+
+                    <listitem>
+                        <para>
+                            <code>lang</code> indicates which two-letter language code to restrict
+                            results to.
+                        </para>
+                    </listitem>
+
+                    <listitem>
+                        <para>
+                            <code>locale</code> indicates which two-letter language code is being
+                            used in the query.
+                        </para>
+                    </listitem>
+
+                    <listitem>
+                        <para>
+                            <code>geocode</code> can be used to indicate the geographical radius in
+                            which tweets should originate; the string should be in the form
+                            "latitude,longitude,radius", with "radius" being a unit followed by one
+                            of "mi" or "km".
+                        </para>
+                    </listitem>
+
+                    <listitem>
+                        <para>
+                            <code>result_type</code> indicates what type of results to retrieve, and
+                            should be one of "mixed," "recent," or "popular."
+                        </para>
+                    </listitem>
+
+                    <listitem>
+                        <para>
+                            <code>until</code> can be used to specify a the latest date for which to
+                            return tweets.
                         </para>
                     </listitem>
                 </itemizedlist>
             </listitem>
         </itemizedlist>
     </sect2>
-    <xi:include href="Zend_Service_Twitter_Search.xml">
-        <xi:fallback>
-            <xi:include href="../../en/module_specs/Zend_Service_Twitter_Search.xml" />
-        </xi:fallback>
-    </xi:include>
+
+    <sect2 id="zend.service.twitter.statuses">
+        <title>Status Methods</title>
+
+        <itemizedlist>
+            <listitem>
+                <para>
+                    <methodname>sample()</methodname> returns the 20 most recent statuses
+                    from non-protected users with a custom user icon. The public timeline is cached
+                    by Twitter for 60 seconds.
+                </para>
+
+                <example id="zend.service.twitter.statuses.sample">
+                    <title>Retrieving public timeline</title>
+
+                    <programlisting language="php"><![CDATA[
+$twitter  = new Zend_Service_Twitter($options);
+$response = $twitter->statuses->sample();
+]]></programlisting>
+                </example>
+            </listitem>
+
+            <listitem>
+                <para>
+                    <methodname>homeTimeline()</methodname> returns the 20 most recent statuses
+                    posted by the authenticating user and that user's friends.
+                </para>
+
+                <example id="zend.service.twitter.statuses.hometimeline">
+                    <title>Retrieving the home timeline</title>
+
+                    <programlisting language="php"><![CDATA[
+$twitter  = new Zend_Service_Twitter($options);
+));
+$response = $twitter->statuses->homeTimeline();
+]]></programlisting>
+                </example>
+
+                <para>
+                    The <methodname>homeTimeline()</methodname> method accepts an array of
+                    optional parameters to modify the query.
+                </para>
+
+                <itemizedlist>
+                    <listitem>
+                        <para>
+                            <code>since_id</code> narrows the returned results to just those
+                            statuses after the specified identifier (up to 24 hours old).
+                        </para>
+                    </listitem>
+
+                    <listitem>
+                        <para>
+                            <code>max_id</code> narrows the returned results to just those
+                            statuses earlier than the specified identifier.
+                        </para>
+                    </listitem>
+
+                    <listitem>
+                        <para>
+                            <code>count</code> specifies the number of statuses to return, up to 200.
+                        </para>
+                    </listitem>
+
+                    <listitem>
+                        <para>
+                            <code>trim_user</code>, when set to boolean true, "t", or 1, will list
+                            the author identifier only in embedded user objects in the statuses
+                            returned.
+                        </para>
+                    </listitem>
+
+                    <listitem>
+                        <para>
+                            <code>contributor_details</code>, when set to boolean true, will return
+                            the screen name of any contributors to a status (instead of only the
+                            contributor identifier).
+                        </para>
+                    </listitem>
+
+                    <listitem>
+                        <para>
+                            <code>include_entities</code> controls whether or not entities, which
+                            includes URLs, mentioned users, and hashtags, will be returned.
+                        </para>
+                    </listitem>
+
+                    <listitem>
+                        <para>
+                            <code>exclude_replies</code> controls whether or not status updates that
+                            are in reply to other statuses will be returned.
+                        </para>
+                    </listitem>
+                </itemizedlist>
+            </listitem>
+
+            <listitem>
+                <para>
+                    <methodname>userTimeline()</methodname> returns the 20 most recent statuses
+                    posted from the authenticating user.
+                </para>
+
+                <example id="zend.service.twitter.statuses.usertimeline">
+                    <title>Retrieving user timeline</title>
+
+                    <programlisting language="php"><![CDATA[
+$twitter  = new Zend_Service_Twitter($options);
+$response = $twitter->statuses->userTimeline();
+]]></programlisting>
+                </example>
+
+                <para>
+                    The <methodname>userTimeline()</methodname> method accepts an array of optional
+                    parameters to modify the query.
+                </para>
+
+                <itemizedlist>
+                    <listitem>
+                        <para>
+                            <code>user_id</code> specifies the ID of the user for whom to return the
+                            timeline.
+                        </para>
+                    </listitem>
+
+                    <listitem>
+                        <para>
+                            <code>screen_name</code> specifies the screen name of the user for
+                            whom to return the timeline.
+                        </para>
+                    </listitem>
+
+                    <listitem>
+                        <para>
+                            <code>since_id</code> narrows the returned results to just those
+                            statuses after the specified identifier (up to 24 hours old).
+                        </para>
+                    </listitem>
+
+                    <listitem>
+                        <para>
+                            <code>max_id</code> narrows the returned results to just those
+                            statuses earlier than the specified identifier.
+                        </para>
+                    </listitem>
+
+                    <listitem>
+                        <para>
+                            <code>count</code> specifies the number of statuses to return, up to 200.
+                        </para>
+                    </listitem>
+
+                    <listitem>
+                        <para>
+                            <code>trim_user</code>, when set to boolean true, "t", or 1, will list
+                            the author identifier only in embedded user objects in the statuses
+                            returned.
+                        </para>
+                    </listitem>
+
+                    <listitem>
+                        <para>
+                            <code>contributor_details</code>, when set to boolean true, will return
+                            the screen name of any contributors to a status (instead of only the
+                            contributor identifier).
+                        </para>
+                    </listitem>
+
+                    <listitem>
+                        <para>
+                            <code>include_rts</code> controls whether or not to include native
+                            retweets in the returned list.
+                        </para>
+                    </listitem>
+
+                    <listitem>
+                        <para>
+                            <code>exclude_replies</code> controls whether or not status updates that
+                            are in reply to other statuses will be returned.
+                        </para>
+                    </listitem>
+                </itemizedlist>
+            </listitem>
+
+            <listitem>
+                <para>
+                    <methodname>show()</methodname> returns a single status, specified by the
+                    <code>id</code> parameter below. The status' author will be returned inline.
+                </para>
+
+                <example id="zend.service.twitter.statuses.show">
+                    <title>Showing user status</title>
+
+                    <programlisting language="php"><![CDATA[
+$twitter  = new Zend_Service_Twitter($options);
+$response = $twitter->statuses->show(1234);
+]]></programlisting>
+                </example>
+            </listitem>
+
+            <listitem>
+                <para>
+                    <methodname>update()</methodname> updates the authenticating user's status.
+                    This method requires that you pass in the status update that you want to post
+                    to Twitter.
+                </para>
+
+                <example id="zend.service.twitter.statuses.update">
+                    <title>Updating user status</title>
+
+                    <programlisting language="php"><![CDATA[
+$twitter  = new Zend_Service_Twitter($options);
+$response = $twitter->statuses->update('My Great Tweet');
+]]></programlisting>
+                </example>
+
+                <para>
+                    The <methodname>update()</methodname> method accepts a second additional
+                    parameter.
+                </para>
+
+                <itemizedlist>
+                    <listitem>
+                        <para>
+                            <code>inReplyToStatusId</code> specifies the ID of an existing
+                            status that the status to be posted is in reply to.
+                        </para>
+                    </listitem>
+                </itemizedlist>
+            </listitem>
+
+            <listitem>
+                <para>
+                    <methodname>mentionsTimeline()</methodname> returns the 20 most recent @replies
+                    (status updates prefixed with @username) for the authenticating user.
+                </para>
+
+                <example id="zend.service.twitter.statuses.mentionstimeline">
+                    <title>Showing user replies</title>
+
+                    <programlisting language="php"><![CDATA[
+$twitter  = new Zend_Service_Twitter($options);
+$response = $twitter->statuses->mentionsTimeline();
+]]></programlisting>
+                </example>
+
+                <para>
+                    The <methodname>mentionsTimeline()</methodname> method accepts an array of
+                    optional parameters to modify the query.
+                </para>
+
+                <itemizedlist>
+                    <listitem>
+                        <para>
+                            <code>since_id</code> narrows the returned results to just those
+                            statuses after the specified identifier (up to 24 hours old).
+                        </para>
+                    </listitem>
+
+                    <listitem>
+                        <para>
+                            <code>max_id</code> narrows the returned results to just those
+                            statuses earlier than the specified identifier.
+                        </para>
+                    </listitem>
+
+                    <listitem>
+                        <para>
+                            <code>count</code> specifies the number of statuses to return, up to 200.
+                        </para>
+                    </listitem>
+
+                    <listitem>
+                        <para>
+                            <code>trim_user</code>, when set to boolean true, "t", or 1, will list
+                            the author identifier only in embedded user objects in the statuses
+                            returned.
+                        </para>
+                    </listitem>
+
+                    <listitem>
+                        <para>
+                            <code>contributor_details</code>, when set to boolean true, will return
+                            the screen name of any contributors to a status (instead of only the
+                            contributor identifier).
+                        </para>
+                    </listitem>
+
+                    <listitem>
+                        <para>
+                            <code>include_entities</code> controls whether or not entities, which
+                            includes URLs, mentioned users, and hashtags, will be returned.
+                        </para>
+                    </listitem>
+                </itemizedlist>
+            </listitem>
+
+            <listitem>
+                <para>
+                    <methodname>destroy()</methodname> destroys the status specified by the
+                    required <code>id</code> parameter.
+                </para>
+
+                <example id="zend.service.twitter.statuses.destroy">
+                    <title>Deleting user status</title>
+
+                    <programlisting language="php"><![CDATA[
+$twitter  = new Zend_Service_Twitter($options);
+$response = $twitter->statuses->destroy(12345);
+]]></programlisting>
+                </example>
+            </listitem>
+        </itemizedlist>
+    </sect2>
+
+    <sect2 id="zend.service.twitter.users">
+        <title>User Methods</title>
+
+        <itemizedlist>
+            <listitem>
+                <para>
+                    <methodname>show()</methodname> returns extended information of a given user,
+                    specified by ID or screen name as per the required <code>id</code>
+                    parameter below.
+                </para>
+
+                <example id="zend.service.twitter.users.show">
+                    <title>Showing user informations</title>
+
+                    <programlisting language="php"><![CDATA[
+$twitter  = new Zend_Service_Twitter($options);
+$response = $twitter->users->show('myfriend');
+]]></programlisting>
+                </example>
+            </listitem>
+
+            <listitem>
+                <para>
+                    <methodname>search()</methodname> will search for users matching the query
+                    provided.
+                </para>
+
+                <example id="zend.service.twitter.users.search">
+                    <title>Searching for users</title>
+
+                    <programlisting language="php"><![CDATA[
+$twitter  = new Zend_Service_Twitter($options);
+$response = $twitter->users->search('Zend');
+]]></programlisting>
+                </example>
+
+                <para>
+                    The <methodname>search()</methodname> method accepts an array of
+                    optional parameters to modify the query.
+                </para>
+
+                <itemizedlist>
+                    <listitem>
+                        <para>
+                            <code>count</code> specifies the number of statuses to return, up to 20.
+                        </para>
+                    </listitem>
+
+                    <listitem>
+                        <para>
+                            <code>page</code> specifies the page of results to return, based on the
+                            <code>count</code> provided.
+                        </para>
+                    </listitem>
+
+                    <listitem>
+                        <para>
+                            <code>include_entities</code> controls whether or not entities, which
+                            includes URLs, mentioned users, and hashtags, will be returned.
+                        </para>
+                    </listitem>
+                </itemizedlist>
+            </listitem>
+        </itemizedlist>
+    </sect2>
 </sect1>
 <!--
 vim:se ts=4 sw=4 et:

--- a/documentation/manual/he/Makefile.in
+++ b/documentation/manual/he/Makefile.in
@@ -38,9 +38,9 @@ FOP=@FOP@
 ECSRC=@ECSRC@
 HERE=@HERE@
 
-DOCBOOK_DTD?=http://framework.zend.com/docbook/xml/4.5/docbookx.dtd
-DOCBOOK_XSL?=http://framework.zend.com/docbook-xsl/htmlhelp/htmlhelp.xsl
-DOCBOOK_FO_XSL?=http://framework.zend.com/docbook-xsl/fo/docbook.xsl
+DOCBOOK_DTD?=https://docbook.org/xml/4.5/docbookx.dtd
+DOCBOOK_XSL?=https://cdn.docbook.org/release/xsl/current/html/chunk.xsl
+DOCBOOK_FO_XSL?=https://cdn.docbook.org/release/xsl/current/fo/docbook.xsl
 HTML_XSL=html.xsl
 MANUAL_XML=manual.xml
 MANUAL_PRINT1_XML=manual-print1.xml
@@ -58,8 +58,8 @@ html: html/index.html
 
 html/index.html: $(MANUAL_XML) $(HTML_XSL)
 	@echo "Rendering the whole manual with $(XSLTPROC)..."
-	$(XMLLINT) --xinclude --output _temp_manual.xml $(MANUAL_XML)
-	$(XSLTPROC) --xinclude --output html/index.html $(HTML_XSL) _temp_manual.xml
+	$(XMLLINT) --xinclude --noent --output _temp_manual.xml $(MANUAL_XML)
+	$(XSLTPROC) --xinclude --maxdepth 6000 --output html/index.html $(HTML_XSL) _temp_manual.xml
 	@echo "Copying manual figures (recursively)..."
 	-[ -d figures ] && cp -r figures html/
 

--- a/documentation/manual/he/module_specs/Zend_Dojo-View.xml
+++ b/documentation/manual/he/module_specs/Zend_Dojo-View.xml
@@ -36,8 +36,16 @@ Zend_Dojo::enableView($view);
         </programlisting>
     </example>
 
-    <xi:include href="Zend_Dojo-View-Dojo.xml" />
-    <xi:include href="Zend_Dojo-View-Helpers.xml" />
+    <xi:include href="Zend_Dojo-View-Dojo.xml">
+        <xi:fallback>
+            <xi:include href="../../en/module_specs/Zend_Dojo-View-Dojo.xml" />
+        </xi:fallback>
+    </xi:include>
+    <xi:include href="Zend_Dojo-View-Helpers.xml">
+        <xi:fallback>
+            <xi:include href="../../en/module_specs/Zend_Dojo-View-Helpers.xml" />
+        </xi:fallback>
+    </xi:include>
 </sect1>
 <!--
 vim:se ts=4 sw=4 et:

--- a/documentation/manual/he/module_specs/Zend_ProgressBar.xml
+++ b/documentation/manual/he/module_specs/Zend_ProgressBar.xml
@@ -59,8 +59,16 @@ $progressBar->finish();
                 <listitem><para><xref linkend="zend.progressbar.adapter.jspull" /></para></listitem>
             </itemizedlist>
         </para>
-        <xi:include href="Zend_ProgressBar_Adapter_Console.xml" />
-        <xi:include href="Zend_ProgressBar_Adapter_JsPush.xml" />
+        <xi:include href="Zend_ProgressBar_Adapter_Console.xml">
+            <xi:fallback>
+                <xi:include href="../../en/module_specs/Zend_ProgressBar_Adapter_Console.xml" />
+            </xi:fallback>
+        </xi:include>
+        <xi:include href="Zend_ProgressBar_Adapter_JsPush.xml">
+            <xi:fallback>
+                <xi:include href="../../en/module_specs/Zend_ProgressBar_Adapter_JsPush.xml" />
+            </xi:fallback>
+        </xi:include>
         <xi:include href="Zend_ProgressBar_Adapter_JsPull.xml" />
     </sect2>
 </sect1>

--- a/documentation/manual/he/module_specs/Zend_Test-PHPUnit.xml
+++ b/documentation/manual/he/module_specs/Zend_Test-PHPUnit.xml
@@ -91,10 +91,22 @@ class UserControllerTest extends Zend_Test_PHPUnit_ControllerTestCase
         </para>
     </example>
 
-    <xi:include href="Zend_Test-PHPUnit-Bootstrapping.xml" />
+    <xi:include href="Zend_Test-PHPUnit-Bootstrapping.xml">
+        <xi:fallback>
+            <xi:include href="../../en/module_specs/Zend_Test-PHPUnit-Bootstrapping.xml" />
+        </xi:fallback>
+    </xi:include>
     <xi:include href="Zend_Test-PHPUnit-Testing.xml" />
-    <xi:include href="Zend_Test-PHPUnit-Assertions.xml" />
-    <xi:include href="Zend_Test-PHPUnit-Examples.xml" />
+    <xi:include href="Zend_Test-PHPUnit-Assertions.xml">
+        <xi:fallback>
+            <xi:include href="../../en/module_specs/Zend_Test-PHPUnit-Assertions.xml" />
+        </xi:fallback>
+    </xi:include>
+    <xi:include href="Zend_Test-PHPUnit-Examples.xml">
+        <xi:fallback>
+            <xi:include href="../../en/module_specs/Zend_Test-PHPUnit-Examples.xml" />
+        </xi:fallback>
+    </xi:include>
 </sect1>
 <!--
 vim:se ts=4 sw=4 et:

--- a/documentation/manual/hu/Makefile.in
+++ b/documentation/manual/hu/Makefile.in
@@ -38,9 +38,9 @@ FOP=@FOP@
 ECSRC=@ECSRC@
 HERE=@HERE@
 
-DOCBOOK_DTD?=http://framework.zend.com/docbook/xml/4.5/docbookx.dtd
-DOCBOOK_XSL?=http://framework.zend.com/docbook-xsl/htmlhelp/htmlhelp.xsl
-DOCBOOK_FO_XSL?=http://framework.zend.com/docbook-xsl/fo/docbook.xsl
+DOCBOOK_DTD?=https://docbook.org/xml/4.5/docbookx.dtd
+DOCBOOK_XSL?=https://cdn.docbook.org/release/xsl/current/html/chunk.xsl
+DOCBOOK_FO_XSL?=https://cdn.docbook.org/release/xsl/current/fo/docbook.xsl
 HTML_XSL=html.xsl
 MANUAL_XML=manual.xml
 MANUAL_PRINT1_XML=manual-print1.xml
@@ -58,8 +58,8 @@ html: html/index.html
 
 html/index.html: $(MANUAL_XML) $(HTML_XSL)
 	@echo "Rendering the whole manual with $(XSLTPROC)..."
-	$(XMLLINT) --xinclude --output _temp_manual.xml $(MANUAL_XML)
-	$(XSLTPROC) --xinclude --output html/index.html $(HTML_XSL) _temp_manual.xml
+	$(XMLLINT) --xinclude --noent --output _temp_manual.xml $(MANUAL_XML)
+	$(XSLTPROC) --xinclude --maxdepth 6000 --output html/index.html $(HTML_XSL) _temp_manual.xml
 	@echo "Copying manual figures (recursively)..."
 	-[ -d figures ] && cp -r figures html/
 

--- a/documentation/manual/id/Makefile.in
+++ b/documentation/manual/id/Makefile.in
@@ -38,9 +38,9 @@ FOP=@FOP@
 ECSRC=@ECSRC@
 HERE=@HERE@
 
-DOCBOOK_DTD?=http://framework.zend.com/docbook/xml/4.5/docbookx.dtd
-DOCBOOK_XSL?=http://framework.zend.com/docbook-xsl/htmlhelp/htmlhelp.xsl
-DOCBOOK_FO_XSL?=http://framework.zend.com/docbook-xsl/fo/docbook.xsl
+DOCBOOK_DTD?=https://docbook.org/xml/4.5/docbookx.dtd
+DOCBOOK_XSL?=https://cdn.docbook.org/release/xsl/current/html/chunk.xsl
+DOCBOOK_FO_XSL?=https://cdn.docbook.org/release/xsl/current/fo/docbook.xsl
 HTML_XSL=html.xsl
 MANUAL_XML=manual.xml
 MANUAL_PRINT1_XML=manual-print1.xml
@@ -58,8 +58,8 @@ html: html/index.html
 
 html/index.html: $(MANUAL_XML) $(HTML_XSL)
 	@echo "Rendering the whole manual with $(XSLTPROC)..."
-	$(XMLLINT) --xinclude --output _temp_manual.xml $(MANUAL_XML)
-	$(XSLTPROC) --xinclude --output html/index.html $(HTML_XSL) _temp_manual.xml
+	$(XMLLINT) --xinclude --noent --output _temp_manual.xml $(MANUAL_XML)
+	$(XSLTPROC) --xinclude --maxdepth 6000 --output html/index.html $(HTML_XSL) _temp_manual.xml
 	@echo "Copying manual figures (recursively)..."
 	-[ -d figures ] && cp -r figures html/
 

--- a/documentation/manual/it/Makefile.in
+++ b/documentation/manual/it/Makefile.in
@@ -38,9 +38,9 @@ FOP=@FOP@
 ECSRC=@ECSRC@
 HERE=@HERE@
 
-DOCBOOK_DTD?=http://framework.zend.com/docbook/xml/4.5/docbookx.dtd
-DOCBOOK_XSL?=http://framework.zend.com/docbook-xsl/htmlhelp/htmlhelp.xsl
-DOCBOOK_FO_XSL?=http://framework.zend.com/docbook-xsl/fo/docbook.xsl
+DOCBOOK_DTD?=https://docbook.org/xml/4.5/docbookx.dtd
+DOCBOOK_XSL?=https://cdn.docbook.org/release/xsl/current/html/chunk.xsl
+DOCBOOK_FO_XSL?=https://cdn.docbook.org/release/xsl/current/fo/docbook.xsl
 HTML_XSL=html.xsl
 MANUAL_XML=manual.xml
 MANUAL_PRINT1_XML=manual-print1.xml
@@ -58,8 +58,8 @@ html: html/index.html
 
 html/index.html: $(MANUAL_XML) $(HTML_XSL)
 	@echo "Rendering the whole manual with $(XSLTPROC)..."
-	$(XMLLINT) --xinclude --output _temp_manual.xml $(MANUAL_XML)
-	$(XSLTPROC) --xinclude --output html/index.html $(HTML_XSL) _temp_manual.xml
+	$(XMLLINT) --xinclude --noent --output _temp_manual.xml $(MANUAL_XML)
+	$(XSLTPROC) --xinclude --maxdepth 6000 --output html/index.html $(HTML_XSL) _temp_manual.xml
 	@echo "Copying manual figures (recursively)..."
 	-[ -d figures ] && cp -r figures html/
 

--- a/documentation/manual/it/module_specs/Zend_Application-CoreFunctionality.xml
+++ b/documentation/manual/it/module_specs/Zend_Application-CoreFunctionality.xml
@@ -8,11 +8,39 @@
         <classname>Zend_Application</classname>.
     </para>
 
-    <xi:include href="Zend_Application-CoreFunctionality-Application.xml" />
-    <xi:include href="Zend_Application-CoreFunctionality-Bootstrap_Bootstrapper.xml" />
-    <xi:include href="Zend_Application-CoreFunctionality-Bootstrap_ResourceBootstrapper.xml" />
-    <xi:include href="Zend_Application-CoreFunctionality-Bootstrap_BootstrapAbstract.xml" />
-    <xi:include href="Zend_Application-CoreFunctionality-Bootstrap_Bootstrap.xml" />
-    <xi:include href="Zend_Application-CoreFunctionality-Resource_Resource.xml" />
-    <xi:include href="Zend_Application-CoreFunctionality-Resource_ResourceAbstract.xml" />
+    <xi:include href="Zend_Application-CoreFunctionality-Application.xml">
+        <xi:fallback>
+            <xi:include href="../../en/module_specs/Zend_Application-CoreFunctionality-Application.xml" />
+        </xi:fallback>
+    </xi:include>
+    <xi:include href="Zend_Application-CoreFunctionality-Bootstrap_Bootstrapper.xml">
+        <xi:fallback>
+            <xi:include href="../../en/module_specs/Zend_Application-CoreFunctionality-Bootstrap_Bootstrapper.xml" />
+        </xi:fallback>
+    </xi:include>
+    <xi:include href="Zend_Application-CoreFunctionality-Bootstrap_ResourceBootstrapper.xml">
+        <xi:fallback>
+            <xi:include href="../../en/module_specs/Zend_Application-CoreFunctionality-Bootstrap_ResourceBootstrapper.xml" />
+        </xi:fallback>
+    </xi:include>
+    <xi:include href="Zend_Application-CoreFunctionality-Bootstrap_BootstrapAbstract.xml">
+        <xi:fallback>
+            <xi:include href="../../en/module_specs/Zend_Application-CoreFunctionality-Bootstrap_BootstrapAbstract.xml" />
+        </xi:fallback>
+    </xi:include>
+    <xi:include href="Zend_Application-CoreFunctionality-Bootstrap_Bootstrap.xml">
+        <xi:fallback>
+            <xi:include href="../../en/module_specs/Zend_Application-CoreFunctionality-Bootstrap_Bootstrap.xml" />
+        </xi:fallback>
+    </xi:include>
+    <xi:include href="Zend_Application-CoreFunctionality-Resource_Resource.xml">
+        <xi:fallback>
+            <xi:include href="../../en/module_specs/Zend_Application-CoreFunctionality-Resource_Resource.xml" />
+        </xi:fallback>
+    </xi:include>
+    <xi:include href="Zend_Application-CoreFunctionality-Resource_ResourceAbstract.xml">
+        <xi:fallback>
+            <xi:include href="../../en/module_specs/Zend_Application-CoreFunctionality-Resource_ResourceAbstract.xml" />
+        </xi:fallback>
+    </xi:include>
 </sect1>

--- a/documentation/manual/ja/Makefile.in
+++ b/documentation/manual/ja/Makefile.in
@@ -38,9 +38,9 @@ FOP=@FOP@
 ECSRC=@ECSRC@
 HERE=@HERE@
 
-DOCBOOK_DTD?=http://framework.zend.com/docbook/xml/4.5/docbookx.dtd
-DOCBOOK_XSL?=http://framework.zend.com/docbook-xsl/htmlhelp/htmlhelp.xsl
-DOCBOOK_FO_XSL?=http://framework.zend.com/docbook-xsl/fo/docbook.xsl
+DOCBOOK_DTD?=https://docbook.org/xml/4.5/docbookx.dtd
+DOCBOOK_XSL?=https://cdn.docbook.org/release/xsl/current/html/chunk.xsl
+DOCBOOK_FO_XSL?=https://cdn.docbook.org/release/xsl/current/fo/docbook.xsl
 HTML_XSL=html.xsl
 MANUAL_XML=manual.xml
 MANUAL_PRINT1_XML=manual-print1.xml
@@ -58,8 +58,8 @@ html: html/index.html
 
 html/index.html: $(MANUAL_XML) $(HTML_XSL)
 	@echo "Rendering the whole manual with $(XSLTPROC)..."
-	$(XMLLINT) --xinclude --output _temp_manual.xml $(MANUAL_XML)
-	$(XSLTPROC) --xinclude --output html/index.html $(HTML_XSL) _temp_manual.xml
+	$(XMLLINT) --xinclude --noent --output _temp_manual.xml $(MANUAL_XML)
+	$(XSLTPROC) --xinclude --maxdepth 6000 --output html/index.html $(HTML_XSL) _temp_manual.xml
 	@echo "Copying manual figures (recursively)..."
 	-[ -d figures ] && cp -r figures html/
 

--- a/documentation/manual/ko/Makefile.in
+++ b/documentation/manual/ko/Makefile.in
@@ -38,9 +38,9 @@ FOP=@FOP@
 ECSRC=@ECSRC@
 HERE=@HERE@
 
-DOCBOOK_DTD?=http://framework.zend.com/docbook/xml/4.5/docbookx.dtd
-DOCBOOK_XSL?=http://framework.zend.com/docbook-xsl/htmlhelp/htmlhelp.xsl
-DOCBOOK_FO_XSL?=http://framework.zend.com/docbook-xsl/fo/docbook.xsl
+DOCBOOK_DTD?=https://docbook.org/xml/4.5/docbookx.dtd
+DOCBOOK_XSL?=https://cdn.docbook.org/release/xsl/current/html/chunk.xsl
+DOCBOOK_FO_XSL?=https://cdn.docbook.org/release/xsl/current/fo/docbook.xsl
 HTML_XSL=html.xsl
 MANUAL_XML=manual.xml
 MANUAL_PRINT1_XML=manual-print1.xml
@@ -58,8 +58,8 @@ html: html/index.html
 
 html/index.html: $(MANUAL_XML) $(HTML_XSL)
 	@echo "Rendering the whole manual with $(XSLTPROC)..."
-	$(XMLLINT) --xinclude --output _temp_manual.xml $(MANUAL_XML)
-	$(XSLTPROC) --xinclude --output html/index.html $(HTML_XSL) _temp_manual.xml
+	$(XMLLINT) --xinclude --noent --output _temp_manual.xml $(MANUAL_XML)
+	$(XSLTPROC) --xinclude --maxdepth 6000 --output html/index.html $(HTML_XSL) _temp_manual.xml
 	@echo "Copying manual figures (recursively)..."
 	-[ -d figures ] && cp -r figures html/
 

--- a/documentation/manual/nl/Makefile.in
+++ b/documentation/manual/nl/Makefile.in
@@ -38,9 +38,9 @@ FOP=@FOP@
 ECSRC=@ECSRC@
 HERE=@HERE@
 
-DOCBOOK_DTD?=http://framework.zend.com/docbook/xml/4.5/docbookx.dtd
-DOCBOOK_XSL?=http://framework.zend.com/docbook-xsl/htmlhelp/htmlhelp.xsl
-DOCBOOK_FO_XSL?=http://framework.zend.com/docbook-xsl/fo/docbook.xsl
+DOCBOOK_DTD?=https://docbook.org/xml/4.5/docbookx.dtd
+DOCBOOK_XSL?=https://cdn.docbook.org/release/xsl/current/html/chunk.xsl
+DOCBOOK_FO_XSL?=https://cdn.docbook.org/release/xsl/current/fo/docbook.xsl
 HTML_XSL=html.xsl
 MANUAL_XML=manual.xml
 MANUAL_PRINT1_XML=manual-print1.xml
@@ -58,8 +58,8 @@ html: html/index.html
 
 html/index.html: $(MANUAL_XML) $(HTML_XSL)
 	@echo "Rendering the whole manual with $(XSLTPROC)..."
-	$(XMLLINT) --xinclude --output _temp_manual.xml $(MANUAL_XML)
-	$(XSLTPROC) --xinclude --output html/index.html $(HTML_XSL) _temp_manual.xml
+	$(XMLLINT) --xinclude --noent --output _temp_manual.xml $(MANUAL_XML)
+	$(XSLTPROC) --xinclude --maxdepth 6000 --output html/index.html $(HTML_XSL) _temp_manual.xml
 	@echo "Copying manual figures (recursively)..."
 	-[ -d figures ] && cp -r figures html/
 

--- a/documentation/manual/pl/Makefile.in
+++ b/documentation/manual/pl/Makefile.in
@@ -38,9 +38,9 @@ FOP=@FOP@
 ECSRC=@ECSRC@
 HERE=@HERE@
 
-DOCBOOK_DTD?=http://framework.zend.com/docbook/xml/4.5/docbookx.dtd
-DOCBOOK_XSL?=http://framework.zend.com/docbook-xsl/htmlhelp/htmlhelp.xsl
-DOCBOOK_FO_XSL?=http://framework.zend.com/docbook-xsl/fo/docbook.xsl
+DOCBOOK_DTD?=https://docbook.org/xml/4.5/docbookx.dtd
+DOCBOOK_XSL?=https://cdn.docbook.org/release/xsl/current/html/chunk.xsl
+DOCBOOK_FO_XSL?=https://cdn.docbook.org/release/xsl/current/fo/docbook.xsl
 HTML_XSL=html.xsl
 MANUAL_XML=manual.xml
 MANUAL_PRINT1_XML=manual-print1.xml
@@ -58,8 +58,8 @@ html: html/index.html
 
 html/index.html: $(MANUAL_XML) $(HTML_XSL)
 	@echo "Rendering the whole manual with $(XSLTPROC)..."
-	$(XMLLINT) --xinclude --output _temp_manual.xml $(MANUAL_XML)
-	$(XSLTPROC) --xinclude --output html/index.html $(HTML_XSL) _temp_manual.xml
+	$(XMLLINT) --xinclude --noent --output _temp_manual.xml $(MANUAL_XML)
+	$(XSLTPROC) --xinclude --maxdepth 6000 --output html/index.html $(HTML_XSL) _temp_manual.xml
 	@echo "Copying manual figures (recursively)..."
 	-[ -d figures ] && cp -r figures html/
 

--- a/documentation/manual/pt-br/Makefile.in
+++ b/documentation/manual/pt-br/Makefile.in
@@ -38,9 +38,9 @@ FOP=@FOP@
 ECSRC=@ECSRC@
 HERE=@HERE@
 
-DOCBOOK_DTD?=http://framework.zend.com/docbook/xml/4.5/docbookx.dtd
-DOCBOOK_XSL?=http://framework.zend.com/docbook-xsl/htmlhelp/htmlhelp.xsl
-DOCBOOK_FO_XSL?=http://framework.zend.com/docbook-xsl/fo/docbook.xsl
+DOCBOOK_DTD?=https://docbook.org/xml/4.5/docbookx.dtd
+DOCBOOK_XSL?=https://cdn.docbook.org/release/xsl/current/html/chunk.xsl
+DOCBOOK_FO_XSL?=https://cdn.docbook.org/release/xsl/current/fo/docbook.xsl
 HTML_XSL=html.xsl
 MANUAL_XML=manual.xml
 MANUAL_PRINT1_XML=manual-print1.xml
@@ -58,8 +58,8 @@ html: html/index.html
 
 html/index.html: $(MANUAL_XML) $(HTML_XSL)
 	@echo "Rendering the whole manual with $(XSLTPROC)..."
-	$(XMLLINT) --xinclude --output _temp_manual.xml $(MANUAL_XML)
-	$(XSLTPROC) --xinclude --output html/index.html $(HTML_XSL) _temp_manual.xml
+	$(XMLLINT) --xinclude --noent --output _temp_manual.xml $(MANUAL_XML)
+	$(XSLTPROC) --xinclude --maxdepth 6000 --output html/index.html $(HTML_XSL) _temp_manual.xml
 	@echo "Copying manual figures (recursively)..."
 	-[ -d figures ] && cp -r figures html/
 

--- a/documentation/manual/pt-br/module_specs/Zend_Application-CoreFunctionality.xml
+++ b/documentation/manual/pt-br/module_specs/Zend_Application-CoreFunctionality.xml
@@ -9,11 +9,39 @@
         principais componentes de <classname>Zend_Application</classname>.
     </para>
 
-    <xi:include href="Zend_Application-CoreFunctionality-Application.xml" />
-    <xi:include href="Zend_Application-CoreFunctionality-Bootstrap_Bootstrapper.xml" />
-    <xi:include href="Zend_Application-CoreFunctionality-Bootstrap_ResourceBootstrapper.xml" />
-    <xi:include href="Zend_Application-CoreFunctionality-Bootstrap_BootstrapAbstract.xml" />
-    <xi:include href="Zend_Application-CoreFunctionality-Bootstrap_Bootstrap.xml" />
-    <xi:include href="Zend_Application-CoreFunctionality-Resource_Resource.xml" />
-    <xi:include href="Zend_Application-CoreFunctionality-Resource_ResourceAbstract.xml" />
+    <xi:include href="Zend_Application-CoreFunctionality-Application.xml">
+        <xi:fallback>
+            <xi:include href="../../en/module_specs/Zend_Application-CoreFunctionality-Application.xml" />
+        </xi:fallback>
+    </xi:include>
+    <xi:include href="Zend_Application-CoreFunctionality-Bootstrap_Bootstrapper.xml">
+        <xi:fallback>
+            <xi:include href="../../en/module_specs/Zend_Application-CoreFunctionality-Bootstrap_Bootstrapper.xml" />
+        </xi:fallback>
+    </xi:include>
+    <xi:include href="Zend_Application-CoreFunctionality-Bootstrap_ResourceBootstrapper.xml">
+        <xi:fallback>
+            <xi:include href="../../en/module_specs/Zend_Application-CoreFunctionality-Bootstrap_ResourceBootstrapper.xml" />
+        </xi:fallback>
+    </xi:include>
+    <xi:include href="Zend_Application-CoreFunctionality-Bootstrap_BootstrapAbstract.xml">
+        <xi:fallback>
+            <xi:include href="../../en/module_specs/Zend_Application-CoreFunctionality-Bootstrap_BootstrapAbstract.xml" />
+        </xi:fallback>
+    </xi:include>
+    <xi:include href="Zend_Application-CoreFunctionality-Bootstrap_Bootstrap.xml">
+        <xi:fallback>
+            <xi:include href="../../en/module_specs/Zend_Application-CoreFunctionality-Bootstrap_Bootstrap.xml" />
+        </xi:fallback>
+    </xi:include>
+    <xi:include href="Zend_Application-CoreFunctionality-Resource_Resource.xml">
+        <xi:fallback>
+            <xi:include href="../../en/module_specs/Zend_Application-CoreFunctionality-Resource_Resource.xml" />
+        </xi:fallback>
+    </xi:include>
+    <xi:include href="Zend_Application-CoreFunctionality-Resource_ResourceAbstract.xml">
+        <xi:fallback>
+            <xi:include href="../../en/module_specs/Zend_Application-CoreFunctionality-Resource_ResourceAbstract.xml" />
+        </xi:fallback>
+    </xi:include>
 </sect1>

--- a/documentation/manual/pt-br/module_specs/Zend_View-Helpers.xml
+++ b/documentation/manual/pt-br/module_specs/Zend_View-Helpers.xml
@@ -387,25 +387,101 @@ echo $this->formCheckbox('foo',
 </form>
 ]]></programlisting>
 
-        <xi:include href="Zend_View-Helpers-Action.xml" />
-        <xi:include href="Zend_View-Helpers-BaseUrl.xml" />
-        <xi:include href="Zend_View-Helpers-Currency.xml" />
-        <xi:include href="Zend_View-Helpers-Cycle.xml" />
-        <xi:include href="Zend_View-Helpers-Partial.xml" />
-        <xi:include href="Zend_View-Helpers-Placeholder.xml" />
-        <xi:include href="Zend_View-Helpers-Doctype.xml" />
-        <xi:include href="Zend_View-Helpers-Gravatar.xml" />
-        <xi:include href="Zend_View-Helpers-HeadLink.xml" />
-        <xi:include href="Zend_View-Helpers-HeadMeta.xml" />
-        <xi:include href="Zend_View-Helpers-HeadScript.xml" />
-        <xi:include href="Zend_View-Helpers-HeadStyle.xml" />
-        <xi:include href="Zend_View-Helpers-HeadTitle.xml" />
-        <xi:include href="Zend_View-Helpers-HtmlObject.xml" />
-        <xi:include href="Zend_View-Helpers-InlineScript.xml" />
-        <xi:include href="Zend_View-Helpers-Json.xml" />
-        <xi:include href="Zend_View-Helpers-Navigation.xml" />
-        <xi:include href="Zend_View-Helpers-Translate.xml" />
-        <xi:include href="Zend_View-Helpers-UserAgent.xml" />
+        <xi:include href="Zend_View-Helpers-Action.xml">
+            <xi:fallback>
+                <xi:include href="../../en/module_specs/Zend_View-Helpers-Action.xml" />
+            </xi:fallback>
+        </xi:include>
+        <xi:include href="Zend_View-Helpers-BaseUrl.xml">
+            <xi:fallback>
+                <xi:include href="../../en/module_specs/Zend_View-Helpers-BaseUrl.xml" />
+            </xi:fallback>
+        </xi:include>
+        <xi:include href="Zend_View-Helpers-Currency.xml">
+            <xi:fallback>
+                <xi:include href="../../en/module_specs/Zend_View-Helpers-Currency.xml" />
+            </xi:fallback>
+        </xi:include>
+        <xi:include href="Zend_View-Helpers-Cycle.xml">
+            <xi:fallback>
+                <xi:include href="../../en/module_specs/Zend_View-Helpers-Cycle.xml" />
+            </xi:fallback>
+        </xi:include>
+        <xi:include href="Zend_View-Helpers-Partial.xml">
+            <xi:fallback>
+                <xi:include href="../../en/module_specs/Zend_View-Helpers-Partial.xml" />
+            </xi:fallback>
+        </xi:include>
+        <xi:include href="Zend_View-Helpers-Placeholder.xml">
+            <xi:fallback>
+                <xi:include href="../../en/module_specs/Zend_View-Helpers-Placeholder.xml" />
+            </xi:fallback>
+        </xi:include>
+        <xi:include href="Zend_View-Helpers-Doctype.xml">
+            <xi:fallback>
+                <xi:include href="../../en/module_specs/Zend_View-Helpers-Doctype.xml" />
+            </xi:fallback>
+        </xi:include>
+        <xi:include href="Zend_View-Helpers-Gravatar.xml">
+            <xi:fallback>
+                <xi:include href="../../en/module_specs/Zend_View-Helpers-Gravatar.xml" />
+            </xi:fallback>
+        </xi:include>
+        <xi:include href="Zend_View-Helpers-HeadLink.xml">
+            <xi:fallback>
+                <xi:include href="../../en/module_specs/Zend_View-Helpers-HeadLink.xml" />
+            </xi:fallback>
+        </xi:include>
+        <xi:include href="Zend_View-Helpers-HeadMeta.xml">
+            <xi:fallback>
+                <xi:include href="../../en/module_specs/Zend_View-Helpers-HeadMeta.xml" />
+            </xi:fallback>
+        </xi:include>
+        <xi:include href="Zend_View-Helpers-HeadScript.xml">
+            <xi:fallback>
+                <xi:include href="../../en/module_specs/Zend_View-Helpers-HeadScript.xml" />
+            </xi:fallback>
+        </xi:include>
+        <xi:include href="Zend_View-Helpers-HeadStyle.xml">
+            <xi:fallback>
+                <xi:include href="../../en/module_specs/Zend_View-Helpers-HeadStyle.xml" />
+            </xi:fallback>
+        </xi:include>
+        <xi:include href="Zend_View-Helpers-HeadTitle.xml">
+            <xi:fallback>
+                <xi:include href="../../en/module_specs/Zend_View-Helpers-HeadTitle.xml" />
+            </xi:fallback>
+        </xi:include>
+        <xi:include href="Zend_View-Helpers-HtmlObject.xml">
+            <xi:fallback>
+                <xi:include href="../../en/module_specs/Zend_View-Helpers-HtmlObject.xml" />
+            </xi:fallback>
+        </xi:include>
+        <xi:include href="Zend_View-Helpers-InlineScript.xml">
+            <xi:fallback>
+                <xi:include href="../../en/module_specs/Zend_View-Helpers-InlineScript.xml" />
+            </xi:fallback>
+        </xi:include>
+        <xi:include href="Zend_View-Helpers-Json.xml">
+            <xi:fallback>
+                <xi:include href="../../en/module_specs/Zend_View-Helpers-Json.xml" />
+            </xi:fallback>
+        </xi:include>
+        <xi:include href="Zend_View-Helpers-Navigation.xml">
+            <xi:fallback>
+                <xi:include href="../../en/module_specs/Zend_View-Helpers-Navigation.xml" />
+            </xi:fallback>
+        </xi:include>
+        <xi:include href="Zend_View-Helpers-Translate.xml">
+            <xi:fallback>
+                <xi:include href="../../en/module_specs/Zend_View-Helpers-Translate.xml" />
+            </xi:fallback>
+        </xi:include>
+        <xi:include href="Zend_View-Helpers-UserAgent.xml">
+            <xi:fallback>
+                <xi:include href="../../en/module_specs/Zend_View-Helpers-UserAgent.xml" />
+            </xi:fallback>
+        </xi:include>
     </sect2>
 
     <sect2 id="zend.view.helpers.paths">

--- a/documentation/manual/ro/Makefile.in
+++ b/documentation/manual/ro/Makefile.in
@@ -38,9 +38,9 @@ FOP=@FOP@
 ECSRC=@ECSRC@
 HERE=@HERE@
 
-DOCBOOK_DTD?=http://framework.zend.com/docbook/xml/4.5/docbookx.dtd
-DOCBOOK_XSL?=http://framework.zend.com/docbook-xsl/htmlhelp/htmlhelp.xsl
-DOCBOOK_FO_XSL?=http://framework.zend.com/docbook-xsl/fo/docbook.xsl
+DOCBOOK_DTD?=https://docbook.org/xml/4.5/docbookx.dtd
+DOCBOOK_XSL?=https://cdn.docbook.org/release/xsl/current/html/chunk.xsl
+DOCBOOK_FO_XSL?=https://cdn.docbook.org/release/xsl/current/fo/docbook.xsl
 HTML_XSL=html.xsl
 MANUAL_XML=manual.xml
 MANUAL_PRINT1_XML=manual-print1.xml
@@ -58,8 +58,8 @@ html: html/index.html
 
 html/index.html: $(MANUAL_XML) $(HTML_XSL)
 	@echo "Rendering the whole manual with $(XSLTPROC)..."
-	$(XMLLINT) --xinclude --output _temp_manual.xml $(MANUAL_XML)
-	$(XSLTPROC) --xinclude --output html/index.html $(HTML_XSL) _temp_manual.xml
+	$(XMLLINT) --xinclude --noent --output _temp_manual.xml $(MANUAL_XML)
+	$(XSLTPROC) --xinclude --maxdepth 6000 --output html/index.html $(HTML_XSL) _temp_manual.xml
 	@echo "Copying manual figures (recursively)..."
 	-[ -d figures ] && cp -r figures html/
 

--- a/documentation/manual/ru/Makefile.in
+++ b/documentation/manual/ru/Makefile.in
@@ -38,9 +38,9 @@ FOP=@FOP@
 ECSRC=@ECSRC@
 HERE=@HERE@
 
-DOCBOOK_DTD?=http://framework.zend.com/docbook/xml/4.5/docbookx.dtd
-DOCBOOK_XSL?=http://framework.zend.com/docbook-xsl/htmlhelp/htmlhelp.xsl
-DOCBOOK_FO_XSL?=http://framework.zend.com/docbook-xsl/fo/docbook.xsl
+DOCBOOK_DTD?=https://docbook.org/xml/4.5/docbookx.dtd
+DOCBOOK_XSL?=https://cdn.docbook.org/release/xsl/current/html/chunk.xsl
+DOCBOOK_FO_XSL?=https://cdn.docbook.org/release/xsl/current/fo/docbook.xsl
 HTML_XSL=html.xsl
 MANUAL_XML=manual.xml
 MANUAL_PRINT1_XML=manual-print1.xml
@@ -58,8 +58,8 @@ html: html/index.html
 
 html/index.html: $(MANUAL_XML) $(HTML_XSL)
 	@echo "Rendering the whole manual with $(XSLTPROC)..."
-	$(XMLLINT) --xinclude --output _temp_manual.xml $(MANUAL_XML)
-	$(XSLTPROC) --xinclude --output html/index.html $(HTML_XSL) _temp_manual.xml
+	$(XMLLINT) --xinclude --noent --output _temp_manual.xml $(MANUAL_XML)
+	$(XSLTPROC) --xinclude --maxdepth 6000 --output html/index.html $(HTML_XSL) _temp_manual.xml
 	@echo "Copying manual figures (recursively)..."
 	-[ -d figures ] && cp -r figures html/
 

--- a/documentation/manual/sk/Makefile.in
+++ b/documentation/manual/sk/Makefile.in
@@ -38,9 +38,9 @@ FOP=@FOP@
 ECSRC=@ECSRC@
 HERE=@HERE@
 
-DOCBOOK_DTD?=http://framework.zend.com/docbook/xml/4.5/docbookx.dtd
-DOCBOOK_XSL?=http://framework.zend.com/docbook-xsl/htmlhelp/htmlhelp.xsl
-DOCBOOK_FO_XSL?=http://framework.zend.com/docbook-xsl/fo/docbook.xsl
+DOCBOOK_DTD?=https://docbook.org/xml/4.5/docbookx.dtd
+DOCBOOK_XSL?=https://cdn.docbook.org/release/xsl/current/html/chunk.xsl
+DOCBOOK_FO_XSL?=https://cdn.docbook.org/release/xsl/current/fo/docbook.xsl
 HTML_XSL=html.xsl
 MANUAL_XML=manual.xml
 MANUAL_PRINT1_XML=manual-print1.xml
@@ -58,8 +58,8 @@ html: html/index.html
 
 html/index.html: $(MANUAL_XML) $(HTML_XSL)
 	@echo "Rendering the whole manual with $(XSLTPROC)..."
-	$(XMLLINT) --xinclude --output _temp_manual.xml $(MANUAL_XML)
-	$(XSLTPROC) --xinclude --output html/index.html $(HTML_XSL) _temp_manual.xml
+	$(XMLLINT) --xinclude --noent --output _temp_manual.xml $(MANUAL_XML)
+	$(XSLTPROC) --xinclude --maxdepth 6000 --output html/index.html $(HTML_XSL) _temp_manual.xml
 	@echo "Copying manual figures (recursively)..."
 	-[ -d figures ] && cp -r figures html/
 

--- a/documentation/manual/sl/Makefile.in
+++ b/documentation/manual/sl/Makefile.in
@@ -38,9 +38,9 @@ FOP=@FOP@
 ECSRC=@ECSRC@
 HERE=@HERE@
 
-DOCBOOK_DTD?=http://framework.zend.com/docbook/xml/4.5/docbookx.dtd
-DOCBOOK_XSL?=http://framework.zend.com/docbook-xsl/htmlhelp/htmlhelp.xsl
-DOCBOOK_FO_XSL?=http://framework.zend.com/docbook-xsl/fo/docbook.xsl
+DOCBOOK_DTD?=https://docbook.org/xml/4.5/docbookx.dtd
+DOCBOOK_XSL?=https://cdn.docbook.org/release/xsl/current/html/chunk.xsl
+DOCBOOK_FO_XSL?=https://cdn.docbook.org/release/xsl/current/fo/docbook.xsl
 HTML_XSL=html.xsl
 MANUAL_XML=manual.xml
 MANUAL_PRINT1_XML=manual-print1.xml
@@ -58,8 +58,8 @@ html: html/index.html
 
 html/index.html: $(MANUAL_XML) $(HTML_XSL)
 	@echo "Rendering the whole manual with $(XSLTPROC)..."
-	$(XMLLINT) --xinclude --output _temp_manual.xml $(MANUAL_XML)
-	$(XSLTPROC) --xinclude --output html/index.html $(HTML_XSL) _temp_manual.xml
+	$(XMLLINT) --xinclude --noent --output _temp_manual.xml $(MANUAL_XML)
+	$(XSLTPROC) --xinclude --maxdepth 6000 --output html/index.html $(HTML_XSL) _temp_manual.xml
 	@echo "Copying manual figures (recursively)..."
 	-[ -d figures ] && cp -r figures html/
 

--- a/documentation/manual/sr/Makefile.in
+++ b/documentation/manual/sr/Makefile.in
@@ -38,9 +38,9 @@ FOP=@FOP@
 ECSRC=@ECSRC@
 HERE=@HERE@
 
-DOCBOOK_DTD?=http://framework.zend.com/docbook/xml/4.5/docbookx.dtd
-DOCBOOK_XSL?=http://framework.zend.com/docbook-xsl/htmlhelp/htmlhelp.xsl
-DOCBOOK_FO_XSL?=http://framework.zend.com/docbook-xsl/fo/docbook.xsl
+DOCBOOK_DTD?=https://docbook.org/xml/4.5/docbookx.dtd
+DOCBOOK_XSL?=https://cdn.docbook.org/release/xsl/current/html/chunk.xsl
+DOCBOOK_FO_XSL?=https://cdn.docbook.org/release/xsl/current/fo/docbook.xsl
 HTML_XSL=html.xsl
 MANUAL_XML=manual.xml
 MANUAL_PRINT1_XML=manual-print1.xml
@@ -58,8 +58,8 @@ html: html/index.html
 
 html/index.html: $(MANUAL_XML) $(HTML_XSL)
 	@echo "Rendering the whole manual with $(XSLTPROC)..."
-	$(XMLLINT) --xinclude --output _temp_manual.xml $(MANUAL_XML)
-	$(XSLTPROC) --xinclude --output html/index.html $(HTML_XSL) _temp_manual.xml
+	$(XMLLINT) --xinclude --noent --output _temp_manual.xml $(MANUAL_XML)
+	$(XSLTPROC) --xinclude --maxdepth 6000 --output html/index.html $(HTML_XSL) _temp_manual.xml
 	@echo "Copying manual figures (recursively)..."
 	-[ -d figures ] && cp -r figures html/
 

--- a/documentation/manual/tr/Makefile.in
+++ b/documentation/manual/tr/Makefile.in
@@ -38,9 +38,9 @@ FOP=@FOP@
 ECSRC=@ECSRC@
 HERE=@HERE@
 
-DOCBOOK_DTD?=http://framework.zend.com/docbook/xml/4.5/docbookx.dtd
-DOCBOOK_XSL?=http://framework.zend.com/docbook-xsl/htmlhelp/htmlhelp.xsl
-DOCBOOK_FO_XSL?=http://framework.zend.com/docbook-xsl/fo/docbook.xsl
+DOCBOOK_DTD?=https://docbook.org/xml/4.5/docbookx.dtd
+DOCBOOK_XSL?=https://cdn.docbook.org/release/xsl/current/html/chunk.xsl
+DOCBOOK_FO_XSL?=https://cdn.docbook.org/release/xsl/current/fo/docbook.xsl
 HTML_XSL=html.xsl
 MANUAL_XML=manual.xml
 MANUAL_PRINT1_XML=manual-print1.xml
@@ -58,8 +58,8 @@ html: html/index.html
 
 html/index.html: $(MANUAL_XML) $(HTML_XSL)
 	@echo "Rendering the whole manual with $(XSLTPROC)..."
-	$(XMLLINT) --xinclude --output _temp_manual.xml $(MANUAL_XML)
-	$(XSLTPROC) --xinclude --output html/index.html $(HTML_XSL) _temp_manual.xml
+	$(XMLLINT) --xinclude --noent --output _temp_manual.xml $(MANUAL_XML)
+	$(XSLTPROC) --xinclude --maxdepth 6000 --output html/index.html $(HTML_XSL) _temp_manual.xml
 	@echo "Copying manual figures (recursively)..."
 	-[ -d figures ] && cp -r figures html/
 

--- a/documentation/manual/uk/Makefile.in
+++ b/documentation/manual/uk/Makefile.in
@@ -38,9 +38,9 @@ FOP=@FOP@
 ECSRC=@ECSRC@
 HERE=@HERE@
 
-DOCBOOK_DTD?=http://framework.zend.com/docbook/xml/4.5/docbookx.dtd
-DOCBOOK_XSL?=http://framework.zend.com/docbook-xsl/htmlhelp/htmlhelp.xsl
-DOCBOOK_FO_XSL?=http://framework.zend.com/docbook-xsl/fo/docbook.xsl
+DOCBOOK_DTD?=https://docbook.org/xml/4.5/docbookx.dtd
+DOCBOOK_XSL?=https://cdn.docbook.org/release/xsl/current/html/chunk.xsl
+DOCBOOK_FO_XSL?=https://cdn.docbook.org/release/xsl/current/fo/docbook.xsl
 HTML_XSL=html.xsl
 MANUAL_XML=manual.xml
 MANUAL_PRINT1_XML=manual-print1.xml
@@ -58,8 +58,8 @@ html: html/index.html
 
 html/index.html: $(MANUAL_XML) $(HTML_XSL)
 	@echo "Rendering the whole manual with $(XSLTPROC)..."
-	$(XMLLINT) --xinclude --output _temp_manual.xml $(MANUAL_XML)
-	$(XSLTPROC) --xinclude --output html/index.html $(HTML_XSL) _temp_manual.xml
+	$(XMLLINT) --xinclude --noent --output _temp_manual.xml $(MANUAL_XML)
+	$(XSLTPROC) --xinclude --maxdepth 6000 --output html/index.html $(HTML_XSL) _temp_manual.xml
 	@echo "Copying manual figures (recursively)..."
 	-[ -d figures ] && cp -r figures html/
 

--- a/documentation/manual/zh/Makefile.in
+++ b/documentation/manual/zh/Makefile.in
@@ -38,9 +38,9 @@ FOP=@FOP@
 ECSRC=@ECSRC@
 HERE=@HERE@
 
-DOCBOOK_DTD?=http://framework.zend.com/docbook/xml/4.5/docbookx.dtd
-DOCBOOK_XSL?=http://framework.zend.com/docbook-xsl/htmlhelp/htmlhelp.xsl
-DOCBOOK_FO_XSL?=http://framework.zend.com/docbook-xsl/fo/docbook.xsl
+DOCBOOK_DTD?=https://docbook.org/xml/4.5/docbookx.dtd
+DOCBOOK_XSL?=https://cdn.docbook.org/release/xsl/current/html/chunk.xsl
+DOCBOOK_FO_XSL?=https://cdn.docbook.org/release/xsl/current/fo/docbook.xsl
 HTML_XSL=html.xsl
 MANUAL_XML=manual.xml
 MANUAL_PRINT1_XML=manual-print1.xml
@@ -58,8 +58,8 @@ html: html/index.html
 
 html/index.html: $(MANUAL_XML) $(HTML_XSL)
 	@echo "Rendering the whole manual with $(XSLTPROC)..."
-	$(XMLLINT) --xinclude --output _temp_manual.xml $(MANUAL_XML)
-	$(XSLTPROC) --xinclude --output html/index.html $(HTML_XSL) _temp_manual.xml
+	$(XMLLINT) --xinclude --noent --output _temp_manual.xml $(MANUAL_XML)
+	$(XSLTPROC) --xinclude --maxdepth 6000 --output html/index.html $(HTML_XSL) _temp_manual.xml
 	@echo "Copying manual figures (recursively)..."
 	-[ -d figures ] && cp -r figures html/
 

--- a/documentation/manual/zh/module_specs/Zend_Service.xml
+++ b/documentation/manual/zh/module_specs/Zend_Service.xml
@@ -5,7 +5,7 @@
         .
     </para>
     <para>
-        通过<link linkend="zend.service.rest"><code>Zend_Service_Rest</code></link>类,
+        通过<link linkend="zend.rest.client"><classname>Zend_Rest_Client</classname></link>类,
         <code>Zend_Service</code>可以支持任何基于REST的web服务。
         .
     </para>


### PR DESCRIPTION
Replaces old ZF Docbook dtd and xsl URLs with generics
Removes link to non-existing Zend File doc that causes the XML linter to fail
Fixes missing xs:fallback bugs in translations
Fixes various element ID issues in translations
Fixes typo in EN README
Adds html_site.xsl.in stylesheet for generating more online-oriented output