### PR TITLE
Addressing issue #181 by adding null check in Zend_Validate_File_Extension 

### DIFF
--- a/library/Zend/Validate/File/Extension.php
+++ b/library/Zend/Validate/File/Extension.php
@@ -121,7 +121,9 @@ class Zend_Validate_File_Extension extends Zend_Validate_Abstract
      */
     public function getExtension()
     {
-        return explode(',', $this->_extension);
+        return $this->_extension !== null
+            ? explode(',', $this->_extension)
+            : [];
     }
 
     /**


### PR DESCRIPTION
Added a null check to prevent `getExtension` from passing null to explode function (non-nullable parameters) which results in a deprecation notice in PHP 8.1 (issue #181).