### PR TITLE
Ensure value is a string prior to validation

### DIFF
--- a/library/Zend/Validate/Int.php
+++ b/library/Zend/Validate/Int.php
@@ -136,7 +136,7 @@ class Zend_Validate_Int extends Zend_Validate_Abstract
 
         } else {
             try {
-                if (!Zend_Locale_Format::isInteger($value, ['locale' => $this->_locale])) {
+                if (!Zend_Locale_Format::isInteger(strval($value), ['locale' => $this->_locale])) {
                     $this->_error(self::NOT_INT);
                     return false;
                 }


### PR DESCRIPTION
Assume this a longstanding ZF bug but with no undesired affects prior to PHP 7.4.

Method expects a string value. If a float is passed in PHP 7.4 will issue a notice for trying to access array offset.