### PR TITLE
Replace last traditional array syntax

### DIFF
--- a/library/Zend/Tool/Framework/Client/Request.php
+++ b/library/Zend/Tool/Framework/Client/Request.php
@@ -47,12 +47,12 @@ class Zend_Tool_Framework_Client_Request
     /**
      * @var array
      */
-    protected $_actionParameters = array();
+    protected $_actionParameters = [];
 
     /**
      * @var array
      */
-    protected $_providerParameters = array();
+    protected $_providerParameters = [];
 
     /**
      * @var bool


### PR DESCRIPTION
I found this tools: [php-short-array-syntax-converter](https://github.com/thomasbachem/php-short-array-syntax-converter)
So I tested to revert to traditional array syntax, then I converted to short array syntax.

Result: only one file was modified.