### PR TITLE
Fixes PHPDoc @return statement for Zend_Db_Select::query()

### DIFF
--- a/library/Zend/Db/Select.php
+++ b/library/Zend/Db/Select.php
@@ -700,7 +700,7 @@ class Zend_Db_Select
      *
      * @param integer $fetchMode OPTIONAL
      * @param  mixed  $bind An array of data to bind to the placeholders.
-     * @return PDO_Statement|Zend_Db_Statement
+     * @return Zend_Db_Statement
      */
     public function query($fetchMode = null, $bind = [])
     {


### PR DESCRIPTION
"PDO_Statement" has been included in the PHPDoc since pre-1.0 days, but has never been correct. This function will only ever return instances of Zend_Db_Statement.

Addresses https://github.com/Shardj/zf1-future/issues/164
Supersedes https://github.com/Shardj/zf1-future/pull/165