### PR TITLE
Db\Select.php Updated regex pattern REGEX_COLUMN_EXPR

### DIFF
--- a/library/Zend/Db/Select.php
+++ b/library/Zend/Db/Select.php
@@ -81,7 +81,7 @@ class Zend_Db_Select
     const SQL_ASC        = 'ASC';
     const SQL_DESC       = 'DESC';
 
-    const REGEX_COLUMN_EXPR       = '/^([\w]*\s*\(([^\(\)]|(?1))*\))$/';
+    const REGEX_COLUMN_EXPR       = '/^([\w]*\s*\(([^\(\)]|(?1))*\))/';
     const REGEX_COLUMN_EXPR_ORDER = '/^([\w]+\s*\(([^\(\)]|(?1))*\))$/';
     const REGEX_COLUMN_EXPR_GROUP = '/^([\w]+\s*\(([^\(\)]|(?1))*\))$/';
     


### PR DESCRIPTION
_tableCols fails to detect `COUNT(tr.customer_id) + MIN(IF(tp.base_popularity IS NOT NULL, tp.base_popularity, 0))` or even `date_format(comment_date, "%d.%m.%Y, %H:%i") cdate`, so the faulty backticks are inserted.

Loosen the regular expression and remove the string end symbol ($), now it successfully detects SQL functions.