### PR TITLE
Avoiding error logs when using class_exists

### DIFF
--- a/library/Zend/Loader.php
+++ b/library/Zend/Loader.php
@@ -134,10 +134,16 @@ class Zend_Loader
         // - Avoid error-logs full of PHP Warnings due to autoloads from class-exists()-checks.
         // - If a class does not exist that we really need, error will be thrown anyway.
         // - Fatal errors from the included files are still thrown anyway.
+        // Since PHP 8.0 @ doesn't mute the errors, which makes for a lot of clutter on the error log when you are using class_exists() and it doesn't
+        // Added stream_resolve_include_path to avoid it.
         if ($once) {
-            @include_once $filename;
+            if(stream_resolve_include_path($filename)) {
+                @include_once $filename;
+            }
         } else {
-            @include $filename;
+            if(stream_resolve_include_path($filename)) {
+                @include $filename;
+            }
         }
 
         /**


### PR DESCRIPTION
Since PHP 8.0 @ doesn't mute the errors, which makes for a lot of clutter on the error log when you are using class_exists() and it doesn't.
Adding this verification solves the problem.