### PR TITLE
fix: PHPDoc typings on Zend_Db_Table_Rowset_Abstract::current [Close #157]

### DIFF
--- a/library/Zend/Db/Table/Rowset/Abstract.php
+++ b/library/Zend/Db/Table/Rowset/Abstract.php
@@ -238,7 +238,7 @@ abstract class Zend_Db_Table_Rowset_Abstract implements SeekableIterator, Counta
      * Similar to the current() function for arrays in PHP
      * Required by interface Iterator.
      *
-     * @return Zend_Db_Table_Row_Abstract current element from the collection
+     * @return Zend_Db_Table_Row_Abstract|null current element from the collection
      */
     public function current()
     {


### PR DESCRIPTION
Closes #157