### PR TITLE
Updated apc with apcu

### DIFF
--- a/library/Zend/Cache/Backend/Apc.php
+++ b/library/Zend/Cache/Backend/Apc.php
@@ -55,7 +55,7 @@ class Zend_Cache_Backend_Apc extends Zend_Cache_Backend implements Zend_Cache_Ba
      */
     public function __construct(array $options = [])
     {
-        if (!extension_loaded('apc')) {
+        if (!extension_loaded('apcu')) {
             Zend_Cache::throwException('The apc extension must be loaded for using this backend !');
         }
         parent::__construct($options);
@@ -72,7 +72,7 @@ class Zend_Cache_Backend_Apc extends Zend_Cache_Backend implements Zend_Cache_Ba
      */
     public function load($id, $doNotTestCacheValidity = false)
     {
-        $tmp = apc_fetch($id);
+        $tmp = apcu_fetch($id);
         if (is_array($tmp)) {
             return $tmp[0];
         }
@@ -87,7 +87,7 @@ class Zend_Cache_Backend_Apc extends Zend_Cache_Backend implements Zend_Cache_Ba
      */
     public function test($id)
     {
-        $tmp = apc_fetch($id);
+        $tmp = apcu_fetch($id);
         if (is_array($tmp)) {
             return $tmp[1];
         }
@@ -109,7 +109,7 @@ class Zend_Cache_Backend_Apc extends Zend_Cache_Backend implements Zend_Cache_Ba
     public function save($data, $id, $tags = [], $specificLifetime = false)
     {
         $lifetime = $this->getLifetime($specificLifetime);
-        $result = apc_store($id, [$data, time(), $lifetime], $lifetime);
+        $result = apcu_store($id, [$data, time(), $lifetime], $lifetime);
         if (count($tags) > 0) {
             $this->_log(self::TAGS_UNSUPPORTED_BY_SAVE_OF_APC_BACKEND);
         }
@@ -124,7 +124,7 @@ class Zend_Cache_Backend_Apc extends Zend_Cache_Backend implements Zend_Cache_Ba
      */
     public function remove($id)
     {
-        return apc_delete($id);
+        return apcu_delete($id);
     }
 
     /**
@@ -146,7 +146,7 @@ class Zend_Cache_Backend_Apc extends Zend_Cache_Backend implements Zend_Cache_Ba
     {
         switch ($mode) {
             case Zend_Cache::CLEANING_MODE_ALL:
-                return apc_clear_cache('user');
+                return apcu_clear_cache('user');
                 break;
             case Zend_Cache::CLEANING_MODE_OLD:
                 $this->_log("Zend_Cache_Backend_Apc::clean() : CLEANING_MODE_OLD is unsupported by the Apc backend");
@@ -183,7 +183,7 @@ class Zend_Cache_Backend_Apc extends Zend_Cache_Backend implements Zend_Cache_Ba
      */
     public function getFillingPercentage()
     {
-        $mem = apc_sma_info(true);
+        $mem = apcu_sma_info(true);
         $memSize    = $mem['num_seg'] * $mem['seg_size'];
         $memAvailable= $mem['avail_mem'];
         $memUsed = $memSize - $memAvailable;
@@ -280,7 +280,7 @@ class Zend_Cache_Backend_Apc extends Zend_Cache_Backend implements Zend_Cache_Ba
      */
     public function getMetadatas($id)
     {
-        $tmp = apc_fetch($id);
+        $tmp = apcu_fetch($id);
         if (is_array($tmp)) {
             $data = $tmp[0];
             $mtime = $tmp[1];
@@ -308,7 +308,7 @@ class Zend_Cache_Backend_Apc extends Zend_Cache_Backend implements Zend_Cache_Ba
      */
     public function touch($id, $extraLifetime)
     {
-        $tmp = apc_fetch($id);
+        $tmp = apcu_fetch($id);
         if (is_array($tmp)) {
             $data = $tmp[0];
             $mtime = $tmp[1];
@@ -322,7 +322,7 @@ class Zend_Cache_Backend_Apc extends Zend_Cache_Backend implements Zend_Cache_Ba
             if ($newLifetime <=0) {
                 return false;
             }
-            apc_store($id, [$data, time(), $newLifetime], $newLifetime);
+            apcu_store($id, [$data, time(), $newLifetime], $newLifetime);
             return true;
         }
         return false;


### PR DESCRIPTION
Since APC is not at all available in PHP 8.0 (not even with apcu_bc extension), I'm switching the functions call to APCu. I'm keeping the APC cache name intact for backward compatibility.