### PR TITLE
Fix for unsupported preg_replace modifier

### DIFF
--- a/bin/classmap_generator.php
+++ b/bin/classmap_generator.php
@@ -229,7 +229,9 @@ foreach ($matches as $match) {
     $maxWidth = max($maxWidth, strlen($match[1]));
 }
 
-$content = preg_replace('(\n\s+([^=]+)=>)e', "'\n    \\1' . str_repeat(' ', " . $maxWidth . " - strlen('\\1')) . '=>'", $content);
+$content = preg_replace_callback('(\n\s+([^=]+)=>)', function ($matches) use ($maxWidth) {
+            return "\n    " . $matches[1] . str_repeat(' ', $maxWidth - strlen($matches[1])) . '=>';
+        }, $content);
 
 // Make the file end by EOL
 $content = rtrim($content, "\n") . "\n";


### PR DESCRIPTION
Replaced usage of unsupported /e regexp modifier in preg_replace() by using preg_replace_callback()