### PR TITLE
errcontext optional

### DIFF
--- a/library/Zend/Log.php
+++ b/library/Zend/Log.php
@@ -619,7 +619,7 @@ class Zend_Log
      * @param array $errcontext
      * @return boolean
      */
-    public function errorHandler($errno, $errstr, $errfile, $errline, $errcontext)
+    public function errorHandler($errno, $errstr, $errfile, $errline, $errcontext = null)
     {
         $errorLevel = error_reporting();
 

--- a/library/Zend/Log.php
+++ b/library/Zend/Log.php
@@ -619,7 +619,7 @@ class Zend_Log
      * @param array $errcontext
      * @return boolean
      */
-    public function errorHandler($errno, $errstr, $errfile, $errline, $errcontext = null)
+    public function errorHandler($errno, $errstr, $errfile, $errline, $errcontext = [])
     {
         $errorLevel = error_reporting();
 


### PR DESCRIPTION
I triggered this bug doing 
`filesize('/tmp/file_does_not_exist')`

```
Too few arguments to function Zend_Log::errorHandler(), 4 passed and exactly 5 expected
#0 [internal function]: Zend_Log->errorHandler()
```

I have no idea the root cause on why there is no context, I'm running PHP 8.0.10. Adding = null to errcontext it's a harmless quick fix.