### PR TITLE
PHP 8.1 compatibility - interfaces Countable,ArrayAccess,Iterator,SeekableIterator,RecursiveFilterIterator,IteratorAggregate,Serializable

### DIFF
--- a/library/Zend/Cloud/DocumentService/Document.php
+++ b/library/Zend/Cloud/DocumentService/Document.php
@@ -231,7 +231,7 @@ class Zend_Cloud_DocumentService_Document
      *
      * @return int
      */
-    public function count()
+    public function count(): int
     {
         return count($this->_fields);
     }

--- a/library/Zend/Cloud/DocumentService/Document.php
+++ b/library/Zend/Cloud/DocumentService/Document.php
@@ -161,7 +161,7 @@ class Zend_Cloud_DocumentService_Document
      * @param  string $name
      * @return bool
      */
-    public function offsetExists($name)
+    public function offsetExists($name): bool
     {
         return isset($this->_fields[$name]);
     }
@@ -172,7 +172,7 @@ class Zend_Cloud_DocumentService_Document
      * @param  string $name
      * @return mixed
      */
-    public function offsetGet($name)
+    public function offsetGet($name): mixed
     {
         return $this->getField($name);
     }
@@ -184,7 +184,7 @@ class Zend_Cloud_DocumentService_Document
      * @param  mixed $value
      * @return void
      */
-    public function offsetSet($name, $value)
+    public function offsetSet($name, $value): void
     {
         $this->setField($name, $value);
     }
@@ -195,7 +195,7 @@ class Zend_Cloud_DocumentService_Document
      * @param  string $name
      * @return void
      */
-    public function offsetUnset($name)
+    public function offsetUnset($name): void
     {
         if ($this->offsetExists($name)) {
             unset($this->_fields[$name]);

--- a/library/Zend/Cloud/DocumentService/Document.php
+++ b/library/Zend/Cloud/DocumentService/Document.php
@@ -241,7 +241,7 @@ class Zend_Cloud_DocumentService_Document
      *
      * @return Iterator
      */
-    public function getIterator()
+    public function getIterator(): ArrayIterator
     {
         return new ArrayIterator($this->_fields);
     }

--- a/library/Zend/Cloud/DocumentService/DocumentSet.php
+++ b/library/Zend/Cloud/DocumentService/DocumentSet.php
@@ -51,7 +51,7 @@ class Zend_Cloud_DocumentService_DocumentSet implements Countable, IteratorAggre
      *
      * @return int
      */
-    public function count()
+    public function count(): int
     {
         return $this->_documentCount;
     }

--- a/library/Zend/Cloud/DocumentService/DocumentSet.php
+++ b/library/Zend/Cloud/DocumentService/DocumentSet.php
@@ -61,7 +61,7 @@ class Zend_Cloud_DocumentService_DocumentSet implements Countable, IteratorAggre
      *
      * @return Traversable
      */
-    public function getIterator()
+    public function getIterator(): Traversable
     {
         return $this->_documents;
     }

--- a/library/Zend/Cloud/Infrastructure/ImageList.php
+++ b/library/Zend/Cloud/Infrastructure/ImageList.php
@@ -87,7 +87,7 @@ class Zend_Cloud_Infrastructure_ImageList implements Countable, Iterator, ArrayA
      *
      * @return int
      */
-    public function count()
+    public function count(): int
     {
         return count($this->images);
     }

--- a/library/Zend/Cloud/Infrastructure/ImageList.php
+++ b/library/Zend/Cloud/Infrastructure/ImageList.php
@@ -99,7 +99,7 @@ class Zend_Cloud_Infrastructure_ImageList implements Countable, Iterator, ArrayA
      *
      * @return Image
      */
-    public function current()
+    public function current(): mixed
     {
         return $this->images[$this->iteratorKey];
     }
@@ -111,7 +111,7 @@ class Zend_Cloud_Infrastructure_ImageList implements Countable, Iterator, ArrayA
      *
      * @return int
      */
-    public function key()
+    public function key(): mixed
     {
         return $this->iteratorKey;
     }
@@ -123,7 +123,7 @@ class Zend_Cloud_Infrastructure_ImageList implements Countable, Iterator, ArrayA
      *
      * @return void
      */
-    public function next()
+    public function next(): void
     {
         $this->iteratorKey++;
     }
@@ -135,7 +135,7 @@ class Zend_Cloud_Infrastructure_ImageList implements Countable, Iterator, ArrayA
      *
      * @return void
      */
-    public function rewind()
+    public function rewind(): void
     {
         $this->iteratorKey = 0;
     }
@@ -147,7 +147,7 @@ class Zend_Cloud_Infrastructure_ImageList implements Countable, Iterator, ArrayA
      *
      * @return bool
      */
-    public function valid()
+    public function valid(): bool
     {
         $numItems = $this->count();
         if ($numItems > 0 && $this->iteratorKey < $numItems) {
@@ -164,7 +164,7 @@ class Zend_Cloud_Infrastructure_ImageList implements Countable, Iterator, ArrayA
      * @param   int     $offset
      * @return  bool
      */
-    public function offsetExists($offset)
+    public function offsetExists($offset): bool
     {
         return ($offset < $this->count());
     }
@@ -178,7 +178,7 @@ class Zend_Cloud_Infrastructure_ImageList implements Countable, Iterator, ArrayA
      * @throws  Zend_Cloud_Infrastructure_Exception
      * @return  Image
      */
-    public function offsetGet($offset)
+    public function offsetGet($offset): mixed
     {
         if (!$this->offsetExists($offset)) {
             require_once 'Zend/Cloud/Infrastructure/Exception.php';
@@ -196,7 +196,7 @@ class Zend_Cloud_Infrastructure_ImageList implements Countable, Iterator, ArrayA
      * @param   string  $value
      * @throws  Zend_Cloud_Infrastructure_Exception
      */
-    public function offsetSet($offset, $value)
+    public function offsetSet($offset, $value): void
     {
         require_once 'Zend/Cloud/Infrastructure/Exception.php';
         throw new Zend_Cloud_Infrastructure_Exception('You are trying to set read-only property');
@@ -210,7 +210,7 @@ class Zend_Cloud_Infrastructure_ImageList implements Countable, Iterator, ArrayA
      * @param   int     $offset
      * @throws  Zend_Cloud_Infrastructure_Exception
      */
-    public function offsetUnset($offset)
+    public function offsetUnset($offset): void
     {
         require_once 'Zend/Cloud/Infrastructure/Exception.php';
         throw new Zend_Cloud_Infrastructure_Exception('You are trying to unset read-only property');

--- a/library/Zend/Cloud/Infrastructure/InstanceList.php
+++ b/library/Zend/Cloud/Infrastructure/InstanceList.php
@@ -88,7 +88,7 @@ class Zend_Cloud_Infrastructure_InstanceList implements Countable, Iterator, Arr
      *
      * @return int
      */
-    public function count()
+    public function count(): int
     {
         return count($this->instances);
     }

--- a/library/Zend/Cloud/Infrastructure/InstanceList.php
+++ b/library/Zend/Cloud/Infrastructure/InstanceList.php
@@ -100,7 +100,7 @@ class Zend_Cloud_Infrastructure_InstanceList implements Countable, Iterator, Arr
      *
      * @return Instance
      */
-    public function current()
+    public function current(): mixed
     {
         return $this->instances[$this->iteratorKey];
     }
@@ -112,7 +112,7 @@ class Zend_Cloud_Infrastructure_InstanceList implements Countable, Iterator, Arr
      *
      * @return int
      */
-    public function key()
+    public function key(): mixed
     {
         return $this->iteratorKey;
     }
@@ -124,7 +124,7 @@ class Zend_Cloud_Infrastructure_InstanceList implements Countable, Iterator, Arr
      *
      * @return void
      */
-    public function next()
+    public function next(): void
     {
         $this->iteratorKey++;
     }
@@ -136,7 +136,7 @@ class Zend_Cloud_Infrastructure_InstanceList implements Countable, Iterator, Arr
      *
      * @return void
      */
-    public function rewind()
+    public function rewind(): void
     {
         $this->iteratorKey = 0;
     }
@@ -148,7 +148,7 @@ class Zend_Cloud_Infrastructure_InstanceList implements Countable, Iterator, Arr
      *
      * @return bool
      */
-    public function valid()
+    public function valid(): bool
     {
         $numItems = $this->count();
         if ($numItems > 0 && $this->iteratorKey < $numItems) {
@@ -165,7 +165,7 @@ class Zend_Cloud_Infrastructure_InstanceList implements Countable, Iterator, Arr
      * @param  int $offset
      * @return bool
      */
-    public function offsetExists($offset)
+    public function offsetExists($offset): bool
     {
         return ($offset < $this->count());
     }
@@ -179,7 +179,7 @@ class Zend_Cloud_Infrastructure_InstanceList implements Countable, Iterator, Arr
      * @return Instance
      * @throws Zend_Cloud_Infrastructure_Exception
      */
-    public function offsetGet($offset)
+    public function offsetGet($offset): mixed
     {
         if (!$this->offsetExists($offset)) {
             require_once 'Zend/Cloud/Infrastructure/Exception.php';
@@ -197,7 +197,7 @@ class Zend_Cloud_Infrastructure_InstanceList implements Countable, Iterator, Arr
      * @param   string  $value
      * @throws  Zend_Cloud_Infrastructure_Exception
      */
-    public function offsetSet($offset, $value)
+    public function offsetSet($offset, $value): void
     {
         require_once 'Zend/Cloud/Infrastructure/Exception.php';
         throw new Zend_Cloud_Infrastructure_Exception('You are trying to set read-only property');
@@ -211,7 +211,7 @@ class Zend_Cloud_Infrastructure_InstanceList implements Countable, Iterator, Arr
      * @param   int     $offset
      * @throws  Zend_Cloud_Infrastructure_Exception
      */
-    public function offsetUnset($offset)
+    public function offsetUnset($offset): void
     {
         require_once 'Zend/Cloud/Infrastructure/Exception.php';
         throw new Zend_Cloud_Infrastructure_Exception('You are trying to unset read-only property');

--- a/library/Zend/Cloud/QueueService/MessageSet.php
+++ b/library/Zend/Cloud/QueueService/MessageSet.php
@@ -51,7 +51,7 @@ class Zend_Cloud_QueueService_MessageSet implements Countable, IteratorAggregate
      *
      * @return int
      */
-    public function count()
+    public function count(): int
     {
         return $this->_messageCount;
     }

--- a/library/Zend/Cloud/QueueService/MessageSet.php
+++ b/library/Zend/Cloud/QueueService/MessageSet.php
@@ -61,7 +61,7 @@ class Zend_Cloud_QueueService_MessageSet implements Countable, IteratorAggregate
      *
      * @return Traversable
      */
-    public function getIterator()
+    public function getIterator(): Traversable
     {
         return $this->_messages;
     }

--- a/library/Zend/Config.php
+++ b/library/Zend/Config.php
@@ -245,7 +245,7 @@ class Zend_Config implements Countable, Iterator
      *
      * @return int
      */
-    public function count()
+    public function count(): int
     {
         return $this->_count;
     }

--- a/library/Zend/Config.php
+++ b/library/Zend/Config.php
@@ -255,7 +255,7 @@ class Zend_Config implements Countable, Iterator
      *
      * @return mixed
      */
-    public function current()
+    public function current(): mixed
     {
         $this->_skipNextIteration = false;
         return current($this->_data);
@@ -266,7 +266,7 @@ class Zend_Config implements Countable, Iterator
      *
      * @return mixed
      */
-    public function key()
+    public function key(): mixed
     {
         return key($this->_data);
     }
@@ -275,7 +275,7 @@ class Zend_Config implements Countable, Iterator
      * Defined by Iterator interface
      *
      */
-    public function next()
+    public function next(): void
     {
         if ($this->_skipNextIteration) {
             $this->_skipNextIteration = false;
@@ -289,7 +289,7 @@ class Zend_Config implements Countable, Iterator
      * Defined by Iterator interface
      *
      */
-    public function rewind()
+    public function rewind(): void
     {
         $this->_skipNextIteration = false;
         reset($this->_data);
@@ -301,7 +301,7 @@ class Zend_Config implements Countable, Iterator
      *
      * @return boolean
      */
-    public function valid()
+    public function valid(): bool
     {
         return $this->_index < $this->_count;
     }

--- a/library/Zend/Controller/Action/HelperBroker/PriorityStack.php
+++ b/library/Zend/Controller/Action/HelperBroker/PriorityStack.php
@@ -198,7 +198,7 @@ class Zend_Controller_Action_HelperBroker_PriorityStack implements IteratorAggre
      *
      * @return int
      */
-    public function count()
+    public function count(): int
     {
         return count($this->_helpersByPriority);
     }

--- a/library/Zend/Controller/Action/HelperBroker/PriorityStack.php
+++ b/library/Zend/Controller/Action/HelperBroker/PriorityStack.php
@@ -97,9 +97,9 @@ class Zend_Controller_Action_HelperBroker_PriorityStack implements IteratorAggre
      * offsetExists()
      *
      * @param int|string $priorityOrHelperName
-     * @return Zend_Controller_Action_HelperBroker_PriorityStack
+     * @return boolean
      */
-    public function offsetExists($priorityOrHelperName)
+    public function offsetExists($priorityOrHelperName): bool
     {
         if (is_string($priorityOrHelperName)) {
             return array_key_exists($priorityOrHelperName, $this->_helpersByNameRef);
@@ -114,7 +114,7 @@ class Zend_Controller_Action_HelperBroker_PriorityStack implements IteratorAggre
      * @param int|string $priorityOrHelperName
      * @return Zend_Controller_Action_HelperBroker_PriorityStack
      */
-    public function offsetGet($priorityOrHelperName)
+    public function offsetGet($priorityOrHelperName): mixed
     {
         if (!$this->offsetExists($priorityOrHelperName)) {
             require_once 'Zend/Controller/Action/Exception.php';
@@ -133,9 +133,9 @@ class Zend_Controller_Action_HelperBroker_PriorityStack implements IteratorAggre
      *
      * @param int $priority
      * @param Zend_Controller_Action_Helper_Abstract $helper
-     * @return Zend_Controller_Action_HelperBroker_PriorityStack
+     * @return void
      */
-    public function offsetSet($priority, $helper)
+    public function offsetSet($priority, $helper): void
     {
         $priority = (int) $priority;
 
@@ -163,16 +163,16 @@ class Zend_Controller_Action_HelperBroker_PriorityStack implements IteratorAggre
         }
 
         krsort($this->_helpersByPriority);  // always make sure priority and LIFO are both enforced
-        return $this;
+
     }
 
     /**
      * offsetUnset()
      *
      * @param int|string $priorityOrHelperName Priority integer or the helper name
-     * @return Zend_Controller_Action_HelperBroker_PriorityStack
+     * @return void
      */
-    public function offsetUnset($priorityOrHelperName)
+    public function offsetUnset($priorityOrHelperName): void
     {
         if (!$this->offsetExists($priorityOrHelperName)) {
             require_once 'Zend/Controller/Action/Exception.php';
@@ -190,7 +190,6 @@ class Zend_Controller_Action_HelperBroker_PriorityStack implements IteratorAggre
 
         unset($this->_helpersByNameRef[$helperName]);
         unset($this->_helpersByPriority[$priority]);
-        return $this;
     }
 
     /**

--- a/library/Zend/Controller/Action/HelperBroker/PriorityStack.php
+++ b/library/Zend/Controller/Action/HelperBroker/PriorityStack.php
@@ -88,7 +88,7 @@ class Zend_Controller_Action_HelperBroker_PriorityStack implements IteratorAggre
      *
      * @return array
      */
-    public function getIterator()
+    public function getIterator(): ArrayObject
     {
         return new ArrayObject($this->_helpersByPriority);
     }

--- a/library/Zend/Controller/Request/Apache404.php
+++ b/library/Zend/Controller/Request/Apache404.php
@@ -46,9 +46,7 @@ class Zend_Controller_Request_Apache404 extends Zend_Controller_Request_Http
     {
         $parseUriGetVars = false;
         if ($requestUri === null) {
-            if (isset($_SERVER['HTTP_X_REWRITE_URL'])) { // check this first so IIS will catch
-                $requestUri = $_SERVER['HTTP_X_REWRITE_URL'];
-            } elseif (isset($_SERVER['REDIRECT_URL'])) {  // Check if using mod_rewrite
+            if (isset($_SERVER['REDIRECT_URL'])) {  // Check if using mod_rewrite
                 $requestUri = $_SERVER['REDIRECT_URL'];
                 if (isset($_SERVER['REDIRECT_QUERY_STRING'])) {
                     $parseUriGetVars = $_SERVER['REDIRECT_QUERY_STRING'];

--- a/library/Zend/Crypt/Rsa/Key.php
+++ b/library/Zend/Crypt/Rsa/Key.php
@@ -61,7 +61,7 @@ class Zend_Crypt_Rsa_Key implements Countable
      * @return string
      * @throws Zend_Crypt_Exception
      */
-    public function toString()
+    public function toString():string
     {
         if (!empty($this->_pemString)) {
             return $this->_pemString;
@@ -83,7 +83,7 @@ class Zend_Crypt_Rsa_Key implements Countable
         return $this->toString();
     }
 
-    public function count()
+    public function count(): int
     {
         return $this->_details['bits'];
     }

--- a/library/Zend/Db/Statement/Pdo.php
+++ b/library/Zend/Db/Statement/Pdo.php
@@ -263,7 +263,7 @@ class Zend_Db_Statement_Pdo extends Zend_Db_Statement implements IteratorAggrega
      *
      * @return IteratorIterator
      */
-    public function getIterator()
+    public function getIterator(): IteratorIterator
     {
         return new IteratorIterator($this->_stmt);
     }

--- a/library/Zend/Db/Table/Row/Abstract.php
+++ b/library/Zend/Db/Table/Row/Abstract.php
@@ -263,7 +263,7 @@ abstract class Zend_Db_Table_Row_Abstract implements ArrayAccess, IteratorAggreg
      * @param string $offset
      * @return boolean
      */
-    public function offsetExists($offset)
+    public function offsetExists($offset): bool
     {
         return $this->__isset($offset);
     }
@@ -275,7 +275,7 @@ abstract class Zend_Db_Table_Row_Abstract implements ArrayAccess, IteratorAggreg
      * @param string $offset
      * @return string
      */
-     public function offsetGet($offset)
+     public function offsetGet($offset): mixed
      {
          return $this->__get($offset);
      }
@@ -287,7 +287,7 @@ abstract class Zend_Db_Table_Row_Abstract implements ArrayAccess, IteratorAggreg
       * @param string $offset
       * @param mixed $value
       */
-     public function offsetSet($offset, $value)
+     public function offsetSet($offset, $value): void
      {
          $this->__set($offset, $value);
      }
@@ -298,9 +298,9 @@ abstract class Zend_Db_Table_Row_Abstract implements ArrayAccess, IteratorAggreg
       *
       * @param string $offset
       */
-     public function offsetUnset($offset)
+     public function offsetUnset($offset): void
      {
-         return $this->__unset($offset);
+         $this->__unset($offset);
      }
 
     /**
@@ -642,7 +642,7 @@ abstract class Zend_Db_Table_Row_Abstract implements ArrayAccess, IteratorAggreg
         return $result;
     }
 
-    public function getIterator()
+    public function getIterator(): ArrayIterator
     {
         return new ArrayIterator((array) $this->_data);
     }

--- a/library/Zend/Dojo/Data.php
+++ b/library/Zend/Dojo/Data.php
@@ -514,7 +514,7 @@ class Zend_Dojo_Data implements ArrayAccess,Iterator,Countable
      *
      * @return int
      */
-    public function count()
+    public function count(): int
     {
         return count($this->_items);
     }

--- a/library/Zend/Dojo/Data.php
+++ b/library/Zend/Dojo/Data.php
@@ -420,7 +420,7 @@ class Zend_Dojo_Data implements ArrayAccess,Iterator,Countable
      * @param  string|int $offset
      * @return bool
      */
-    public function offsetExists($offset)
+    public function offsetExists($offset): bool
     {
         return (null !== $this->getItem($offset));
     }
@@ -431,7 +431,7 @@ class Zend_Dojo_Data implements ArrayAccess,Iterator,Countable
      * @param  string|int $offset
      * @return array
      */
-    public function offsetGet($offset)
+    public function offsetGet($offset): mixed
     {
         return $this->getItem($offset);
     }
@@ -443,7 +443,7 @@ class Zend_Dojo_Data implements ArrayAccess,Iterator,Countable
      * @param  array|object|null $value
      * @return void
      */
-    public function offsetSet($offset, $value)
+    public function offsetSet($offset, $value): void
     {
         $this->setItem($value, $offset);
     }
@@ -454,7 +454,7 @@ class Zend_Dojo_Data implements ArrayAccess,Iterator,Countable
      * @param  string $offset
      * @return void
      */
-    public function offsetUnset($offset)
+    public function offsetUnset($offset): void
     {
         $this->removeItem($offset);
     }
@@ -464,7 +464,7 @@ class Zend_Dojo_Data implements ArrayAccess,Iterator,Countable
      *
      * @return array
      */
-    public function current()
+    public function current(): mixed
     {
         return current($this->_items);
     }
@@ -474,7 +474,7 @@ class Zend_Dojo_Data implements ArrayAccess,Iterator,Countable
      *
      * @return string|int
      */
-    public function key()
+    public function key(): mixed
     {
         return key($this->_items);
     }
@@ -484,9 +484,9 @@ class Zend_Dojo_Data implements ArrayAccess,Iterator,Countable
      *
      * @return void
      */
-    public function next()
+    public function next(): void
     {
-        return next($this->_items);
+        next($this->_items);
     }
 
     /**
@@ -494,9 +494,9 @@ class Zend_Dojo_Data implements ArrayAccess,Iterator,Countable
      *
      * @return void
      */
-    public function rewind()
+    public function rewind(): void
     {
-        return reset($this->_items);
+        reset($this->_items);
     }
 
     /**
@@ -504,7 +504,7 @@ class Zend_Dojo_Data implements ArrayAccess,Iterator,Countable
      *
      * @return bool
      */
-    public function valid()
+    public function valid(): bool
     {
         return (bool) $this->current();
     }

--- a/library/Zend/Dom/Query/Result.php
+++ b/library/Zend/Dom/Query/Result.php
@@ -175,7 +175,7 @@ class Zend_Dom_Query_Result implements Iterator,Countable
      *
      * @return int
      */
-    public function count()
+    public function count(): int
     {
         return $this->_nodeList->length;
     }

--- a/library/Zend/Dom/Query/Result.php
+++ b/library/Zend/Dom/Query/Result.php
@@ -120,10 +120,10 @@ class Zend_Dom_Query_Result implements Iterator,Countable
      *
      * @return DOMNode|null
      */
-    public function rewind()
+    public function rewind(): void
     {
         $this->_position = 0;
-        return $this->_nodeList->item(0);
+        $this->_nodeList->item(0);
     }
 
     /**
@@ -131,7 +131,7 @@ class Zend_Dom_Query_Result implements Iterator,Countable
      *
      * @return bool
      */
-    public function valid()
+    public function valid(): bool
     {
         if (in_array($this->_position, range(0, $this->_nodeList->length - 1)) && $this->_nodeList->length > 0) {
             return true;
@@ -144,7 +144,7 @@ class Zend_Dom_Query_Result implements Iterator,Countable
      *
      * @return DOMElement
      */
-    public function current()
+    public function current(): mixed
     {
         return $this->_nodeList->item($this->_position);
     }
@@ -154,7 +154,7 @@ class Zend_Dom_Query_Result implements Iterator,Countable
      *
      * @return int
      */
-    public function key()
+    public function key(): mixed
     {
         return $this->_position;
     }
@@ -164,10 +164,10 @@ class Zend_Dom_Query_Result implements Iterator,Countable
      *
      * @return DOMNode|null
      */
-    public function next()
+    public function next(): void
     {
         ++$this->_position;
-        return $this->_nodeList->item($this->_position);
+        $this->_nodeList->item($this->_position);
     }
 
     /**

--- a/library/Zend/EventManager/ResponseCollection.php
+++ b/library/Zend/EventManager/ResponseCollection.php
@@ -110,7 +110,7 @@ if (version_compare(PHP_VERSION, '5.3.0', '<')) {
          *
          * @return mixed
          */
-        public function current()
+        public function current(): mixed
         {
             if (!$this->stack) {
                 $this->rewind();
@@ -143,7 +143,7 @@ if (version_compare(PHP_VERSION, '5.3.0', '<')) {
          *
          * @return mixed
          */
-        public function key()
+        public function key(): mixed
         {
             if (!$this->stack) {
                 $this->rewind();
@@ -156,12 +156,12 @@ if (version_compare(PHP_VERSION, '5.3.0', '<')) {
          *
          * @return void
          */
-        public function next()
+        public function next(): void
         {
             if (!$this->stack) {
                 $this->rewind();
             }
-            return next($this->stack);
+            next($this->stack);
         }
 
         /**
@@ -263,10 +263,10 @@ if (version_compare(PHP_VERSION, '5.3.0', '<')) {
          *
          * @return void
          */
-        public function rewind()
+        public function rewind(): void
         {
             if (is_array($this->stack)) {
-                return reset($this->stack);
+                reset($this->stack);
             }
             $this->stack = array_reverse($this->data, true);
         }
@@ -276,7 +276,7 @@ if (version_compare(PHP_VERSION, '5.3.0', '<')) {
          *
          * @return string
          */
-        public function serialize()
+        public function serialize(): string
         {
             return serialize($this->data);
         }
@@ -314,7 +314,7 @@ if (version_compare(PHP_VERSION, '5.3.0', '<')) {
          * @param  string
          * @return void
          */
-        public function unserialize($serialized)
+        public function unserialize($serialized): void
         {
             $this->data  = unserialize($serialized);
             $this->stack = false;
@@ -338,7 +338,7 @@ if (version_compare(PHP_VERSION, '5.3.0', '<')) {
          *
          * @return bool
          */
-        public function valid()
+        public function valid(): bool
         {
             $key = key($this->stack);
 

--- a/library/Zend/EventManager/ResponseCollection.php
+++ b/library/Zend/EventManager/ResponseCollection.php
@@ -170,7 +170,7 @@ if (version_compare(PHP_VERSION, '5.3.0', '<')) {
          * @param  mixed $index
          * @return bool
          */
-        public function offsetExists($index)
+        public function offsetExists($index): bool
         {
             return array_key_exists($index, $this->data);
         }
@@ -182,7 +182,7 @@ if (version_compare(PHP_VERSION, '5.3.0', '<')) {
          * @return mixed
          * @throws OutOfRangeException
          */
-        public function offsetGet($index)
+        public function offsetGet($index): mixed
         {
             if (!$this->offsetExists($index)) {
                 throw OutOfRangeException(sprintf('Invalid index ("%s") specified', $index));
@@ -197,7 +197,7 @@ if (version_compare(PHP_VERSION, '5.3.0', '<')) {
          * @param  mixed $newval
          * @return void
          */
-        public function offsetSet($index, $newval)
+        public function offsetSet($index, $newval): void
         {
             $this->data[$index] = $newval;
             $this->stack = false;
@@ -211,7 +211,7 @@ if (version_compare(PHP_VERSION, '5.3.0', '<')) {
          * @return void
          * @throws OutOfRangeException
          */
-        public function offsetUnset($index)
+        public function offsetUnset($index): void
         {
             if (!$this->offsetExists($index)) {
                 throw OutOfRangeException(sprintf('Invalid index ("%s") specified', $index));

--- a/library/Zend/EventManager/ResponseCollection.php
+++ b/library/Zend/EventManager/ResponseCollection.php
@@ -100,7 +100,7 @@ if (version_compare(PHP_VERSION, '5.3.0', '<')) {
          *
          * @return int
          */
-        public function count()
+        public function count(): int
         {
             return $this->count;
         }

--- a/library/Zend/Feed/Abstract.php
+++ b/library/Zend/Feed/Abstract.php
@@ -174,7 +174,7 @@ abstract class Zend_Feed_Abstract extends Zend_Feed_Element implements Iterator,
      *
      * @return integer Entry count.
      */
-    public function count()
+    public function count(): int
     {
         return count($this->_entries);
     }

--- a/library/Zend/Feed/Abstract.php
+++ b/library/Zend/Feed/Abstract.php
@@ -185,7 +185,7 @@ abstract class Zend_Feed_Abstract extends Zend_Feed_Element implements Iterator,
      *
      * @return void
      */
-    public function rewind()
+    public function rewind(): void
     {
         $this->_entryIndex = 0;
     }
@@ -196,7 +196,7 @@ abstract class Zend_Feed_Abstract extends Zend_Feed_Element implements Iterator,
      *
      * @return mixed The current row, or null if no rows.
      */
-    public function current()
+    public function current(): mixed
     {
         return new $this->_entryClassName(
             null,
@@ -209,7 +209,7 @@ abstract class Zend_Feed_Abstract extends Zend_Feed_Element implements Iterator,
      *
      * @return mixed The current row number (starts at 0), or NULL if no rows
      */
-    public function key()
+    public function key(): mixed
     {
         return $this->_entryIndex;
     }
@@ -220,7 +220,7 @@ abstract class Zend_Feed_Abstract extends Zend_Feed_Element implements Iterator,
      *
      * @return mixed The next row, or null if no more rows.
      */
-    public function next()
+    public function next(): void
     {
         ++$this->_entryIndex;
     }
@@ -231,7 +231,7 @@ abstract class Zend_Feed_Abstract extends Zend_Feed_Element implements Iterator,
      *
      * @return boolean Whether the iteration is valid
      */
-    public function valid()
+    public function valid(): bool
     {
         return 0 <= $this->_entryIndex && $this->_entryIndex < $this->count();
     }

--- a/library/Zend/Feed/Element.php
+++ b/library/Zend/Feed/Element.php
@@ -374,7 +374,7 @@ class Zend_Feed_Element implements ArrayAccess
      * @param  string $offset
      * @return boolean
      */
-    public function offsetExists($offset)
+    public function offsetExists($offset): bool
     {
         if (strpos($offset, ':') !== false) {
             list($ns, $attr) = explode(':', $offset, 2);
@@ -391,7 +391,7 @@ class Zend_Feed_Element implements ArrayAccess
      * @param  string $offset
      * @return string
      */
-    public function offsetGet($offset)
+    public function offsetGet($offset): mixed
     {
         if (strpos($offset, ':') !== false) {
             list($ns, $attr) = explode(':', $offset, 2);
@@ -409,16 +409,16 @@ class Zend_Feed_Element implements ArrayAccess
      * @param  string $value
      * @return string
      */
-    public function offsetSet($offset, $value)
+    public function offsetSet($offset, $value): void
     {
         $this->ensureAppended();
 
         if (strpos($offset, ':') !== false) {
             list($ns, $attr) = explode(':', $offset, 2);
             // DOMElement::setAttributeNS() requires $qualifiedName to have a prefix
-            return $this->_element->setAttributeNS(Zend_Feed::lookupNamespace($ns), $offset, $value);
+            $this->_element->setAttributeNS(Zend_Feed::lookupNamespace($ns), $offset, $value);
         } else {
-            return $this->_element->setAttribute($offset, $value);
+            $this->_element->setAttribute($offset, $value);
         }
     }
 
@@ -429,13 +429,13 @@ class Zend_Feed_Element implements ArrayAccess
      * @param  string $offset
      * @return boolean
      */
-    public function offsetUnset($offset)
+    public function offsetUnset($offset): void
     {
         if (strpos($offset, ':') !== false) {
             list($ns, $attr) = explode(':', $offset, 2);
-            return $this->_element->removeAttributeNS(Zend_Feed::lookupNamespace($ns), $attr);
+            $this->_element->removeAttributeNS(Zend_Feed::lookupNamespace($ns), $attr);
         } else {
-            return $this->_element->removeAttribute($offset);
+            $this->_element->removeAttribute($offset);
         }
     }
 

--- a/library/Zend/Feed/Reader/Feed/Atom/Source.php
+++ b/library/Zend/Feed/Reader/Feed/Atom/Source.php
@@ -67,7 +67,7 @@ class Zend_Feed_Reader_Feed_Atom_Source extends Zend_Feed_Reader_Feed_Atom
     /**
      * @return void
      */
-    public function count() {}
+    public function count(): int {}
 
     /**
      * @return void

--- a/library/Zend/Feed/Reader/Feed/Atom/Source.php
+++ b/library/Zend/Feed/Reader/Feed/Atom/Source.php
@@ -72,27 +72,27 @@ class Zend_Feed_Reader_Feed_Atom_Source extends Zend_Feed_Reader_Feed_Atom
     /**
      * @return void
      */
-    public function current() {}
+    public function current(): mixed {}
 
     /**
      * @return void
      */
-    public function key() {}
+    public function key(): mixed {}
 
     /**
      * @return void
      */
-    public function next() {}
+    public function next(): void {}
 
     /**
      * @return void
      */
-    public function rewind() {}
+    public function rewind(): void {}
 
     /**
      * @return void
      */
-    public function valid() {}
+    public function valid(): bool {}
 
     /**
      * @return void

--- a/library/Zend/Feed/Reader/FeedAbstract.php
+++ b/library/Zend/Feed/Reader/FeedAbstract.php
@@ -136,7 +136,7 @@ abstract class Zend_Feed_Reader_FeedAbstract implements Zend_Feed_Reader_FeedInt
      *
      * @return int
      */
-    public function count()
+    public function count(): int
     {
         return count($this->_entries);
     }

--- a/library/Zend/Feed/Reader/FeedAbstract.php
+++ b/library/Zend/Feed/Reader/FeedAbstract.php
@@ -146,7 +146,7 @@ abstract class Zend_Feed_Reader_FeedAbstract implements Zend_Feed_Reader_FeedInt
      *
      * @return Zend_Feed_Reader_EntryInterface
      */
-    public function current()
+    public function current(): mixed
     {
         if (substr($this->getType(), 0, 3) == 'rss') {
             $reader = new Zend_Feed_Reader_Entry_Rss($this->_entries[$this->key()], $this->key(), $this->getType());
@@ -228,7 +228,7 @@ abstract class Zend_Feed_Reader_FeedAbstract implements Zend_Feed_Reader_FeedInt
      *
      * @return unknown
      */
-    public function key()
+    public function key(): mixed
     {
         return $this->_entriesKey;
     }
@@ -237,7 +237,7 @@ abstract class Zend_Feed_Reader_FeedAbstract implements Zend_Feed_Reader_FeedInt
      * Move the feed pointer forward
      *
      */
-    public function next()
+    public function next(): void
     {
         ++$this->_entriesKey;
     }
@@ -246,7 +246,7 @@ abstract class Zend_Feed_Reader_FeedAbstract implements Zend_Feed_Reader_FeedInt
      * Reset the pointer in the feed object
      *
      */
-    public function rewind()
+    public function rewind(): void
     {
         $this->_entriesKey = 0;
     }
@@ -256,7 +256,7 @@ abstract class Zend_Feed_Reader_FeedAbstract implements Zend_Feed_Reader_FeedInt
      *
      * @return boolean
      */
-    public function valid()
+    public function valid(): bool
     {
         return 0 <= $this->_entriesKey && $this->_entriesKey < $this->count();
     }

--- a/library/Zend/Feed/Reader/FeedSet.php
+++ b/library/Zend/Feed/Reader/FeedSet.php
@@ -132,7 +132,7 @@ class Zend_Feed_Reader_FeedSet extends ArrayObject
      * @return mixed
      * @uses Zend_Feed_Reader
      */
-    public function offsetGet($offset)
+    public function offsetGet($offset): mixed
     {
         if ($offset == 'feed' && !$this->offsetExists('feed')) {
             if (!$this->offsetExists('href')) {

--- a/library/Zend/Feed/Writer/Feed.php
+++ b/library/Zend/Feed/Writer/Feed.php
@@ -200,7 +200,7 @@ implements Iterator, Countable
      *
      * @return int
      */
-    public function count()
+    public function count(): int
     {
         return count($this->_entries);
     }

--- a/library/Zend/Feed/Writer/Feed.php
+++ b/library/Zend/Feed/Writer/Feed.php
@@ -210,7 +210,7 @@ implements Iterator, Countable
      *
      * @return Zend_Feed_Reader_Entry_Interface
      */
-    public function current()
+    public function current(): mixed
     {
         return $this->_entries[$this->key()];
     }
@@ -220,7 +220,7 @@ implements Iterator, Countable
      *
      * @return unknown
      */
-    public function key()
+    public function key(): mixed
     {
         return $this->_entriesKey;
     }
@@ -230,7 +230,7 @@ implements Iterator, Countable
      *
      * @return void
      */
-    public function next()
+    public function next(): void
     {
         ++$this->_entriesKey;
     }
@@ -240,7 +240,7 @@ implements Iterator, Countable
      *
      * @return void
      */
-    public function rewind()
+    public function rewind(): void
     {
         $this->_entriesKey = 0;
     }
@@ -250,7 +250,7 @@ implements Iterator, Countable
      *
      * @return boolean
      */
-    public function valid()
+    public function valid(): bool
     {
         return 0 <= $this->_entriesKey && $this->_entriesKey < $this->count();
     }

--- a/library/Zend/Form.php
+++ b/library/Zend/Form.php
@@ -3271,7 +3271,7 @@ class Zend_Form implements Iterator, Countable, Zend_Validate_Interface
      * @throws Zend_Form_Exception
      * @return Zend_Form_Element|Zend_Form_DisplayGroup|Zend_Form
      */
-    public function current()
+    public function current(): mixed
     {
         $this->_sort();
         current($this->_order);
@@ -3294,7 +3294,7 @@ class Zend_Form implements Iterator, Countable, Zend_Validate_Interface
      *
      * @return string
      */
-    public function key()
+    public function key(): mixed
     {
         $this->_sort();
         return key($this->_order);
@@ -3305,7 +3305,7 @@ class Zend_Form implements Iterator, Countable, Zend_Validate_Interface
      *
      * @return void
      */
-    public function next()
+    public function next(): void
     {
         $this->_sort();
         next($this->_order);
@@ -3316,7 +3316,7 @@ class Zend_Form implements Iterator, Countable, Zend_Validate_Interface
      *
      * @return void
      */
-    public function rewind()
+    public function rewind(): void
     {
         $this->_sort();
         reset($this->_order);
@@ -3327,7 +3327,7 @@ class Zend_Form implements Iterator, Countable, Zend_Validate_Interface
      *
      * @return bool
      */
-    public function valid()
+    public function valid(): bool
     {
         $this->_sort();
         return (current($this->_order) !== false);

--- a/library/Zend/Form.php
+++ b/library/Zend/Form.php
@@ -3338,7 +3338,7 @@ class Zend_Form implements Iterator, Countable, Zend_Validate_Interface
      *
      * @return int
      */
-    public function count()
+    public function count(): int
     {
         return count($this->_order);
     }

--- a/library/Zend/Form/DisplayGroup.php
+++ b/library/Zend/Form/DisplayGroup.php
@@ -1045,7 +1045,7 @@ class Zend_Form_DisplayGroup implements Iterator,Countable
      *
      * @return Zend_Form_Element
      */
-    public function current()
+    public function current(): mixed
     {
         $this->_sort();
         current($this->_elementOrder);
@@ -1058,7 +1058,7 @@ class Zend_Form_DisplayGroup implements Iterator,Countable
      *
      * @return string
      */
-    public function key()
+    public function key(): mixed
     {
         $this->_sort();
         return key($this->_elementOrder);
@@ -1069,7 +1069,7 @@ class Zend_Form_DisplayGroup implements Iterator,Countable
      *
      * @return void
      */
-    public function next()
+    public function next(): void
     {
         $this->_sort();
         next($this->_elementOrder);
@@ -1080,7 +1080,7 @@ class Zend_Form_DisplayGroup implements Iterator,Countable
      *
      * @return void
      */
-    public function rewind()
+    public function rewind(): void
     {
         $this->_sort();
         reset($this->_elementOrder);
@@ -1091,7 +1091,7 @@ class Zend_Form_DisplayGroup implements Iterator,Countable
      *
      * @return bool
      */
-    public function valid()
+    public function valid(): bool
     {
         $this->_sort();
         return (current($this->_elementOrder) !== false);

--- a/library/Zend/Form/DisplayGroup.php
+++ b/library/Zend/Form/DisplayGroup.php
@@ -1102,7 +1102,7 @@ class Zend_Form_DisplayGroup implements Iterator,Countable
      *
      * @return int
      */
-    public function count()
+    public function count(): int
     {
         return count($this->_elements);
     }

--- a/library/Zend/Gdata/App/Feed.php
+++ b/library/Zend/Gdata/App/Feed.php
@@ -129,7 +129,7 @@ class Zend_Gdata_App_Feed extends Zend_Gdata_App_FeedSourceParent
      *
      * @return integer Entry count.
      */
-    public function count()
+    public function count(): int
     {
         return count($this->_entry);
     }

--- a/library/Zend/Gdata/App/Feed.php
+++ b/library/Zend/Gdata/App/Feed.php
@@ -139,7 +139,7 @@ class Zend_Gdata_App_Feed extends Zend_Gdata_App_FeedSourceParent
      *
      * @return void
      */
-    public function rewind()
+    public function rewind(): void
     {
         $this->_entryIndex = 0;
     }
@@ -149,7 +149,7 @@ class Zend_Gdata_App_Feed extends Zend_Gdata_App_FeedSourceParent
      *
      * @return mixed The current row, or null if no rows.
      */
-    public function current()
+    public function current(): mixed
     {
         return $this->_entry[$this->_entryIndex];
     }
@@ -159,7 +159,7 @@ class Zend_Gdata_App_Feed extends Zend_Gdata_App_FeedSourceParent
      *
      * @return mixed The current row number (starts at 0), or NULL if no rows
      */
-    public function key()
+    public function key(): mixed
     {
         return $this->_entryIndex;
     }
@@ -169,7 +169,7 @@ class Zend_Gdata_App_Feed extends Zend_Gdata_App_FeedSourceParent
      *
      * @return mixed The next row, or null if no more rows.
      */
-    public function next()
+    public function next(): void
     {
         ++$this->_entryIndex;
     }
@@ -179,7 +179,7 @@ class Zend_Gdata_App_Feed extends Zend_Gdata_App_FeedSourceParent
      *
      * @return boolean Whether the iteration is valid
      */
-    public function valid()
+    public function valid(): bool
     {
         return 0 <= $this->_entryIndex && $this->_entryIndex < $this->count();
     }

--- a/library/Zend/Gdata/App/Feed.php
+++ b/library/Zend/Gdata/App/Feed.php
@@ -228,7 +228,7 @@ class Zend_Gdata_App_Feed extends Zend_Gdata_App_FeedSourceParent
      * @param Zend_Gdata_App_Entry $value The value to set
      * @return void
      */
-    public function offsetSet($key, $value)
+    public function offsetSet($key, $value): void
     {
         $this->_entry[$key] = $value;
     }
@@ -239,7 +239,7 @@ class Zend_Gdata_App_Feed extends Zend_Gdata_App_FeedSourceParent
      * @param int $key The index to get
      * @param Zend_Gdata_App_Entry $value The value to set
      */
-    public function offsetGet($key)
+    public function offsetGet($key): mixed
     {
         if (array_key_exists($key, $this->_entry)) {
             return $this->_entry[$key];
@@ -252,7 +252,7 @@ class Zend_Gdata_App_Feed extends Zend_Gdata_App_FeedSourceParent
      * @param int $key The index to set
      * @param Zend_Gdata_App_Entry $value The value to set
      */
-    public function offsetUnset($key)
+    public function offsetUnset($key): void
     {
         if (array_key_exists($key, $this->_entry)) {
             unset($this->_entry[$key]);
@@ -265,7 +265,7 @@ class Zend_Gdata_App_Feed extends Zend_Gdata_App_FeedSourceParent
      * @param int $key The index to check for existence
      * @return boolean
      */
-    public function offsetExists($key)
+    public function offsetExists($key): bool
     {
         return (array_key_exists($key, $this->_entry));
     }

--- a/library/Zend/Http/CookieJar.php
+++ b/library/Zend/Http/CookieJar.php
@@ -390,7 +390,7 @@ class Zend_Http_CookieJar implements Countable, IteratorAggregate
      *
      * @return int
      */
-    public function count()
+    public function count(): int
     {
         return count($this->_rawCookies);
     }

--- a/library/Zend/Http/CookieJar.php
+++ b/library/Zend/Http/CookieJar.php
@@ -400,7 +400,7 @@ class Zend_Http_CookieJar implements Countable, IteratorAggregate
      *
      * @return ArrayIterator
      */
-    public function getIterator()
+    public function getIterator(): ArrayIterator
     {
         return new ArrayIterator($this->_rawCookies);
     }

--- a/library/Zend/Http/UserAgent.php
+++ b/library/Zend/Http/UserAgent.php
@@ -169,7 +169,7 @@ class Zend_Http_UserAgent implements Serializable
      *
      * @return string
      */
-    public function serialize()
+    public function serialize(): string
     {
         $device = $this->getDevice();
         $spec = [
@@ -189,7 +189,7 @@ class Zend_Http_UserAgent implements Serializable
      * @param  string $serialized
      * @return void
      */
-    public function unserialize($serialized)
+    public function unserialize($serialized): void
     {
         $spec = unserialize($serialized);
 

--- a/library/Zend/Http/UserAgent/AbstractDevice.php
+++ b/library/Zend/Http/UserAgent/AbstractDevice.php
@@ -124,7 +124,7 @@ abstract class Zend_Http_UserAgent_AbstractDevice
      *
      * @return string
      */
-    public function serialize()
+    public function serialize(): string
     {
         $spec = [
             '_aFeatures'      => $this->_aFeatures,
@@ -143,7 +143,7 @@ abstract class Zend_Http_UserAgent_AbstractDevice
      * @param  string $serialized
      * @return void
      */
-    public function unserialize($serialized)
+    public function unserialize($serialized): void
     {
         $spec = unserialize($serialized);
         $this->_restoreFromArray($spec);

--- a/library/Zend/Ldap/Collection.php
+++ b/library/Zend/Ldap/Collection.php
@@ -120,7 +120,7 @@ class Zend_Ldap_Collection implements Iterator, Countable
      *
      * @return int
      */
-    public function count()
+    public function count(): int
     {
         return $this->_iterator->count();
     }

--- a/library/Zend/Ldap/Collection.php
+++ b/library/Zend/Ldap/Collection.php
@@ -132,7 +132,7 @@ class Zend_Ldap_Collection implements Iterator, Countable
      * @return array|null
      * @throws Zend_Ldap_Exception
      */
-    public function current()
+    public function current(): mixed
     {
         if ($this->count() > 0) {
             if ($this->_current < 0) {
@@ -185,7 +185,7 @@ class Zend_Ldap_Collection implements Iterator, Countable
      *
      * @return int|null
      */
-    public function key()
+    public function key(): mixed
     {
         if ($this->count() > 0) {
             if ($this->_current < 0) {
@@ -203,7 +203,7 @@ class Zend_Ldap_Collection implements Iterator, Countable
      *
      * @throws Zend_Ldap_Exception
      */
-    public function next()
+    public function next(): void
     {
         $this->_iterator->next();
         $this->_current++;
@@ -215,7 +215,7 @@ class Zend_Ldap_Collection implements Iterator, Countable
      *
      * @throws Zend_Ldap_Exception
      */
-    public function rewind()
+    public function rewind(): void
     {
         $this->_iterator->rewind();
         $this->_current = 0;
@@ -228,7 +228,7 @@ class Zend_Ldap_Collection implements Iterator, Countable
      *
      * @return boolean
      */
-    public function valid()
+    public function valid(): bool
     {
         if (isset($this->_cache[$this->_current])) {
             return true;

--- a/library/Zend/Ldap/Collection/Iterator/Default.php
+++ b/library/Zend/Ldap/Collection/Iterator/Default.php
@@ -177,7 +177,7 @@ class Zend_Ldap_Collection_Iterator_Default implements Iterator, Countable
      *
      * @return int
      */
-    public function count()
+    public function count(): int
     {
         return $this->_itemCount;
     }

--- a/library/Zend/Ldap/Collection/Iterator/Default.php
+++ b/library/Zend/Ldap/Collection/Iterator/Default.php
@@ -189,7 +189,7 @@ class Zend_Ldap_Collection_Iterator_Default implements Iterator, Countable
      * @return array|null
      * @throws Zend_Ldap_Exception
      */
-    public function current()
+    public function current(): mixed
     {
         if (!is_resource($this->_current)) {
             $this->rewind();
@@ -232,7 +232,7 @@ class Zend_Ldap_Collection_Iterator_Default implements Iterator, Countable
      *
      * @return string|null
      */
-    public function key()
+    public function key(): mixed
     {
         if (!is_resource($this->_current)) {
             $this->rewind();
@@ -256,7 +256,7 @@ class Zend_Ldap_Collection_Iterator_Default implements Iterator, Countable
      *
      * @throws Zend_Ldap_Exception
      */
-    public function next()
+    public function next(): void
     {
         if (is_resource($this->_current) && $this->_itemCount > 0) {
             $this->_current = @ldap_next_entry($this->_ldap->getResource(), $this->_current);
@@ -282,7 +282,7 @@ class Zend_Ldap_Collection_Iterator_Default implements Iterator, Countable
      *
      * @throws Zend_Ldap_Exception
      */
-    public function rewind()
+    public function rewind(): void
     {
         if (is_resource($this->_resultId)) {
             $this->_current = @ldap_first_entry($this->_ldap->getResource(), $this->_resultId);
@@ -302,7 +302,7 @@ class Zend_Ldap_Collection_Iterator_Default implements Iterator, Countable
      *
      * @return boolean
      */
-    public function valid()
+    public function valid(): bool
     {
         return (is_resource($this->_current));
     }

--- a/library/Zend/Ldap/Dn.php
+++ b/library/Zend/Ldap/Dn.php
@@ -418,7 +418,7 @@ class Zend_Ldap_Dn implements ArrayAccess
      * @param  int $offset
      * @return boolean
      */
-    public function offsetExists($offset)
+    public function offsetExists($offset): bool
     {
         $offset = (int)$offset;
         if ($offset < 0 || $offset >= count($this->_dn)) {
@@ -435,7 +435,7 @@ class Zend_Ldap_Dn implements ArrayAccess
      * @param  int $offset
      * @return array
      */
-     public function offsetGet($offset)
+     public function offsetGet($offset): mixed
      {
          return $this->get($offset, 1, null);
      }
@@ -447,7 +447,7 @@ class Zend_Ldap_Dn implements ArrayAccess
       * @param int   $offset
       * @param array $value
       */
-     public function offsetSet($offset, $value)
+     public function offsetSet($offset, $value): void
      {
          $this->set($offset, $value);
      }
@@ -458,7 +458,7 @@ class Zend_Ldap_Dn implements ArrayAccess
       *
       * @param int $offset
       */
-     public function offsetUnset($offset)
+     public function offsetUnset($offset): void
      {
          $this->remove($offset, 1);
      }

--- a/library/Zend/Ldap/Node.php
+++ b/library/Zend/Ldap/Node.php
@@ -880,7 +880,7 @@ class Zend_Ldap_Node extends Zend_Ldap_Node_Abstract implements Iterator, Recurs
      * @return null
      * @throws Zend_Ldap_Exception
      */
-    public function offsetSet($name, $value)
+    public function offsetSet($name, $value): void
     {
         $this->setAttribute($name, $value);
     }

--- a/library/Zend/Ldap/Node.php
+++ b/library/Zend/Ldap/Node.php
@@ -894,10 +894,10 @@ class Zend_Ldap_Node extends Zend_Ldap_Node_Abstract implements Iterator, Recurs
      * This is an offline method.
      *
      * @param  string $name
-     * @return null
+     * @return void
      * @throws Zend_Ldap_Exception
      */
-    public function offsetUnset($name)
+    public function offsetUnset($name): void
     {
         $this->deleteAttribute($name);
     }

--- a/library/Zend/Ldap/Node.php
+++ b/library/Zend/Ldap/Node.php
@@ -1012,7 +1012,7 @@ class Zend_Ldap_Node extends Zend_Ldap_Node_Abstract implements Iterator, Recurs
      * @return boolean
      * @throws Zend_Ldap_Exception
      */
-    public function hasChildren()
+    public function hasChildren(): bool
     {
         if (!is_array($this->_children)) {
             if ($this->isAttached()) {
@@ -1033,7 +1033,7 @@ class Zend_Ldap_Node extends Zend_Ldap_Node_Abstract implements Iterator, Recurs
      * @return Zend_Ldap_Node_ChildrenIterator
      * @throws Zend_Ldap_Exception
      */
-    public function getChildren()
+    public function getChildren(): ?Zend_Ldap_Node_ChildrenIterator
     {
         if (!is_array($this->_children)) {
             $this->_children = [];
@@ -1075,7 +1075,7 @@ class Zend_Ldap_Node extends Zend_Ldap_Node_Abstract implements Iterator, Recurs
      *
      * @return array
      */
-    public function current()
+    public function current(): mixed
     {
         return $this;
     }
@@ -1086,7 +1086,7 @@ class Zend_Ldap_Node extends Zend_Ldap_Node_Abstract implements Iterator, Recurs
      *
      * @return string
      */
-    public function key()
+    public function key(): mixed
     {
         return $this->getRdnString();
     }
@@ -1095,7 +1095,7 @@ class Zend_Ldap_Node extends Zend_Ldap_Node_Abstract implements Iterator, Recurs
      * Move forward to next attribute.
      * Implements Iterator
      */
-    public function next()
+    public function next(): void
     {
         $this->_iteratorRewind = false;
     }
@@ -1104,7 +1104,7 @@ class Zend_Ldap_Node extends Zend_Ldap_Node_Abstract implements Iterator, Recurs
      * Rewind the Iterator to the first attribute.
      * Implements Iterator
      */
-    public function rewind()
+    public function rewind(): void
     {
         $this->_iteratorRewind = true;
     }
@@ -1116,7 +1116,7 @@ class Zend_Ldap_Node extends Zend_Ldap_Node_Abstract implements Iterator, Recurs
      *
      * @return boolean
      */
-    public function valid()
+    public function valid(): bool
     {
         return $this->_iteratorRewind;
     }

--- a/library/Zend/Ldap/Node/Abstract.php
+++ b/library/Zend/Ldap/Node/Abstract.php
@@ -417,10 +417,10 @@ abstract class Zend_Ldap_Node_Abstract implements ArrayAccess, Countable
      *
      * @param  string $name
      * @param  mixed  $value
-     * @return null
+     * @return void
      * @throws BadMethodCallException
      */
-    public function offsetSet($name, $value)
+    public function offsetSet($name, $value): void
     {
         throw new BadMethodCallException();
     }
@@ -435,7 +435,7 @@ abstract class Zend_Ldap_Node_Abstract implements ArrayAccess, Countable
      * @return array
      * @throws Zend_Ldap_Exception
      */
-    public function offsetGet($name)
+    public function offsetGet($name): mixed
     {
         return $this->getAttribute($name, null);
     }
@@ -449,10 +449,10 @@ abstract class Zend_Ldap_Node_Abstract implements ArrayAccess, Countable
      * This is an offline method.
      *
      * @param  string $name
-     * @return null
+     * @return void
      * @throws BadMethodCallException
      */
-    public function offsetUnset($name)
+    public function offsetUnset($name): void
     {
         throw new BadMethodCallException();
     }
@@ -466,7 +466,7 @@ abstract class Zend_Ldap_Node_Abstract implements ArrayAccess, Countable
      * @param  string $name
      * @return boolean
      */
-    public function offsetExists($name)
+    public function offsetExists($name): bool
     {
         return $this->existsAttribute($name, false);
     }

--- a/library/Zend/Ldap/Node/Abstract.php
+++ b/library/Zend/Ldap/Node/Abstract.php
@@ -477,7 +477,7 @@ abstract class Zend_Ldap_Node_Abstract implements ArrayAccess, Countable
      *
      * @return int
      */
-    public function count()
+    public function count(): int
     {
         return count($this->_currentData);
     }

--- a/library/Zend/Ldap/Node/ChildrenIterator.php
+++ b/library/Zend/Ldap/Node/ChildrenIterator.php
@@ -60,7 +60,7 @@ class Zend_Ldap_Node_ChildrenIterator implements Iterator, Countable, RecursiveI
      *
      * @return int
      */
-    public function count()
+    public function count(): int
     {
         return count($this->_data);
     }

--- a/library/Zend/Ldap/Node/ChildrenIterator.php
+++ b/library/Zend/Ldap/Node/ChildrenIterator.php
@@ -153,7 +153,7 @@ class Zend_Ldap_Node_ChildrenIterator implements Iterator, Countable, RecursiveI
      * @param  string $rdn
      * @return Zend_Ldap_node
      */
-    public function offsetGet($rdn): Zend_Ldap_node
+    public function offsetGet($rdn): mixed
     {
         if ($this->offsetExists($rdn)) {
             return $this->_data[$rdn];

--- a/library/Zend/Ldap/Node/ChildrenIterator.php
+++ b/library/Zend/Ldap/Node/ChildrenIterator.php
@@ -71,7 +71,7 @@ class Zend_Ldap_Node_ChildrenIterator implements Iterator, Countable, RecursiveI
      *
      * @return Zend_Ldap_Node
      */
-    public function current()
+    public function current(): mixed
     {
         return current($this->_data);
     }
@@ -82,7 +82,7 @@ class Zend_Ldap_Node_ChildrenIterator implements Iterator, Countable, RecursiveI
      *
      * @return string
      */
-    public function key()
+    public function key(): mixed
     {
         return key($this->_data);
     }
@@ -91,7 +91,7 @@ class Zend_Ldap_Node_ChildrenIterator implements Iterator, Countable, RecursiveI
      * Move forward to next child.
      * Implements Iterator
      */
-    public function next()
+    public function next(): void
     {
         next($this->_data);
     }
@@ -100,7 +100,7 @@ class Zend_Ldap_Node_ChildrenIterator implements Iterator, Countable, RecursiveI
      * Rewind the Iterator to the first child.
      * Implements Iterator
      */
-    public function rewind()
+    public function rewind(): void
     {
         reset($this->_data);
     }
@@ -112,7 +112,7 @@ class Zend_Ldap_Node_ChildrenIterator implements Iterator, Countable, RecursiveI
      *
      * @return boolean
      */
-    public function valid()
+    public function valid(): bool
     {
         return (current($this->_data)!==false);
     }
@@ -123,7 +123,7 @@ class Zend_Ldap_Node_ChildrenIterator implements Iterator, Countable, RecursiveI
      *
      * @return boolean
      */
-    public function hasChildren()
+    public function hasChildren(): bool
     {
         if ($this->current() instanceof Zend_Ldap_Node) {
             return $this->current()->hasChildren();
@@ -137,7 +137,7 @@ class Zend_Ldap_Node_ChildrenIterator implements Iterator, Countable, RecursiveI
      *
      * @return Zend_Ldap_Node_ChildrenIterator
      */
-    public function getChildren()
+    public function getChildren(): ?Zend_Ldap_Node_ChildrenIterator
     {
         if ($this->current() instanceof Zend_Ldap_Node) {
             return $this->current()->getChildren();
@@ -153,12 +153,12 @@ class Zend_Ldap_Node_ChildrenIterator implements Iterator, Countable, RecursiveI
      * @param  string $rdn
      * @return Zend_Ldap_node
      */
-    public function offsetGet($rdn)
+    public function offsetGet($rdn): Zend_Ldap_node
     {
         if ($this->offsetExists($rdn)) {
             return $this->_data[$rdn];
         } else {
-            return null;
+            return [];
         }
     }
 
@@ -169,7 +169,7 @@ class Zend_Ldap_Node_ChildrenIterator implements Iterator, Countable, RecursiveI
      * @param  string $rdn
      * @return boolean
      */
-    public function offsetExists($rdn)
+    public function offsetExists($rdn): bool
     {
         return (array_key_exists($rdn, $this->_data));
     }
@@ -181,7 +181,7 @@ class Zend_Ldap_Node_ChildrenIterator implements Iterator, Countable, RecursiveI
      * @param  string $name
      * @return null
      */
-    public function offsetUnset($name) { }
+    public function offsetUnset($name): void { }
 
     /**
      * Does nothing.
@@ -191,7 +191,7 @@ class Zend_Ldap_Node_ChildrenIterator implements Iterator, Countable, RecursiveI
      * @param  mixed $value
      * @return null
      */
-    public function offsetSet($name, $value) { }
+    public function offsetSet($name, $value): void { }
 
     /**
      * Get all children as an array

--- a/library/Zend/Ldap/Node/Collection.php
+++ b/library/Zend/Ldap/Node/Collection.php
@@ -60,7 +60,7 @@ class Zend_Ldap_Node_Collection extends Zend_Ldap_Collection
      *
      * @return string
      */
-    public function key()
+    public function key(): mixed
     {
         return $this->_iterator->key();
     }

--- a/library/Zend/Ldap/Node/Schema/Item.php
+++ b/library/Zend/Ldap/Node/Schema/Item.php
@@ -156,7 +156,7 @@ abstract class Zend_Ldap_Node_Schema_Item implements ArrayAccess, Countable
      *
      * @return int
      */
-    public function count()
+    public function count(): int
     {
         return count($this->_data);
     }

--- a/library/Zend/Ldap/Node/Schema/Item.php
+++ b/library/Zend/Ldap/Node/Schema/Item.php
@@ -105,10 +105,10 @@ abstract class Zend_Ldap_Node_Schema_Item implements ArrayAccess, Countable
      *
      * @param  string $name
      * @param  mixed $value
-     * @return null
+     * @return void
      * @throws BadMethodCallException
      */
-    public function offsetSet($name, $value)
+    public function offsetSet($name, $value): void
     {
         throw new BadMethodCallException();
     }
@@ -119,7 +119,7 @@ abstract class Zend_Ldap_Node_Schema_Item implements ArrayAccess, Countable
      * @param  string $name
      * @return mixed
      */
-    public function offsetGet($name)
+    public function offsetGet($name): mixed
     {
         return $this->__get($name);
     }
@@ -131,10 +131,10 @@ abstract class Zend_Ldap_Node_Schema_Item implements ArrayAccess, Countable
      * This method is needed for a full implementation of ArrayAccess
      *
      * @param  string $name
-     * @return null
+     * @return void
      * @throws BadMethodCallException
      */
-    public function offsetUnset($name)
+    public function offsetUnset($name): void
     {
         throw new BadMethodCallException();
     }
@@ -145,7 +145,7 @@ abstract class Zend_Ldap_Node_Schema_Item implements ArrayAccess, Countable
      * @param  string $name
      * @return boolean
      */
-    public function offsetExists($name)
+    public function offsetExists($name): bool
     {
         return $this->__isset($name);
     }

--- a/library/Zend/Mail/Part.php
+++ b/library/Zend/Mail/Part.php
@@ -509,7 +509,7 @@ class Zend_Mail_Part implements RecursiveIterator, Zend_Mail_Part_Interface
      *
      * @return bool current element has children/is multipart
      */
-    public function hasChildren()
+    public function hasChildren(): bool
     {
         $current = $this->current();
         return $current && $current instanceof Zend_Mail_Part && $current->isMultipart();
@@ -520,7 +520,7 @@ class Zend_Mail_Part implements RecursiveIterator, Zend_Mail_Part_Interface
      *
      * @return Zend_Mail_Part same as self::current()
      */
-    public function getChildren()
+    public function getChildren(): ?Zend_Mail_Part
     {
         return $this->current();
     }
@@ -530,7 +530,7 @@ class Zend_Mail_Part implements RecursiveIterator, Zend_Mail_Part_Interface
      *
      * @return bool check if there's a current element
      */
-    public function valid()
+    public function valid(): bool
     {
         if ($this->_countParts === null) {
             $this->countParts();
@@ -543,7 +543,7 @@ class Zend_Mail_Part implements RecursiveIterator, Zend_Mail_Part_Interface
      *
      * @return null
      */
-    public function next()
+    public function next(): void
     {
         ++$this->_iterationPos;
     }
@@ -553,7 +553,7 @@ class Zend_Mail_Part implements RecursiveIterator, Zend_Mail_Part_Interface
      *
      * @return string key/number of current part
      */
-    public function key()
+    public function key(): mixed
     {
         return $this->_iterationPos;
     }
@@ -563,7 +563,7 @@ class Zend_Mail_Part implements RecursiveIterator, Zend_Mail_Part_Interface
      *
      * @return Zend_Mail_Part current part
      */
-    public function current()
+    public function current(): mixed
     {
         return $this->getPart($this->_iterationPos);
     }
@@ -573,7 +573,7 @@ class Zend_Mail_Part implements RecursiveIterator, Zend_Mail_Part_Interface
      *
      * @return null
      */
-    public function rewind()
+    public function rewind(): void
     {
         $this->countParts();
         $this->_iterationPos = 1;

--- a/library/Zend/Mail/Storage/Abstract.php
+++ b/library/Zend/Mail/Storage/Abstract.php
@@ -216,7 +216,7 @@ abstract class Zend_Mail_Storage_Abstract implements Countable, ArrayAccess, See
      *
      * @return   int
      */
-     public function count()
+     public function count(): int
      {
         return $this->countMessages();
      }

--- a/library/Zend/Mail/Storage/Abstract.php
+++ b/library/Zend/Mail/Storage/Abstract.php
@@ -228,7 +228,7 @@ abstract class Zend_Mail_Storage_Abstract implements Countable, ArrayAccess, See
       * @param    int     $id
       * @return   boolean
       */
-     public function offsetExists($id)
+     public function offsetExists($id): bool
      {
         try {
             if ($this->getMessage($id)) {
@@ -246,7 +246,7 @@ abstract class Zend_Mail_Storage_Abstract implements Countable, ArrayAccess, See
       * @param    int $id
       * @return   Zend_Mail_Message message object
       */
-     public function offsetGet($id)
+     public function offsetGet($id): Zend_Mail_Message
      {
         return $this->getMessage($id);
      }
@@ -260,7 +260,7 @@ abstract class Zend_Mail_Storage_Abstract implements Countable, ArrayAccess, See
       * @throws   Zend_Mail_Storage_Exception
       * @return   void
       */
-     public function offsetSet($id, $value)
+     public function offsetSet($id, $value): void
      {
         /**
          * @see Zend_Mail_Storage_Exception
@@ -276,9 +276,9 @@ abstract class Zend_Mail_Storage_Abstract implements Countable, ArrayAccess, See
       * @param    int   $id
       * @return   boolean success
       */
-     public function offsetUnset($id)
+     public function offsetUnset($id): void
      {
-        return $this->removeMessage($id);
+        $this->removeMessage($id);
      }
 
 

--- a/library/Zend/Mail/Storage/Abstract.php
+++ b/library/Zend/Mail/Storage/Abstract.php
@@ -291,7 +291,7 @@ abstract class Zend_Mail_Storage_Abstract implements Countable, ArrayAccess, See
       *
       * @return   void
       */
-     public function rewind()
+     public function rewind(): void
      {
         $this->_iterationMax = $this->countMessages();
         $this->_iterationPos = 1;
@@ -303,7 +303,7 @@ abstract class Zend_Mail_Storage_Abstract implements Countable, ArrayAccess, See
       *
       * @return   Zend_Mail_Message current message
       */
-     public function current()
+     public function current(): mixed
      {
         return $this->getMessage($this->_iterationPos);
      }
@@ -314,7 +314,7 @@ abstract class Zend_Mail_Storage_Abstract implements Countable, ArrayAccess, See
       *
       * @return   int id of current position
       */
-     public function key()
+     public function key(): mixed
      {
         return $this->_iterationPos;
      }
@@ -325,7 +325,7 @@ abstract class Zend_Mail_Storage_Abstract implements Countable, ArrayAccess, See
       *
       * @return   void
       */
-     public function next()
+     public function next(): void
      {
         ++$this->_iterationPos;
      }
@@ -336,7 +336,7 @@ abstract class Zend_Mail_Storage_Abstract implements Countable, ArrayAccess, See
       *
       * @return   boolean
       */
-     public function valid()
+     public function valid(): bool
      {
         if ($this->_iterationMax === null) {
           $this->_iterationMax = $this->countMessages();
@@ -352,7 +352,7 @@ abstract class Zend_Mail_Storage_Abstract implements Countable, ArrayAccess, See
       * @return void
       * @throws OutOfBoundsException
       */
-     public function seek($pos)
+     public function seek($pos): void
      {
         if ($this->_iterationMax === null) {
           $this->_iterationMax = $this->countMessages();

--- a/library/Zend/Mail/Storage/Folder.php
+++ b/library/Zend/Mail/Storage/Folder.php
@@ -75,7 +75,7 @@ class Zend_Mail_Storage_Folder implements RecursiveIterator
      *
      * @return bool current element has children
      */
-    public function hasChildren()
+    public function hasChildren(): bool
     {
         $current = $this->current();
         return $current && $current instanceof Zend_Mail_Storage_Folder && !$current->isLeaf();
@@ -86,7 +86,7 @@ class Zend_Mail_Storage_Folder implements RecursiveIterator
      *
      * @return Zend_Mail_Storage_Folder same as self::current()
      */
-    public function getChildren()
+    public function getChildren(): ?Zend_Mail_Storage_Folder
     {
         return $this->current();
     }
@@ -96,7 +96,7 @@ class Zend_Mail_Storage_Folder implements RecursiveIterator
      *
      * @return bool check if there's a current element
      */
-    public function valid()
+    public function valid(): bool
     {
         return key($this->_folders) !== null;
     }
@@ -106,7 +106,7 @@ class Zend_Mail_Storage_Folder implements RecursiveIterator
      *
      * @return null
      */
-    public function next()
+    public function next(): void
     {
         next($this->_folders);
     }
@@ -116,7 +116,7 @@ class Zend_Mail_Storage_Folder implements RecursiveIterator
      *
      * @return string key/local name of current element
      */
-    public function key()
+    public function key(): mixed
     {
         return key($this->_folders);
     }
@@ -126,7 +126,7 @@ class Zend_Mail_Storage_Folder implements RecursiveIterator
      *
      * @return Zend_Mail_Storage_Folder current folder
      */
-    public function current()
+    public function current(): mixed
     {
         return current($this->_folders);
     }
@@ -136,7 +136,7 @@ class Zend_Mail_Storage_Folder implements RecursiveIterator
      *
      * @return null
      */
-    public function rewind()
+    public function rewind(): void
     {
         reset($this->_folders);
     }

--- a/library/Zend/Markup/Token.php
+++ b/library/Zend/Markup/Token.php
@@ -252,7 +252,7 @@ class Zend_Markup_Token
      *
      * @return Zend_Markup_TokenList
      */
-    public function getChildren()
+    public function getChildren(): ?Zend_Markup_TokenList
     {
         if (null === $this->_children) {
             $this->setChildren(new Zend_Markup_TokenList());
@@ -265,7 +265,7 @@ class Zend_Markup_Token
      *
      * @return bool
      */
-    public function hasChildren()
+    public function hasChildren(): bool
     {
         return !empty($this->_children);
     }

--- a/library/Zend/Markup/TokenList.php
+++ b/library/Zend/Markup/TokenList.php
@@ -45,7 +45,7 @@ class Zend_Markup_TokenList implements RecursiveIterator
      *
      * @return Zend_Markup_Token
      */
-    public function current()
+    public function current(): mixed
     {
         return current($this->_tokens);
     }
@@ -55,7 +55,7 @@ class Zend_Markup_TokenList implements RecursiveIterator
      *
      * @return Zend_Markup_TokenList
      */
-    public function getChildren()
+    public function getChildren(): ?Zend_Markup_TokenList
     {
         return current($this->_tokens)->getChildren();
     }
@@ -77,7 +77,7 @@ class Zend_Markup_TokenList implements RecursiveIterator
      *
      * @return bool
      */
-    public function hasChildren()
+    public function hasChildren(): bool
     {
         return current($this->_tokens)->hasChildren();
     }
@@ -87,7 +87,7 @@ class Zend_Markup_TokenList implements RecursiveIterator
      *
      * @return int
      */
-    public function key()
+    public function key(): mixed
     {
         return key($this->_tokens);
     }
@@ -97,9 +97,9 @@ class Zend_Markup_TokenList implements RecursiveIterator
      *
      * @return Zend_Markup_Token
      */
-    public function next()
+    public function next(): void
     {
-        return next($this->_tokens);
+        next($this->_tokens);
     }
 
     /**
@@ -107,7 +107,7 @@ class Zend_Markup_TokenList implements RecursiveIterator
      *
      * @return void
      */
-    public function rewind()
+    public function rewind(): void
     {
         reset($this->_tokens);
     }
@@ -117,7 +117,7 @@ class Zend_Markup_TokenList implements RecursiveIterator
      *
      * @return void
      */
-    public function valid()
+    public function valid(): bool
     {
         return $this->current() !== false;
     }

--- a/library/Zend/Memory/Value.php
+++ b/library/Zend/Memory/Value.php
@@ -86,7 +86,7 @@ class Zend_Memory_Value implements ArrayAccess {
      * @param integer $offset
      * @return boolean
      */
-    public function offsetExists($offset)
+    public function offsetExists($offset): bool
     {
         return $offset >= 0  &&  $offset < strlen($this->_value);
     }
@@ -98,7 +98,7 @@ class Zend_Memory_Value implements ArrayAccess {
      * @param integer $offset
      * @return string
      */
-    public function offsetGet($offset)
+    public function offsetGet($offset): mixed
     {
         return $this->_value[$offset];
     }
@@ -110,7 +110,7 @@ class Zend_Memory_Value implements ArrayAccess {
      * @param integer $offset
      * @param string $char
      */
-    public function offsetSet($offset, $char)
+    public function offsetSet($offset, $char): void
     {
         $this->_value[$offset] = $char;
 
@@ -126,7 +126,7 @@ class Zend_Memory_Value implements ArrayAccess {
      *
      * @param integer $offset
      */
-    public function offsetUnset($offset)
+    public function offsetUnset($offset): void
     {
         unset($this->_value[$offset]);
 

--- a/library/Zend/Navigation/Container.php
+++ b/library/Zend/Navigation/Container.php
@@ -616,7 +616,7 @@ abstract class Zend_Navigation_Container implements RecursiveIterator, Countable
      *
      * @return int  number of pages in the container
      */
-    public function count()
+    public function count(): int
     {
         return count($this->_index);
     }

--- a/library/Zend/Navigation/Container.php
+++ b/library/Zend/Navigation/Container.php
@@ -509,7 +509,7 @@ abstract class Zend_Navigation_Container implements RecursiveIterator, Countable
      * @return Zend_Navigation_Page       current page or null
      * @throws Zend_Navigation_Exception  if the index is invalid
      */
-    public function current()
+    public function current(): mixed
     {
         $this->_sort();
         current($this->_index);
@@ -532,7 +532,7 @@ abstract class Zend_Navigation_Container implements RecursiveIterator, Countable
      *
      * @return string  hash code of current page
      */
-    public function key()
+    public function key(): mixed
     {
         $this->_sort();
         return key($this->_index);
@@ -545,7 +545,7 @@ abstract class Zend_Navigation_Container implements RecursiveIterator, Countable
      *
      * @return void
      */
-    public function next()
+    public function next(): void
     {
         $this->_sort();
         next($this->_index);
@@ -558,7 +558,7 @@ abstract class Zend_Navigation_Container implements RecursiveIterator, Countable
      *
      * @return void
      */
-    public function rewind()
+    public function rewind(): void
     {
         $this->_sort();
         reset($this->_index);
@@ -571,7 +571,7 @@ abstract class Zend_Navigation_Container implements RecursiveIterator, Countable
      *
      * @return bool
      */
-    public function valid()
+    public function valid(): bool
     {
         $this->_sort();
         return current($this->_index) !== false;
@@ -584,7 +584,7 @@ abstract class Zend_Navigation_Container implements RecursiveIterator, Countable
      *
      * @return bool  whether container has any pages
      */
-    public function hasChildren()
+    public function hasChildren(): bool
     {
         return $this->hasPages();
     }
@@ -596,7 +596,7 @@ abstract class Zend_Navigation_Container implements RecursiveIterator, Countable
      *
      * @return Zend_Navigation_Page|null
      */
-    public function getChildren()
+    public function getChildren(): ?Zend_Navigation_Page
     {
         $hash = key($this->_index);
 

--- a/library/Zend/OpenId.php
+++ b/library/Zend/OpenId.php
@@ -127,13 +127,7 @@ class Zend_OpenId
         }
 
         $url .= $port;
-        if (isset($_SERVER['HTTP_X_ORIGINAL_URL'])) {
-            // IIS with Microsoft Rewrite Module
-            $url .= $_SERVER['HTTP_X_ORIGINAL_URL'];
-        } elseif (isset($_SERVER['HTTP_X_REWRITE_URL'])) {
-            // IIS with ISAPI_Rewrite
-            $url .= $_SERVER['HTTP_X_REWRITE_URL'];
-        } elseif (isset($_SERVER['REQUEST_URI'])) {
+        if (isset($_SERVER['REQUEST_URI'])) {
             $query = strpos($_SERVER['REQUEST_URI'], '?');
             if ($query === false) {
                 $url .= $_SERVER['REQUEST_URI'];

--- a/library/Zend/Paginator.php
+++ b/library/Zend/Paginator.php
@@ -817,7 +817,7 @@ class Zend_Paginator implements Countable, IteratorAggregate
      *
      * @return Traversable
      */
-    public function getIterator()
+    public function getIterator(): Traversable
     {
         return $this->getCurrentItems();
     }

--- a/library/Zend/Paginator.php
+++ b/library/Zend/Paginator.php
@@ -513,7 +513,7 @@ class Zend_Paginator implements Countable, IteratorAggregate
      *
      * @return integer
      */
-    public function count()
+    public function count(): int
     {
         if (!$this->_pageCount) {
             $this->_pageCount = $this->_calculatePageCount();

--- a/library/Zend/Paginator/Adapter/Array.php
+++ b/library/Zend/Paginator/Adapter/Array.php
@@ -74,7 +74,7 @@ class Zend_Paginator_Adapter_Array implements Zend_Paginator_Adapter_Interface
      *
      * @return integer
      */
-    public function count()
+    public function count(): int
     {
         return $this->_count;
     }

--- a/library/Zend/Paginator/Adapter/DbSelect.php
+++ b/library/Zend/Paginator/Adapter/DbSelect.php
@@ -175,7 +175,7 @@ class Zend_Paginator_Adapter_DbSelect implements Zend_Paginator_Adapter_Interfac
      *
      * @return integer
      */
-    public function count()
+    public function count(): int
     {
         if ($this->_rowCount === null) {
             $this->setRowCount(

--- a/library/Zend/Paginator/Adapter/Iterator.php
+++ b/library/Zend/Paginator/Adapter/Iterator.php
@@ -95,7 +95,7 @@ class Zend_Paginator_Adapter_Iterator implements Zend_Paginator_Adapter_Interfac
      *
      * @return integer
      */
-    public function count()
+    public function count(): int
     {
         return $this->_count;
     }

--- a/library/Zend/Paginator/Adapter/Null.php
+++ b/library/Zend/Paginator/Adapter/Null.php
@@ -73,7 +73,7 @@ class Zend_Paginator_Adapter_Null implements Zend_Paginator_Adapter_Interface
      *
      * @return integer
      */
-    public function count()
+    public function count(): int
     {
         return $this->_count;
     }

--- a/library/Zend/Paginator/SerializableLimitIterator.php
+++ b/library/Zend/Paginator/SerializableLimitIterator.php
@@ -60,7 +60,7 @@ class Zend_Paginator_SerializableLimitIterator extends LimitIterator implements 
     /**
      * @return string representation of the instance
      */
-    public function serialize()
+    public function serialize(): string
     {
         return serialize([
             'it'     => $this->getInnerIterator(),
@@ -73,7 +73,7 @@ class Zend_Paginator_SerializableLimitIterator extends LimitIterator implements 
     /**
      * @param string $data representation of the instance
      */
-    public function unserialize($data)
+    public function unserialize($data): void
     {
         $dataArr = unserialize($data);
         $this->__construct($dataArr['it'], $dataArr['offset'], $dataArr['count']);
@@ -86,7 +86,7 @@ class Zend_Paginator_SerializableLimitIterator extends LimitIterator implements 
      * @param int $offset
      * @return mixed
      */
-    public function offsetGet($offset)
+    public function offsetGet($offset): mixed
     {
         $currentOffset = $this->key();
         $this->seek($offset);
@@ -102,7 +102,7 @@ class Zend_Paginator_SerializableLimitIterator extends LimitIterator implements 
      * @param int $offset
      * @param mixed $value
      */
-    public function offsetSet($offset, $value)
+    public function offsetSet($offset, $value): void
     {
     }
 
@@ -111,7 +111,7 @@ class Zend_Paginator_SerializableLimitIterator extends LimitIterator implements 
      *
      * @param int $offset
      */
-    public function offsetExists($offset)
+    public function offsetExists($offset): bool
     {
         if ($offset > 0 && $offset < $this->_count) {
             try {
@@ -136,7 +136,7 @@ class Zend_Paginator_SerializableLimitIterator extends LimitIterator implements 
      *
      * @param int $offset
      */
-    public function offsetUnset($offset)
+    public function offsetUnset($offset): void
     {
     }
 }

--- a/library/Zend/Pdf/Action.php
+++ b/library/Zend/Pdf/Action.php
@@ -397,7 +397,7 @@ abstract class Zend_Pdf_Action extends Zend_Pdf_Target implements RecursiveItera
      *
      * @return int
      */
-    public function count()
+    public function count(): int
     {
         return count($this->childOutlines);
     }

--- a/library/Zend/Pdf/Action.php
+++ b/library/Zend/Pdf/Action.php
@@ -326,7 +326,7 @@ abstract class Zend_Pdf_Action extends Zend_Pdf_Target implements RecursiveItera
      *
      * @return Zend_Pdf_Action
      */
-    public function current()
+    public function current(): mixed
     {
         return current($this->next);
     }
@@ -336,7 +336,7 @@ abstract class Zend_Pdf_Action extends Zend_Pdf_Target implements RecursiveItera
      *
      * @return integer
      */
-    public function key()
+    public function key(): mixed
     {
         return key($this->next);
     }
@@ -344,17 +344,17 @@ abstract class Zend_Pdf_Action extends Zend_Pdf_Target implements RecursiveItera
     /**
      * Go to next child
      */
-    public function next()
+    public function next(): void
     {
-        return next($this->next);
+        next($this->next);
     }
 
     /**
      * Rewind children
      */
-    public function rewind()
+    public function rewind(): void
     {
-        return reset($this->next);
+        reset($this->next);
     }
 
     /**
@@ -362,7 +362,7 @@ abstract class Zend_Pdf_Action extends Zend_Pdf_Target implements RecursiveItera
      *
      * @return boolean
      */
-    public function valid()
+    public function valid(): bool
     {
         return current($this->next) !== false;
     }
@@ -372,7 +372,7 @@ abstract class Zend_Pdf_Action extends Zend_Pdf_Target implements RecursiveItera
      *
      * @return Zend_Pdf_Action|null
      */
-    public function getChildren()
+    public function getChildren(): ?Zend_Pdf_Action
     {
         return current($this->next);
     }
@@ -382,7 +382,7 @@ abstract class Zend_Pdf_Action extends Zend_Pdf_Target implements RecursiveItera
      *
      * @return bool  whether container has any pages
      */
-    public function hasChildren()
+    public function hasChildren(): bool
     {
         return count($this->next) > 0;
     }

--- a/library/Zend/Pdf/NameTree.php
+++ b/library/Zend/Pdf/NameTree.php
@@ -85,48 +85,48 @@ class Zend_Pdf_NameTree implements ArrayAccess, Iterator, Countable
         }
     }
 
-    public function current()
+    public function current(): mixed
     {
         return current($this->_items);
     }
 
 
-    public function next()
+    public function next(): void
     {
-        return next($this->_items);
+        next($this->_items);
     }
 
 
-    public function key()
+    public function key(): mixed
     {
         return key($this->_items);
     }
 
 
-    public function valid() {
+    public function valid(): bool {
         return current($this->_items)!==false;
     }
 
 
-    public function rewind()
+    public function rewind(): void
     {
         reset($this->_items);
     }
 
 
-    public function offsetExists($offset)
+    public function offsetExists($offset): bool
     {
         return array_key_exists($offset, $this->_items);
     }
 
 
-    public function offsetGet($offset)
+    public function offsetGet($offset): mixed
     {
         return $this->_items[$offset];
     }
 
 
-    public function offsetSet($offset, $value)
+    public function offsetSet($offset, $value): void
     {
         if ($offset === null) {
             $this->_items[]        = $value;
@@ -136,7 +136,7 @@ class Zend_Pdf_NameTree implements ArrayAccess, Iterator, Countable
     }
 
 
-    public function offsetUnset($offset)
+    public function offsetUnset($offset): void
     {
         unset($this->_items[$offset]);
     }

--- a/library/Zend/Pdf/NameTree.php
+++ b/library/Zend/Pdf/NameTree.php
@@ -147,7 +147,7 @@ class Zend_Pdf_NameTree implements ArrayAccess, Iterator, Countable
         $this->_items = [];
     }
 
-    public function count()
+    public function count(): int
     {
         return count($this->_items);
     }

--- a/library/Zend/Pdf/Outline.php
+++ b/library/Zend/Pdf/Outline.php
@@ -366,7 +366,7 @@ abstract class Zend_Pdf_Outline implements RecursiveIterator, Countable
      *
      * @return int
      */
-    public function count()
+    public function count(): int
     {
         return count($this->childOutlines);
     }

--- a/library/Zend/Pdf/Outline.php
+++ b/library/Zend/Pdf/Outline.php
@@ -295,7 +295,7 @@ abstract class Zend_Pdf_Outline implements RecursiveIterator, Countable
      *
      * @return Zend_Pdf_Outline
      */
-    public function current()
+    public function current(): mixed
     {
         return current($this->childOutlines);
     }
@@ -305,7 +305,7 @@ abstract class Zend_Pdf_Outline implements RecursiveIterator, Countable
      *
      * @return integer
      */
-    public function key()
+    public function key(): mixed
     {
         return key($this->childOutlines);
     }
@@ -313,17 +313,17 @@ abstract class Zend_Pdf_Outline implements RecursiveIterator, Countable
     /**
      * Go to next child
      */
-    public function next()
+    public function next(): void
     {
-        return next($this->childOutlines);
+        next($this->childOutlines);
     }
 
     /**
      * Rewind children
      */
-    public function rewind()
+    public function rewind(): void
     {
-        return reset($this->childOutlines);
+        reset($this->childOutlines);
     }
 
     /**
@@ -331,7 +331,7 @@ abstract class Zend_Pdf_Outline implements RecursiveIterator, Countable
      *
      * @return boolean
      */
-    public function valid()
+    public function valid(): bool
     {
         return current($this->childOutlines) !== false;
     }
@@ -341,7 +341,7 @@ abstract class Zend_Pdf_Outline implements RecursiveIterator, Countable
      *
      * @return Zend_Pdf_Outline|null
      */
-    public function getChildren()
+    public function getChildren(): ?Zend_Pdf_Outline
     {
         return current($this->childOutlines);
     }
@@ -351,7 +351,7 @@ abstract class Zend_Pdf_Outline implements RecursiveIterator, Countable
      *
      * @return bool  whether container has any pages
      */
-    public function hasChildren()
+    public function hasChildren(): bool
     {
         return count($this->childOutlines) > 0;
     }

--- a/library/Zend/Pdf/RecursivelyIteratableObjectsContainer.php
+++ b/library/Zend/Pdf/RecursivelyIteratableObjectsContainer.php
@@ -41,5 +41,5 @@ class Zend_Pdf_RecursivelyIteratableObjectsContainer implements RecursiveIterato
     public function getChildren()  { return current($this->_objects);            }
     public function hasChildren()  { return count($this->_objects) > 0;          }
 
-    public function count() { return count($this->_objects); }
+    public function count(): int { return count($this->_objects); }
 }

--- a/library/Zend/Pdf/RecursivelyIteratableObjectsContainer.php
+++ b/library/Zend/Pdf/RecursivelyIteratableObjectsContainer.php
@@ -33,13 +33,13 @@ class Zend_Pdf_RecursivelyIteratableObjectsContainer implements RecursiveIterato
 
     public function __construct(array $objects) { $this->_objects = $objects; }
 
-    public function current()      { return current($this->_objects);            }
-    public function key()          { return key($this->_objects);                }
-    public function next()         { return next($this->_objects);               }
-    public function rewind()       { return reset($this->_objects);              }
-    public function valid()        { return current($this->_objects) !== false;  }
-    public function getChildren()  { return current($this->_objects);            }
-    public function hasChildren()  { return count($this->_objects) > 0;          }
+    public function current(): mixed      { return current($this->_objects);            }
+    public function key(): mixed          { return key($this->_objects);                }
+    public function next(): void         {  next($this->_objects);               }
+    public function rewind(): void       {  reset($this->_objects);              }
+    public function valid(): bool        { return current($this->_objects) !== false;  }
+    public function getChildren(): ?RecursiveIterator  { return current($this->_objects);            }
+    public function hasChildren(): bool  { return count($this->_objects) > 0;          }
 
     public function count(): int { return count($this->_objects); }
 }

--- a/library/Zend/Queue.php
+++ b/library/Zend/Queue.php
@@ -421,7 +421,7 @@ class Zend_Queue implements Countable
      *
      * @return integer
      */
-    public function count()
+    public function count(): int
     {
         if ($this->getAdapter()->isSupported('count')) {
             return $this->getAdapter()->count();

--- a/library/Zend/Queue/Message/Iterator.php
+++ b/library/Zend/Queue/Message/Iterator.php
@@ -278,7 +278,7 @@ class Zend_Queue_Message_Iterator implements Iterator, Countable
      *
      * @return integer
      */
-    public function count()
+    public function count(): int
     {
         return count($this->_data);
     }

--- a/library/Zend/Queue/Message/Iterator.php
+++ b/library/Zend/Queue/Message/Iterator.php
@@ -212,7 +212,7 @@ class Zend_Queue_Message_Iterator implements Iterator, Countable
      *
      * @return void
      */
-    public function rewind()
+    public function rewind(): void
     {
         $this->_pointer = 0;
     }
@@ -224,7 +224,7 @@ class Zend_Queue_Message_Iterator implements Iterator, Countable
      *
      * @return Zend_Queue_Message current element from the collection
      */
-    public function current()
+    public function current(): mixed
     {
         return (($this->valid() === false)
             ? null
@@ -238,7 +238,7 @@ class Zend_Queue_Message_Iterator implements Iterator, Countable
      *
      * @return integer
      */
-    public function key()
+    public function key(): mixed
     {
         return $this->_pointer;
     }
@@ -250,7 +250,7 @@ class Zend_Queue_Message_Iterator implements Iterator, Countable
      *
      * @return void
      */
-    public function next()
+    public function next(): void
     {
         ++$this->_pointer;
     }
@@ -262,7 +262,7 @@ class Zend_Queue_Message_Iterator implements Iterator, Countable
      *
      * @return bool False if there's nothing more to iterate over
      */
-    public function valid()
+    public function valid(): bool
     {
         return $this->_pointer < count($this);
     }

--- a/library/Zend/Rest/Client/Result.php
+++ b/library/Zend/Rest/Client/Result.php
@@ -171,7 +171,7 @@ class Zend_Rest_Client_Result implements IteratorAggregate {
      *
      * @return SimpleXMLIterator
      */
-    public function getIterator()
+    public function getIterator(): SimpleXMLIterator
     {
         return $this->_sxml;
     }

--- a/library/Zend/Search/Lucene.php
+++ b/library/Zend/Search/Lucene.php
@@ -667,7 +667,7 @@ class Zend_Search_Lucene implements Zend_Search_Lucene_Interface
      *
      * @return integer
      */
-    public function count()
+    public function count(): int
     {
         return $this->_docCount;
     }

--- a/library/Zend/Search/Lucene/Index/SegmentInfo.php
+++ b/library/Zend/Search/Lucene/Index/SegmentInfo.php
@@ -689,7 +689,7 @@ class Zend_Search_Lucene_Index_SegmentInfo implements Zend_Search_Lucene_Index_T
      *
      * @return integer
      */
-    public function count()
+    public function count(): int
     {
         return $this->_docCount;
     }

--- a/library/Zend/Search/Lucene/Index/SegmentWriter.php
+++ b/library/Zend/Search/Lucene/Index/SegmentWriter.php
@@ -257,7 +257,7 @@ abstract class Zend_Search_Lucene_Index_SegmentWriter
      *
      * @return integer
      */
-    public function count()
+    public function count(): int
     {
         return $this->_docCount;
     }

--- a/library/Zend/Search/Lucene/Index/Term.php
+++ b/library/Zend/Search/Lucene/Index/Term.php
@@ -67,7 +67,7 @@ class Zend_Search_Lucene_Index_Term
      *
      * @return string
      */
-    public function key()
+    public function key(): mixed
     {
         return $this->field . chr(0) . $this->text;
     }

--- a/library/Zend/Search/Lucene/Interface.php
+++ b/library/Zend/Search/Lucene/Interface.php
@@ -93,7 +93,7 @@ interface Zend_Search_Lucene_Interface extends Zend_Search_Lucene_Index_TermsStr
      *
      * @return integer
      */
-    public function count();
+    public function count(): int;
 
     /**
      * Returns one greater than the largest possible document number.

--- a/library/Zend/Search/Lucene/MultiSearcher.php
+++ b/library/Zend/Search/Lucene/MultiSearcher.php
@@ -145,7 +145,7 @@ class Zend_Search_Lucene_MultiSearcher implements Zend_Search_Lucene_Interface
      *
      * @return integer
      */
-    public function count()
+    public function count(): int
     {
         $count = 0;
 

--- a/library/Zend/Search/Lucene/Proxy.php
+++ b/library/Zend/Search/Lucene/Proxy.php
@@ -129,7 +129,7 @@ class Zend_Search_Lucene_Proxy implements Zend_Search_Lucene_Interface
      *
      * @return integer
      */
-    public function count()
+    public function count(): int
     {
         return $this->_index->count();
     }

--- a/library/Zend/Server/Definition.php
+++ b/library/Zend/Server/Definition.php
@@ -210,7 +210,7 @@ class Zend_Server_Definition implements Countable, Iterator
      *
      * @return int
      */
-    public function count()
+    public function count(): int
     {
         return count($this->_methods);
     }

--- a/library/Zend/Server/Definition.php
+++ b/library/Zend/Server/Definition.php
@@ -220,7 +220,7 @@ class Zend_Server_Definition implements Countable, Iterator
      *
      * @return mixed
      */
-    public function current()
+    public function current(): mixed
     {
         return current($this->_methods);
     }
@@ -230,7 +230,7 @@ class Zend_Server_Definition implements Countable, Iterator
      *
      * @return int|string
      */
-    public function key()
+    public function key(): mixed
     {
         return key($this->_methods);
     }
@@ -240,9 +240,9 @@ class Zend_Server_Definition implements Countable, Iterator
      *
      * @return void
      */
-    public function next()
+    public function next(): void
     {
-        return next($this->_methods);
+        next($this->_methods);
     }
 
     /**
@@ -250,9 +250,9 @@ class Zend_Server_Definition implements Countable, Iterator
      *
      * @return void
      */
-    public function rewind()
+    public function rewind(): void
     {
-        return reset($this->_methods);
+        reset($this->_methods);
     }
 
     /**
@@ -260,7 +260,7 @@ class Zend_Server_Definition implements Countable, Iterator
      *
      * @return bool
      */
-    public function valid()
+    public function valid(): bool
     {
         return (bool) $this->current();
     }

--- a/library/Zend/Server/Reflection/Node.php
+++ b/library/Zend/Server/Reflection/Node.php
@@ -115,7 +115,7 @@ class Zend_Server_Reflection_Node
      *
      * @return array
      */
-    public function getChildren()
+    public function getChildren(): ?Array
     {
         return $this->_children;
     }
@@ -125,7 +125,7 @@ class Zend_Server_Reflection_Node
      *
      * @return boolean
      */
-    public function hasChildren()
+    public function hasChildren(): bool
     {
         return count($this->_children) > 0;
     }

--- a/library/Zend/Service/Amazon/ResultSet.php
+++ b/library/Zend/Service/Amazon/ResultSet.php
@@ -106,7 +106,7 @@ class Zend_Service_Amazon_ResultSet implements SeekableIterator
      *
      * @return Zend_Service_Amazon_Item
      */
-    public function current()
+    public function current(): mixed
     {
         return new Zend_Service_Amazon_Item($this->_results->item($this->_currentIndex));
     }
@@ -116,7 +116,7 @@ class Zend_Service_Amazon_ResultSet implements SeekableIterator
      *
      * @return int
      */
-    public function key()
+    public function key(): mixed
     {
         return $this->_currentIndex;
     }
@@ -126,7 +126,7 @@ class Zend_Service_Amazon_ResultSet implements SeekableIterator
      *
      * @return void
      */
-    public function next()
+    public function next(): void
     {
         $this->_currentIndex += 1;
     }
@@ -136,7 +136,7 @@ class Zend_Service_Amazon_ResultSet implements SeekableIterator
      *
      * @return void
      */
-    public function rewind()
+    public function rewind(): void
     {
         $this->_currentIndex = 0;
     }
@@ -148,7 +148,7 @@ class Zend_Service_Amazon_ResultSet implements SeekableIterator
      * @throws OutOfBoundsException
      * @return void
      */
-    public function seek($index)
+    public function seek($index): void
     {
         $indexInt = (int) $index;
         if ($indexInt >= 0 && (null === $this->_results || $indexInt < $this->_results->length)) {
@@ -163,7 +163,7 @@ class Zend_Service_Amazon_ResultSet implements SeekableIterator
      *
      * @return boolean
      */
-    public function valid()
+    public function valid(): bool
     {
         return null !== $this->_results && $this->_currentIndex < $this->_results->length;
     }

--- a/library/Zend/Service/Delicious/PostList.php
+++ b/library/Zend/Service/Delicious/PostList.php
@@ -161,7 +161,7 @@ class Zend_Service_Delicious_PostList implements Countable, Iterator, ArrayAcces
      *
      * @return int
      */
-    public function count()
+    public function count(): int
     {
         return count($this->_posts);
     }

--- a/library/Zend/Service/Delicious/PostList.php
+++ b/library/Zend/Service/Delicious/PostList.php
@@ -173,7 +173,7 @@ class Zend_Service_Delicious_PostList implements Countable, Iterator, ArrayAcces
      *
      * @return Zend_Service_Delicious_SimplePost
      */
-    public function current()
+    public function current(): mixed
     {
         return $this->_posts[$this->_iteratorKey];
     }
@@ -185,7 +185,7 @@ class Zend_Service_Delicious_PostList implements Countable, Iterator, ArrayAcces
      *
      * @return int
      */
-    public function key()
+    public function key(): mixed
     {
         return $this->_iteratorKey;
     }
@@ -197,7 +197,7 @@ class Zend_Service_Delicious_PostList implements Countable, Iterator, ArrayAcces
      *
      * @return void
      */
-    public function next()
+    public function next(): void
     {
         $this->_iteratorKey += 1;
     }
@@ -209,7 +209,7 @@ class Zend_Service_Delicious_PostList implements Countable, Iterator, ArrayAcces
      *
      * @return void
      */
-    public function rewind()
+    public function rewind(): void
     {
         $this->_iteratorKey = 0;
     }
@@ -221,7 +221,7 @@ class Zend_Service_Delicious_PostList implements Countable, Iterator, ArrayAcces
      *
      * @return bool
      */
-    public function valid()
+    public function valid(): bool
     {
         $numItems = $this->count();
 
@@ -240,7 +240,7 @@ class Zend_Service_Delicious_PostList implements Countable, Iterator, ArrayAcces
      * @param   int     $offset
      * @return  bool
      */
-    public function offsetExists($offset)
+    public function offsetExists($offset): bool
     {
         return ($offset < $this->count());
     }
@@ -254,7 +254,7 @@ class Zend_Service_Delicious_PostList implements Countable, Iterator, ArrayAcces
      * @throws  OutOfBoundsException
      * @return  Zend_Service_Delicious_SimplePost
      */
-    public function offsetGet($offset)
+    public function offsetGet($offset): mixed
     {
         if ($this->offsetExists($offset)) {
             return $this->_posts[$offset];
@@ -272,7 +272,7 @@ class Zend_Service_Delicious_PostList implements Countable, Iterator, ArrayAcces
      * @param   string  $value
      * @throws  Zend_Service_Delicious_Exception
      */
-    public function offsetSet($offset, $value)
+    public function offsetSet($offset, $value): void
     {
         /**
          * @see Zend_Service_Delicious_Exception
@@ -289,7 +289,7 @@ class Zend_Service_Delicious_PostList implements Countable, Iterator, ArrayAcces
      * @param   int     $offset
      * @throws  Zend_Service_Delicious_Exception
      */
-    public function offsetUnset($offset)
+    public function offsetUnset($offset): void
     {
         /**
          * @see Zend_Service_Delicious_Exception

--- a/library/Zend/Service/Ebay/Finding/Aspect/Histogram/Value/Set.php
+++ b/library/Zend/Service/Ebay/Finding/Aspect/Histogram/Value/Set.php
@@ -40,7 +40,7 @@ class Zend_Service_Ebay_Finding_Aspect_Histogram_Value_Set extends Zend_Service_
      *
      * @return Zend_Service_Ebay_Finding_Aspect_Histogram_Value
      */
-    public function current()
+    public function current(): mixed
     {
         // check node
         $node = $this->_nodes->item($this->_key);

--- a/library/Zend/Service/Ebay/Finding/Aspect/Set.php
+++ b/library/Zend/Service/Ebay/Finding/Aspect/Set.php
@@ -40,7 +40,7 @@ class Zend_Service_Ebay_Finding_Aspect_Set extends Zend_Service_Ebay_Finding_Set
      *
      * @return Zend_Service_Ebay_Finding_Aspect
      */
-    public function current()
+    public function current(): mixed
     {
         // check node
         $node = $this->_nodes->item($this->_key);

--- a/library/Zend/Service/Ebay/Finding/Category/Histogram/Set.php
+++ b/library/Zend/Service/Ebay/Finding/Category/Histogram/Set.php
@@ -40,7 +40,7 @@ class Zend_Service_Ebay_Finding_Category_Histogram_Set extends Zend_Service_Ebay
      *
      * @return Zend_Service_Ebay_Finding_Category_Histogram
      */
-    public function current()
+    public function current(): mixed
     {
         // check node
         $node = $this->_nodes->item($this->_key);

--- a/library/Zend/Service/Ebay/Finding/Error/Data/Set.php
+++ b/library/Zend/Service/Ebay/Finding/Error/Data/Set.php
@@ -40,7 +40,7 @@ class Zend_Service_Ebay_Finding_Error_Data_Set extends Zend_Service_Ebay_Finding
      *
      * @return Zend_Service_Ebay_Finding_Error_Data
      */
-    public function current()
+    public function current(): mixed
     {
         // check node
         $node = $this->_nodes->item($this->_key);

--- a/library/Zend/Service/Ebay/Finding/Search/Item/Set.php
+++ b/library/Zend/Service/Ebay/Finding/Search/Item/Set.php
@@ -40,7 +40,7 @@ class Zend_Service_Ebay_Finding_Search_Item_Set extends Zend_Service_Ebay_Findin
      *
      * @return Zend_Service_Ebay_Finding_Search_Item
      */
-    public function current()
+    public function current(): mixed
     {
         // check node
         $node = $this->_nodes->item($this->_key);

--- a/library/Zend/Service/Ebay/Finding/Set/Abstract.php
+++ b/library/Zend/Service/Ebay/Finding/Set/Abstract.php
@@ -121,7 +121,7 @@ abstract class Zend_Service_Ebay_Finding_Set_Abstract implements SeekableIterato
      *
      * @return integer
      */
-    public function count()
+    public function count(): int
     {
         return $this->_nodes ? $this->_nodes->length : 0;
     }

--- a/library/Zend/Service/Ebay/Finding/Set/Abstract.php
+++ b/library/Zend/Service/Ebay/Finding/Set/Abstract.php
@@ -67,7 +67,7 @@ abstract class Zend_Service_Ebay_Finding_Set_Abstract implements SeekableIterato
      * @throws OutOfBoundsException When $key is not seekable
      * @return void
      */
-    public function seek($key)
+    public function seek($key): void
     {
         if ($key < 0 || $key >= $this->count()) {
             $message = "Position '{$key}' is not seekable.";
@@ -81,7 +81,7 @@ abstract class Zend_Service_Ebay_Finding_Set_Abstract implements SeekableIterato
      *
      * @return integer
      */
-    public function key()
+    public function key(): mixed
     {
         return $this->_key;
     }
@@ -91,7 +91,7 @@ abstract class Zend_Service_Ebay_Finding_Set_Abstract implements SeekableIterato
      *
      * @return void
      */
-    public function next()
+    public function next(): void
     {
         $this->_key++;
     }
@@ -101,7 +101,7 @@ abstract class Zend_Service_Ebay_Finding_Set_Abstract implements SeekableIterato
      *
      * @return void
      */
-    public function rewind()
+    public function rewind(): void
     {
         $this->_key = 0;
     }
@@ -111,7 +111,7 @@ abstract class Zend_Service_Ebay_Finding_Set_Abstract implements SeekableIterato
      *
      * @return boolean
      */
-    public function valid()
+    public function valid(): bool
     {
         return $this->_key >= 0 && $this->_key < $this->count();
     }

--- a/library/Zend/Service/Flickr/ResultSet.php
+++ b/library/Zend/Service/Flickr/ResultSet.php
@@ -123,7 +123,7 @@ class Zend_Service_Flickr_ResultSet implements SeekableIterator
      *
      * @return Zend_Service_Flickr_Result
      */
-    public function current()
+    public function current(): mixed
     {
         return new Zend_Service_Flickr_Result($this->_results->item($this->_currentIndex), $this->_flickr);
     }
@@ -133,7 +133,7 @@ class Zend_Service_Flickr_ResultSet implements SeekableIterator
      *
      * @return int
      */
-    public function key()
+    public function key(): mixed
     {
         return $this->_currentIndex;
     }
@@ -143,7 +143,7 @@ class Zend_Service_Flickr_ResultSet implements SeekableIterator
      *
      * @return void
      */
-    public function next()
+    public function next(): void
     {
         $this->_currentIndex += 1;
     }
@@ -153,7 +153,7 @@ class Zend_Service_Flickr_ResultSet implements SeekableIterator
      *
      * @return void
      */
-    public function rewind()
+    public function rewind(): void
     {
         $this->_currentIndex = 0;
     }
@@ -165,7 +165,7 @@ class Zend_Service_Flickr_ResultSet implements SeekableIterator
      * @throws OutOfBoundsException
      * @return void
      */
-    public function seek($index)
+    public function seek($index): void
     {
         $indexInt = (int) $index;
         if ($indexInt >= 0 && (null === $this->_results || $indexInt < $this->_results->length)) {
@@ -180,7 +180,7 @@ class Zend_Service_Flickr_ResultSet implements SeekableIterator
      *
      * @return boolean
      */
-    public function valid()
+    public function valid(): bool
     {
         return null !== $this->_results && $this->_currentIndex < $this->_results->length;
     }

--- a/library/Zend/Service/Rackspace/Files/ContainerList.php
+++ b/library/Zend/Service/Rackspace/Files/ContainerList.php
@@ -95,7 +95,7 @@ class Zend_Service_Rackspace_Files_ContainerList implements Countable, Iterator,
      *
      * @return int
      */
-    public function count()
+    public function count(): int
     {
         return count($this->objects);
     }

--- a/library/Zend/Service/Rackspace/Files/ContainerList.php
+++ b/library/Zend/Service/Rackspace/Files/ContainerList.php
@@ -106,7 +106,7 @@ class Zend_Service_Rackspace_Files_ContainerList implements Countable, Iterator,
      *
      * @return Zend_Service_Rackspace_Files_Container
      */
-    public function current()
+    public function current(): mixed
     {
         return $this->objects[$this->iteratorKey];
     }
@@ -117,7 +117,7 @@ class Zend_Service_Rackspace_Files_ContainerList implements Countable, Iterator,
      *
      * @return int
      */
-    public function key()
+    public function key(): mixed
     {
         return $this->iteratorKey;
     }
@@ -128,7 +128,7 @@ class Zend_Service_Rackspace_Files_ContainerList implements Countable, Iterator,
      *
      * @return void
      */
-    public function next()
+    public function next(): void
     {
         $this->iteratorKey += 1;
     }
@@ -139,7 +139,7 @@ class Zend_Service_Rackspace_Files_ContainerList implements Countable, Iterator,
      *
      * @return void
      */
-    public function rewind()
+    public function rewind(): void
     {
         $this->iteratorKey = 0;
     }
@@ -150,7 +150,7 @@ class Zend_Service_Rackspace_Files_ContainerList implements Countable, Iterator,
      *
      * @return bool
      */
-    public function valid()
+    public function valid(): bool
     {
         $numItems = $this->count();
         if ($numItems > 0 && $this->iteratorKey < $numItems) {
@@ -167,7 +167,7 @@ class Zend_Service_Rackspace_Files_ContainerList implements Countable, Iterator,
      * @param   int     $offset
      * @return  bool
      */
-    public function offsetExists($offset)
+    public function offsetExists($offset): bool
     {
         return ($offset < $this->count());
     }
@@ -180,7 +180,7 @@ class Zend_Service_Rackspace_Files_ContainerList implements Countable, Iterator,
      * @throws  Zend_Service_Rackspace_Files_Exception
      * @return  Zend_Service_Rackspace_Files_Container
      */
-    public function offsetGet($offset)
+    public function offsetGet($offset): mixed
     {
         if ($this->offsetExists($offset)) {
             return $this->objects[$offset];
@@ -199,7 +199,7 @@ class Zend_Service_Rackspace_Files_ContainerList implements Countable, Iterator,
      * @param   string  $value
      * @throws  Zend_Service_Rackspace_Files_Exception
      */
-    public function offsetSet($offset, $value)
+    public function offsetSet($offset, $value): void
     {
         require_once 'Zend/Service/Rackspace/Files/Exception.php';
         throw new Zend_Service_Rackspace_Files_Exception('You are trying to set read-only property');
@@ -213,7 +213,7 @@ class Zend_Service_Rackspace_Files_ContainerList implements Countable, Iterator,
      * @param   int     $offset
      * @throws  Zend_Service_Rackspace_Files_Exception
      */
-    public function offsetUnset($offset)
+    public function offsetUnset($offset): void
     {
         require_once 'Zend/Service/Rackspace/Files/Exception.php';
         throw new Zend_Service_Rackspace_Files_Exception('You are trying to unset read-only property');

--- a/library/Zend/Service/Rackspace/Files/ObjectList.php
+++ b/library/Zend/Service/Rackspace/Files/ObjectList.php
@@ -111,7 +111,7 @@ class Zend_Service_Rackspace_Files_ObjectList implements Countable, Iterator, Ar
      *
      * @return int
      */
-    public function count()
+    public function count(): int
     {
         return count($this->objects);
     }

--- a/library/Zend/Service/Rackspace/Files/ObjectList.php
+++ b/library/Zend/Service/Rackspace/Files/ObjectList.php
@@ -122,7 +122,7 @@ class Zend_Service_Rackspace_Files_ObjectList implements Countable, Iterator, Ar
      *
      * @return Zend_Service_Rackspace_Files_Object
      */
-    public function current()
+    public function current(): mixed
     {
         return $this->objects[$this->iteratorKey];
     }
@@ -133,7 +133,7 @@ class Zend_Service_Rackspace_Files_ObjectList implements Countable, Iterator, Ar
      *
      * @return int
      */
-    public function key()
+    public function key(): mixed
     {
         return $this->iteratorKey;
     }
@@ -144,7 +144,7 @@ class Zend_Service_Rackspace_Files_ObjectList implements Countable, Iterator, Ar
      *
      * @return void
      */
-    public function next()
+    public function next(): void
     {
         $this->iteratorKey += 1;
     }
@@ -155,7 +155,7 @@ class Zend_Service_Rackspace_Files_ObjectList implements Countable, Iterator, Ar
      *
      * @return void
      */
-    public function rewind()
+    public function rewind(): void
     {
         $this->iteratorKey = 0;
     }
@@ -166,7 +166,7 @@ class Zend_Service_Rackspace_Files_ObjectList implements Countable, Iterator, Ar
      *
      * @return bool
      */
-    public function valid()
+    public function valid(): bool
     {
         $numItems = $this->count();
         if ($numItems > 0 && $this->iteratorKey < $numItems) {
@@ -183,7 +183,7 @@ class Zend_Service_Rackspace_Files_ObjectList implements Countable, Iterator, Ar
      * @param   int     $offset
      * @return  bool
      */
-    public function offsetExists($offset)
+    public function offsetExists($offset): bool
     {
         return ($offset < $this->count());
     }
@@ -196,7 +196,7 @@ class Zend_Service_Rackspace_Files_ObjectList implements Countable, Iterator, Ar
      * @throws  Zend_Service_Rackspace_Files_Exception
      * @return  Zend_Service_Rackspace_Files_Object
      */
-    public function offsetGet($offset)
+    public function offsetGet($offset): mixed
     {
         if ($this->offsetExists($offset)) {
             return $this->objects[$offset];
@@ -215,7 +215,7 @@ class Zend_Service_Rackspace_Files_ObjectList implements Countable, Iterator, Ar
      * @param   string  $value
      * @throws  Zend_Service_Rackspace_Files_Exception
      */
-    public function offsetSet($offset, $value)
+    public function offsetSet($offset, $value): void
     {
         require_once 'Zend/Service/Rackspace/Files/Exception.php';
         throw new Zend_Service_Rackspace_Files_Exception('You are trying to set read-only property');
@@ -229,7 +229,7 @@ class Zend_Service_Rackspace_Files_ObjectList implements Countable, Iterator, Ar
      * @param   int     $offset
      * @throws  Zend_Service_Rackspace_Files_Exception
      */
-    public function offsetUnset($offset)
+    public function offsetUnset($offset): void
     {
         require_once 'Zend/Service/Rackspace/Files/Exception.php';
         throw new Zend_Service_Rackspace_Files_Exception('You are trying to unset read-only property');

--- a/library/Zend/Service/Rackspace/Servers/ImageList.php
+++ b/library/Zend/Service/Rackspace/Servers/ImageList.php
@@ -108,7 +108,7 @@ class Zend_Service_Rackspace_Servers_ImageList implements Countable, Iterator, A
      *
      * @return int
      */
-    public function count()
+    public function count(): int
     {
         return count($this->images);
     }

--- a/library/Zend/Service/Rackspace/Servers/ImageList.php
+++ b/library/Zend/Service/Rackspace/Servers/ImageList.php
@@ -119,7 +119,7 @@ class Zend_Service_Rackspace_Servers_ImageList implements Countable, Iterator, A
      *
      * @return Zend_Service_Rackspace_Servers_Image
      */
-    public function current()
+    public function current(): mixed
     {
         return $this->images[$this->iteratorKey];
     }
@@ -130,7 +130,7 @@ class Zend_Service_Rackspace_Servers_ImageList implements Countable, Iterator, A
      *
      * @return int
      */
-    public function key()
+    public function key(): mixed
     {
         return $this->iteratorKey;
     }
@@ -141,7 +141,7 @@ class Zend_Service_Rackspace_Servers_ImageList implements Countable, Iterator, A
      *
      * @return void
      */
-    public function next()
+    public function next(): void
     {
         $this->iteratorKey += 1;
     }
@@ -152,7 +152,7 @@ class Zend_Service_Rackspace_Servers_ImageList implements Countable, Iterator, A
      *
      * @return void
      */
-    public function rewind()
+    public function rewind(): void
     {
         $this->iteratorKey = 0;
     }
@@ -163,7 +163,7 @@ class Zend_Service_Rackspace_Servers_ImageList implements Countable, Iterator, A
      *
      * @return bool
      */
-    public function valid()
+    public function valid(): bool
     {
         $numItems = $this->count();
         if ($numItems > 0 && $this->iteratorKey < $numItems) {
@@ -180,7 +180,7 @@ class Zend_Service_Rackspace_Servers_ImageList implements Countable, Iterator, A
      * @param   int     $offset
      * @return  bool
      */
-    public function offsetExists($offset)
+    public function offsetExists($offset): bool
     {
         return ($offset < $this->count());
     }
@@ -193,7 +193,7 @@ class Zend_Service_Rackspace_Servers_ImageList implements Countable, Iterator, A
      * @throws  Zend_Service_Rackspace_Servers_Exception
      * @return  Zend_Service_Rackspace_Servers_Image
      */
-    public function offsetGet($offset)
+    public function offsetGet($offset): mixed
     {
         if ($this->offsetExists($offset)) {
             return $this->images[$offset];
@@ -212,7 +212,7 @@ class Zend_Service_Rackspace_Servers_ImageList implements Countable, Iterator, A
      * @param   string  $value
      * @throws  Zend_Service_Rackspace_Servers_Exception
      */
-    public function offsetSet($offset, $value)
+    public function offsetSet($offset, $value): void
     {
         require_once 'Zend/Service/Rackspace/Servers/Exception.php';
         throw new Zend_Service_Rackspace_Servers_Exception('You are trying to set read-only property');
@@ -226,7 +226,7 @@ class Zend_Service_Rackspace_Servers_ImageList implements Countable, Iterator, A
      * @param   int     $offset
      * @throws  Zend_Service_Rackspace_Servers_Exception
      */
-    public function offsetUnset($offset)
+    public function offsetUnset($offset): void
     {
         require_once 'Zend/Service/Rackspace/Servers/Exception.php';
         throw new Zend_Service_Rackspace_Servers_Exception('You are trying to unset read-only property');

--- a/library/Zend/Service/Rackspace/Servers/ServerList.php
+++ b/library/Zend/Service/Rackspace/Servers/ServerList.php
@@ -109,7 +109,7 @@ class Zend_Service_Rackspace_Servers_ServerList implements Countable, Iterator, 
      *
      * @return int
      */
-    public function count()
+    public function count(): int
     {
         return count($this->servers);
     }

--- a/library/Zend/Service/Rackspace/Servers/ServerList.php
+++ b/library/Zend/Service/Rackspace/Servers/ServerList.php
@@ -120,7 +120,7 @@ class Zend_Service_Rackspace_Servers_ServerList implements Countable, Iterator, 
      *
      * @return Zend_Service_Rackspace_Servers_Server
      */
-    public function current()
+    public function current(): mixed
     {
         return $this->servers[$this->iteratorKey];
     }
@@ -131,7 +131,7 @@ class Zend_Service_Rackspace_Servers_ServerList implements Countable, Iterator, 
      *
      * @return int
      */
-    public function key()
+    public function key(): mixed
     {
         return $this->iteratorKey;
     }
@@ -142,7 +142,7 @@ class Zend_Service_Rackspace_Servers_ServerList implements Countable, Iterator, 
      *
      * @return void
      */
-    public function next()
+    public function next(): void
     {
         $this->iteratorKey += 1;
     }
@@ -153,7 +153,7 @@ class Zend_Service_Rackspace_Servers_ServerList implements Countable, Iterator, 
      *
      * @return void
      */
-    public function rewind()
+    public function rewind(): void
     {
         $this->iteratorKey = 0;
     }
@@ -164,7 +164,7 @@ class Zend_Service_Rackspace_Servers_ServerList implements Countable, Iterator, 
      *
      * @return bool
      */
-    public function valid()
+    public function valid(): bool
     {
         $numItems = $this->count();
         if ($numItems > 0 && $this->iteratorKey < $numItems) {
@@ -181,7 +181,7 @@ class Zend_Service_Rackspace_Servers_ServerList implements Countable, Iterator, 
      * @param   int     $offset
      * @return  bool
      */
-    public function offsetExists($offset)
+    public function offsetExists($offset): bool
     {
         return ($offset < $this->count());
     }
@@ -194,7 +194,7 @@ class Zend_Service_Rackspace_Servers_ServerList implements Countable, Iterator, 
      * @throws  Zend_Service_Rackspace_Servers_Exception
      * @return  Zend_Service_Rackspace_Servers_Server
      */
-    public function offsetGet($offset)
+    public function offsetGet($offset): mixed
     {
         if ($this->offsetExists($offset)) {
             return $this->servers[$offset];
@@ -213,7 +213,7 @@ class Zend_Service_Rackspace_Servers_ServerList implements Countable, Iterator, 
      * @param   string  $value
      * @throws  Zend_Service_Rackspace_Servers_Exception
      */
-    public function offsetSet($offset, $value)
+    public function offsetSet($offset, $value): void
     {
         require_once 'Zend/Service/Rackspace/Servers/Exception.php';
         throw new Zend_Service_Rackspace_Servers_Exception('You are trying to set read-only property');
@@ -227,7 +227,7 @@ class Zend_Service_Rackspace_Servers_ServerList implements Countable, Iterator, 
      * @param   int     $offset
      * @throws  Zend_Service_Rackspace_Servers_Exception
      */
-    public function offsetUnset($offset)
+    public function offsetUnset($offset): void
     {
         require_once 'Zend/Service/Rackspace/Servers/Exception.php';
         throw new Zend_Service_Rackspace_Servers_Exception('You are trying to unset read-only property');

--- a/library/Zend/Service/Rackspace/Servers/SharedIpGroupList.php
+++ b/library/Zend/Service/Rackspace/Servers/SharedIpGroupList.php
@@ -108,7 +108,7 @@ class Zend_Service_Rackspace_Servers_SharedIpGroupList implements Countable, Ite
      *
      * @return int
      */
-    public function count()
+    public function count(): int
     {
         return count($this->shared);
     }

--- a/library/Zend/Service/Rackspace/Servers/SharedIpGroupList.php
+++ b/library/Zend/Service/Rackspace/Servers/SharedIpGroupList.php
@@ -119,7 +119,7 @@ class Zend_Service_Rackspace_Servers_SharedIpGroupList implements Countable, Ite
      *
      * @return Zend_Service_Rackspace_Servers_SharedIpGroup
      */
-    public function current()
+    public function current(): mixed
     {
         return $this->shared[$this->iteratorKey];
     }
@@ -130,7 +130,7 @@ class Zend_Service_Rackspace_Servers_SharedIpGroupList implements Countable, Ite
      *
      * @return int
      */
-    public function key()
+    public function key(): mixed
     {
         return $this->iteratorKey;
     }
@@ -141,7 +141,7 @@ class Zend_Service_Rackspace_Servers_SharedIpGroupList implements Countable, Ite
      *
      * @return void
      */
-    public function next()
+    public function next(): void
     {
         $this->iteratorKey += 1;
     }
@@ -152,7 +152,7 @@ class Zend_Service_Rackspace_Servers_SharedIpGroupList implements Countable, Ite
      *
      * @return void
      */
-    public function rewind()
+    public function rewind(): void
     {
         $this->iteratorKey = 0;
     }
@@ -163,7 +163,7 @@ class Zend_Service_Rackspace_Servers_SharedIpGroupList implements Countable, Ite
      *
      * @return boolean
      */
-    public function valid()
+    public function valid(): bool
     {
         $numItems = $this->count();
         if ($numItems > 0 && $this->iteratorKey < $numItems) {
@@ -180,7 +180,7 @@ class Zend_Service_Rackspace_Servers_SharedIpGroupList implements Countable, Ite
      * @param   int     $offset
      * @return  boolean
      */
-    public function offsetExists($offset)
+    public function offsetExists($offset): bool
     {
         return ($offset < $this->count());
     }
@@ -193,7 +193,7 @@ class Zend_Service_Rackspace_Servers_SharedIpGroupList implements Countable, Ite
      * @throws  Zend_Service_Rackspace_Servers_Exception
      * @return  Zend_Service_Rackspace_Servers_SharedIpGroup
      */
-    public function offsetGet($offset)
+    public function offsetGet($offset): mixed
     {
         if ($this->offsetExists($offset)) {
             return $this->shared[$offset];
@@ -212,7 +212,7 @@ class Zend_Service_Rackspace_Servers_SharedIpGroupList implements Countable, Ite
      * @param   string  $value
      * @throws  Zend_Service_Rackspace_Servers_Exception
      */
-    public function offsetSet($offset, $value)
+    public function offsetSet($offset, $value): void
     {
         require_once 'Zend/Service/Rackspace/Servers/Exception.php';
         throw new Zend_Service_Rackspace_Servers_Exception('You are trying to set read-only property');
@@ -226,7 +226,7 @@ class Zend_Service_Rackspace_Servers_SharedIpGroupList implements Countable, Ite
      * @param  int $offset
      * @throws Zend_Service_Rackspace_Servers_Exception
      */
-    public function offsetUnset($offset)
+    public function offsetUnset($offset): void
     {
         require_once 'Zend/Service/Rackspace/Servers/Exception.php';
         throw new Zend_Service_Rackspace_Servers_Exception('You are trying to unset read-only property');

--- a/library/Zend/Service/Yahoo/ImageResultSet.php
+++ b/library/Zend/Service/Yahoo/ImageResultSet.php
@@ -56,7 +56,7 @@ class Zend_Service_Yahoo_ImageResultSet extends Zend_Service_Yahoo_ResultSet
      *
      * @return Zend_Service_Yahoo_ImageResult
      */
-    public function current()
+    public function current(): Zend_Service_Yahoo_ImageResult
     {
         return new Zend_Service_Yahoo_ImageResult($this->_results->item($this->_currentIndex));
     }

--- a/library/Zend/Service/Yahoo/InlinkDataResultSet.php
+++ b/library/Zend/Service/Yahoo/InlinkDataResultSet.php
@@ -55,7 +55,7 @@ class Zend_Service_Yahoo_InlinkDataResultSet extends Zend_Service_Yahoo_ResultSe
      *
      * @return Zend_Service_Yahoo_InlinkDataResult
      */
-    public function current()
+    public function current(): Zend_Service_Yahoo_InlinkDataResult
     {
         return new Zend_Service_Yahoo_InlinkDataResult($this->_results->item($this->_currentIndex));
     }

--- a/library/Zend/Service/Yahoo/LocalResultSet.php
+++ b/library/Zend/Service/Yahoo/LocalResultSet.php
@@ -77,7 +77,7 @@ class Zend_Service_Yahoo_LocalResultSet extends Zend_Service_Yahoo_ResultSet
      *
      * @return Zend_Service_Yahoo_LocalResult
      */
-    public function current()
+    public function current(): Zend_Service_Yahoo_LocalResult
     {
         return new Zend_Service_Yahoo_LocalResult($this->_results->item($this->_currentIndex));
     }

--- a/library/Zend/Service/Yahoo/NewsResultSet.php
+++ b/library/Zend/Service/Yahoo/NewsResultSet.php
@@ -56,7 +56,7 @@ class Zend_Service_Yahoo_NewsResultSet extends Zend_Service_Yahoo_ResultSet
      *
      * @return Zend_Service_Yahoo_NewsResult
      */
-    public function current()
+    public function current(): Zend_Service_Yahoo_NewsResult
     {
         return new Zend_Service_Yahoo_NewsResult($this->_results->item($this->_currentIndex));
     }

--- a/library/Zend/Service/Yahoo/PageDataResultSet.php
+++ b/library/Zend/Service/Yahoo/PageDataResultSet.php
@@ -55,7 +55,7 @@ class Zend_Service_Yahoo_PageDataResultSet extends Zend_Service_Yahoo_ResultSet
      *
      * @return Zend_Service_Yahoo_WebResult
      */
-    public function current()
+    public function current(): Zend_Service_Yahoo_PageDataResult
     {
         return new Zend_Service_Yahoo_PageDataResult($this->_results->item($this->_currentIndex));
     }

--- a/library/Zend/Service/Yahoo/ResultSet.php
+++ b/library/Zend/Service/Yahoo/ResultSet.php
@@ -121,7 +121,7 @@ class Zend_Service_Yahoo_ResultSet implements SeekableIterator
      * @throws Zend_Service_Exception
      * @return Zend_Service_Yahoo_Result
      */
-    public function current()
+    public function current(): mixed
     {
         /**
          * @see Zend_Service_Exception
@@ -137,7 +137,7 @@ class Zend_Service_Yahoo_ResultSet implements SeekableIterator
      *
      * @return int
      */
-    public function key()
+    public function key(): mixed
     {
         return $this->_currentIndex;
     }
@@ -148,7 +148,7 @@ class Zend_Service_Yahoo_ResultSet implements SeekableIterator
      *
      * @return void
      */
-    public function next()
+    public function next(): void
     {
         $this->_currentIndex += 1;
     }
@@ -159,7 +159,7 @@ class Zend_Service_Yahoo_ResultSet implements SeekableIterator
      *
      * @return void
      */
-    public function rewind()
+    public function rewind(): void
     {
         $this->_currentIndex = 0;
     }
@@ -172,7 +172,7 @@ class Zend_Service_Yahoo_ResultSet implements SeekableIterator
      * @return void
      * @throws OutOfBoundsException
      */
-    public function seek($index)
+    public function seek($index): void
     {
         $indexInt = (int) $index;
         if ($indexInt >= 0 && $indexInt < $this->_results->length) {
@@ -188,7 +188,7 @@ class Zend_Service_Yahoo_ResultSet implements SeekableIterator
      *
      * @return boolean
      */
-    public function valid()
+    public function valid(): bool
     {
         return $this->_currentIndex < $this->_results->length;
     }

--- a/library/Zend/Service/Yahoo/VideoResultSet.php
+++ b/library/Zend/Service/Yahoo/VideoResultSet.php
@@ -56,7 +56,7 @@ class Zend_Service_Yahoo_VideoResultSet extends Zend_Service_Yahoo_ResultSet
      *
      * @return Zend_Service_Yahoo_VideoResult
      */
-    public function current()
+    public function current(): mixed
     {
         return new Zend_Service_Yahoo_VideoResult($this->_results->item($this->_currentIndex));
     }

--- a/library/Zend/Service/Yahoo/WebResultSet.php
+++ b/library/Zend/Service/Yahoo/WebResultSet.php
@@ -56,7 +56,7 @@ class Zend_Service_Yahoo_WebResultSet extends Zend_Service_Yahoo_ResultSet
      *
      * @return Zend_Service_Yahoo_WebResult
      */
-    public function current()
+    public function current(): mixed
     {
         return new Zend_Service_Yahoo_WebResult($this->_results->item($this->_currentIndex));
     }

--- a/library/Zend/Session/Namespace.php
+++ b/library/Zend/Session/Namespace.php
@@ -207,7 +207,7 @@ class Zend_Session_Namespace extends Zend_Session_Abstract implements IteratorAg
      *
      * @return ArrayObject - iteratable container of the namespace contents
      */
-    public function getIterator()
+    public function getIterator(): ArrayObject
     {
         return new ArrayObject(parent::_namespaceGetAll($this->_namespace));
     }
@@ -229,7 +229,7 @@ class Zend_Session_Namespace extends Zend_Session_Abstract implements IteratorAg
      *
      * @return void
      */
-    public function unlock()
+    public function unlock(): void
     {
         unset(self::$_namespaceLocks[$this->_namespace]);
     }

--- a/library/Zend/Soap/AutoDiscover.php
+++ b/library/Zend/Soap/AutoDiscover.php
@@ -268,11 +268,7 @@ class Zend_Soap_AutoDiscover implements Zend_Server_Interface
      */
     protected function getRequestUriWithoutParameters()
     {
-        if (isset($_SERVER['HTTP_X_ORIGINAL_URL'])) { // IIS with Microsoft Rewrite Module
-            $requestUri = $_SERVER['HTTP_X_ORIGINAL_URL'];
-        } elseif (isset($_SERVER['HTTP_X_REWRITE_URL'])) { // check this first so IIS will catch
-            $requestUri = $_SERVER['HTTP_X_REWRITE_URL'];
-        } elseif (isset($_SERVER['REQUEST_URI'])) {
+        if (isset($_SERVER['REQUEST_URI'])) {
             $requestUri = $_SERVER['REQUEST_URI'];
         } elseif (isset($_SERVER['ORIG_PATH_INFO'])) { // IIS 5.0, PHP as CGI
             $requestUri = $_SERVER['ORIG_PATH_INFO'];

--- a/library/Zend/Stdlib/PriorityQueue.php
+++ b/library/Zend/Stdlib/PriorityQueue.php
@@ -134,7 +134,7 @@ class Zend_Stdlib_PriorityQueue implements Countable, IteratorAggregate, Seriali
      *
      * @return int
      */
-    public function count()
+    public function count(): int
     {
         return count($this->items);
     }

--- a/library/Zend/Stdlib/PriorityQueue.php
+++ b/library/Zend/Stdlib/PriorityQueue.php
@@ -171,7 +171,7 @@ class Zend_Stdlib_PriorityQueue implements Countable, IteratorAggregate, Seriali
      *
      * @return SplPriorityQueue
      */
-    public function getIterator()
+    public function getIterator(): Traversable
     {
         $queue = $this->getQueue();
         return clone $queue;
@@ -182,7 +182,7 @@ class Zend_Stdlib_PriorityQueue implements Countable, IteratorAggregate, Seriali
      *
      * @return string
      */
-    public function serialize()
+    public function serialize(): string
     {
         return serialize($this->items);
     }
@@ -195,7 +195,7 @@ class Zend_Stdlib_PriorityQueue implements Countable, IteratorAggregate, Seriali
      * @param  string $data
      * @return void
      */
-    public function unserialize($data)
+    public function unserialize($data): void
     {
         foreach (unserialize($data) as $item) {
             $this->insert($item['data'], $item['priority']);

--- a/library/Zend/Stdlib/SplPriorityQueue.php
+++ b/library/Zend/Stdlib/SplPriorityQueue.php
@@ -105,7 +105,7 @@ if (version_compare(PHP_VERSION, '5.3.0', '<')) {
          *
          * @return int
          */
-        public function count()
+        public function count(): int
         {
             return $this->count;
         }

--- a/library/Zend/Stdlib/SplPriorityQueue.php
+++ b/library/Zend/Stdlib/SplPriorityQueue.php
@@ -115,7 +115,7 @@ if (version_compare(PHP_VERSION, '5.3.0', '<')) {
          *
          * @return mixed
          */
-        public function current()
+        public function current(): mixed
         {
             if (!$this->preparedQueue) {
                 $this->rewind();
@@ -227,7 +227,7 @@ if (!is_array($this->preparedQueue)) {
          *
          * @return mixed Usually an int or string
          */
-        public function key()
+        public function key(): mixed
         {
             return $this->count;
         }
@@ -237,7 +237,7 @@ if (!is_array($this->preparedQueue)) {
          *
          * @return void
          */
-        public function next()
+        public function next(): void
         {
             $this->count--;
         }
@@ -259,7 +259,7 @@ if (!is_array($this->preparedQueue)) {
          *
          * @return void
          */
-        public function rewind()
+        public function rewind(): void
         {
             if (!$this->preparedQueue) {
                 $this->prepareQueue();
@@ -328,7 +328,7 @@ if (!is_array($this->preparedQueue)) {
          *
          * @return bool
          */
-        public function valid()
+        public function valid(): bool
         {
             return (bool) $this->count;
         }
@@ -466,7 +466,7 @@ class Zend_Stdlib_SplPriorityQueue extends SplPriorityQueue implements Serializa
      *
      * @return string
      */
-    public function serialize()
+    public function serialize(): string
     {
         $data = [];
         $this->setExtractFlags(self::EXTR_BOTH);
@@ -490,7 +490,7 @@ class Zend_Stdlib_SplPriorityQueue extends SplPriorityQueue implements Serializa
      * @param  string $data
      * @return void
      */
-    public function unserialize($data)
+    public function unserialize($data): void
     {
         foreach (unserialize($data) as $item) {
             $this->insert($item['data'], $item['priority']);

--- a/library/Zend/Tag/ItemList.php
+++ b/library/Zend/Tag/ItemList.php
@@ -45,7 +45,7 @@ class Zend_Tag_ItemList implements Countable, SeekableIterator, ArrayAccess
      *
      * @return integer
      */
-    public function count()
+    public function count(): int
     {
         return count($this->_items);
     }

--- a/library/Zend/Tag/ItemList.php
+++ b/library/Zend/Tag/ItemList.php
@@ -211,7 +211,7 @@ class Zend_Tag_ItemList implements Countable, SeekableIterator, ArrayAccess
      * @throws OutOfBoundsException When item does not implement Zend_Tag_Taggable
      * @return void
      */
-    public function offsetSet($offset, $item) {
+    public function offsetSet($offset, $item): void {
         // We need to make that check here, as the method signature must be
         // compatible with ArrayAccess::offsetSet()
         if (!($item instanceof Zend_Tag_Taggable)) {

--- a/library/Zend/Tag/ItemList.php
+++ b/library/Zend/Tag/ItemList.php
@@ -118,7 +118,7 @@ class Zend_Tag_ItemList implements Countable, SeekableIterator, ArrayAccess
      * @throws OutOfBoundsException When the seek position is invalid
      * @return void
      */
-    public function seek($index)
+    public function seek($index): void
     {
         $this->rewind();
         $position = 0;
@@ -138,7 +138,7 @@ class Zend_Tag_ItemList implements Countable, SeekableIterator, ArrayAccess
      *
      * @return mixed
      */
-    public function current()
+    public function current(): mixed
     {
         return current($this->_items);
     }
@@ -148,9 +148,9 @@ class Zend_Tag_ItemList implements Countable, SeekableIterator, ArrayAccess
      *
      * @return mixed
      */
-    public function next()
+    public function next(): void
     {
-        return next($this->_items);
+        next($this->_items);
     }
 
     /**
@@ -158,7 +158,7 @@ class Zend_Tag_ItemList implements Countable, SeekableIterator, ArrayAccess
      *
      * @return mixed
      */
-    public function key()
+    public function key(): mixed
     {
         return key($this->_items);
     }
@@ -168,7 +168,7 @@ class Zend_Tag_ItemList implements Countable, SeekableIterator, ArrayAccess
      *
      * @return boolean
      */
-    public function valid()
+    public function valid(): bool
     {
         return ($this->current() !== false);
     }
@@ -178,7 +178,7 @@ class Zend_Tag_ItemList implements Countable, SeekableIterator, ArrayAccess
      *
      * @return void
      */
-    public function rewind()
+    public function rewind(): void
     {
         reset($this->_items);
     }
@@ -189,7 +189,7 @@ class Zend_Tag_ItemList implements Countable, SeekableIterator, ArrayAccess
      * @param  mixed $offset
      * @return boolean
      */
-    public function offsetExists($offset) {
+    public function offsetExists($offset): bool {
         return array_key_exists($offset, $this->_items);
     }
 
@@ -199,7 +199,7 @@ class Zend_Tag_ItemList implements Countable, SeekableIterator, ArrayAccess
      * @param  mixed $offset
      * @return Zend_Tag_Taggable
      */
-    public function offsetGet($offset) {
+    public function offsetGet($offset): mixed {
         return $this->_items[$offset];
     }
 
@@ -232,7 +232,7 @@ class Zend_Tag_ItemList implements Countable, SeekableIterator, ArrayAccess
      * @param  mixed $offset
      * @return void
      */
-    public function offsetUnset($offset) {
+    public function offsetUnset($offset): void {
         unset($this->_items[$offset]);
     }
 }

--- a/library/Zend/TimeSync.php
+++ b/library/Zend/TimeSync.php
@@ -93,7 +93,7 @@ class Zend_TimeSync implements IteratorAggregate
      *
      * @return ArrayObject
      */
-    public function getIterator()
+    public function getIterator(): ArrayObject
     {
         return new ArrayObject($this->_timeservers);
     }

--- a/library/Zend/Tool/Framework/Action/Repository.php
+++ b/library/Zend/Tool/Framework/Action/Repository.php
@@ -120,7 +120,7 @@ class Zend_Tool_Framework_Action_Repository
      *
      * @return int
      */
-    public function count()
+    public function count(): int
     {
         return count($this->_actions);
     }

--- a/library/Zend/Tool/Framework/Action/Repository.php
+++ b/library/Zend/Tool/Framework/Action/Repository.php
@@ -130,7 +130,7 @@ class Zend_Tool_Framework_Action_Repository
      *
      * @return array
      */
-    public function getIterator()
+    public function getIterator(): ArrayObject
     {
         return new ArrayIterator($this->_actions);
     }

--- a/library/Zend/Tool/Framework/Loader/IncludePathLoader/RecursiveFilterIterator.php
+++ b/library/Zend/Tool/Framework/Loader/IncludePathLoader/RecursiveFilterIterator.php
@@ -51,7 +51,7 @@ class Zend_Tool_Framework_Loader_IncludePathLoader_RecursiveFilterIterator exten
      *
      * @return unknown
      */
-    public function accept()
+    public function accept(): bool
     {
         $currentNode = $this->current();
         $currentNodeRealPath = $currentNode->getRealPath();

--- a/library/Zend/Tool/Framework/Loader/IncludePathLoader/RecursiveFilterIterator.php
+++ b/library/Zend/Tool/Framework/Loader/IncludePathLoader/RecursiveFilterIterator.php
@@ -73,7 +73,7 @@ class Zend_Tool_Framework_Loader_IncludePathLoader_RecursiveFilterIterator exten
      *
      * @return Zend_Tool_Framework_Loader_IncludePathLoader_RecursiveFilterIterator
      */
-    public function getChildren()
+    public function getChildren(): ?Zend_Tool_Framework_Loader_IncludePathLoader_RecursiveFilterIterator
     {
         if (empty($this->ref)) {
             $this->ref = new ReflectionClass($this);

--- a/library/Zend/Tool/Framework/Manifest/Repository.php
+++ b/library/Zend/Tool/Framework/Manifest/Repository.php
@@ -295,7 +295,7 @@ class Zend_Tool_Framework_Manifest_Repository
      *
      * @return int
      */
-    public function count()
+    public function count(): int
     {
         return count($this->_metadatas);
     }

--- a/library/Zend/Tool/Framework/Manifest/Repository.php
+++ b/library/Zend/Tool/Framework/Manifest/Repository.php
@@ -305,7 +305,7 @@ class Zend_Tool_Framework_Manifest_Repository
      *
      * @return ArrayIterator
      */
-    public function getIterator()
+    public function getIterator(): ArrayObject
     {
         return new ArrayIterator($this->_metadatas);
     }

--- a/library/Zend/Tool/Framework/Provider/Repository.php
+++ b/library/Zend/Tool/Framework/Provider/Repository.php
@@ -238,7 +238,7 @@ class Zend_Tool_Framework_Provider_Repository
      *
      * @return int
      */
-    public function count()
+    public function count(): int
     {
         return count($this->_providers);
     }

--- a/library/Zend/Tool/Framework/Provider/Repository.php
+++ b/library/Zend/Tool/Framework/Provider/Repository.php
@@ -248,7 +248,7 @@ class Zend_Tool_Framework_Provider_Repository
      *
      * @return ArrayIterator
      */
-    public function getIterator()
+    public function getIterator(): ArrayIterator
     {
         return new ArrayIterator($this->getProviders());
     }

--- a/library/Zend/Tool/Project/Context/Repository.php
+++ b/library/Zend/Tool/Project/Context/Repository.php
@@ -176,7 +176,7 @@ class Zend_Tool_Project_Context_Repository implements Countable
         return $this->_contexts[$index]['isOverwritable'];
     }
 
-    public function count()
+    public function count(): int
     {
         return count($this->_contexts);
     }

--- a/library/Zend/Tool/Project/Profile.php
+++ b/library/Zend/Tool/Project/Profile.php
@@ -80,7 +80,7 @@ class Zend_Tool_Project_Profile extends Zend_Tool_Project_Profile_Resource_Conta
      *
      * @return RecursiveIteratorIterator
      */
-    public function getIterator()
+    public function getIterator(): RecursiveIteratorIterator
     {
         require_once 'Zend/Tool/Project/Profile/Iterator/EnabledResourceFilter.php';
 

--- a/library/Zend/Tool/Project/Profile/Resource/Container.php
+++ b/library/Zend/Tool/Project/Profile/Resource/Container.php
@@ -401,7 +401,7 @@ class Zend_Tool_Project_Profile_Resource_Container implements RecursiveIterator,
      *
      * @return int
      */
-    public function count()
+    public function count(): int
     {
         return count($this->_subResources);
     }

--- a/library/Zend/Tool/Project/Profile/Resource/Container.php
+++ b/library/Zend/Tool/Project/Profile/Resource/Container.php
@@ -331,7 +331,7 @@ class Zend_Tool_Project_Profile_Resource_Container implements RecursiveIterator,
      *
      * @return Zend_Tool_Project_Profile_Resource
      */
-    public function current()
+    public function current(): mixed
     {
         return current($this->_subResources);
     }
@@ -341,7 +341,7 @@ class Zend_Tool_Project_Profile_Resource_Container implements RecursiveIterator,
      *
      * @return int
      */
-    public function key()
+    public function key(): mixed
     {
         return key($this->_subResources);
     }
@@ -351,9 +351,9 @@ class Zend_Tool_Project_Profile_Resource_Container implements RecursiveIterator,
      *
      * @return bool
      */
-    public function next()
+    public function next(): void
     {
-        return next($this->_subResources);
+        next($this->_subResources);
     }
 
     /**
@@ -361,9 +361,9 @@ class Zend_Tool_Project_Profile_Resource_Container implements RecursiveIterator,
      *
      * @return bool
      */
-    public function rewind()
+    public function rewind(): void
     {
-        return reset($this->_subResources);
+        reset($this->_subResources);
     }
 
     /**
@@ -371,7 +371,7 @@ class Zend_Tool_Project_Profile_Resource_Container implements RecursiveIterator,
      *
      * @return bool
      */
-    public function valid()
+    public function valid(): bool
     {
         return (bool) $this->current();
     }
@@ -381,7 +381,7 @@ class Zend_Tool_Project_Profile_Resource_Container implements RecursiveIterator,
      *
      * @return bool
      */
-    public function hasChildren()
+    public function hasChildren(): bool
     {
         return (count($this->_subResources) > 0) ? true : false;
     }
@@ -391,7 +391,7 @@ class Zend_Tool_Project_Profile_Resource_Container implements RecursiveIterator,
      *
      * @return array
      */
-    public function getChildren()
+    public function getChildren(): ?Array
     {
         return $this->current();
     }

--- a/library/Zend/Tool/Project/Profile/Resource/Container.php
+++ b/library/Zend/Tool/Project/Profile/Resource/Container.php
@@ -391,7 +391,7 @@ class Zend_Tool_Project_Profile_Resource_Container implements RecursiveIterator,
      *
      * @return array
      */
-    public function getChildren(): ?Array
+    public function getChildren(): ?RecursiveIterator
     {
         return $this->current();
     }

--- a/library/Zend/Uri.php
+++ b/library/Zend/Uri.php
@@ -203,5 +203,5 @@ abstract class Zend_Uri
      *
      * @return boolean
      */
-    abstract public function valid();
+    abstract public function valid(): bool;
 }

--- a/library/Zend/Uri/Http.php
+++ b/library/Zend/Uri/Http.php
@@ -268,7 +268,7 @@ class Zend_Uri_Http extends Zend_Uri
      *
      * @return boolean
      */
-    public function valid()
+    public function valid(): bool
     {
         // Return true if and only if all parts of the URI have passed validation
         return $this->validateUsername()

--- a/library/Zend/View/Helper/Cycle.php
+++ b/library/Zend/View/Helper/Cycle.php
@@ -154,14 +154,13 @@ class Zend_View_Helper_Cycle implements Iterator
      *
      * @return Zend_View_Helper_Cycle
      */
-    public function next()
+    public function next(): void
     {
         $count = count($this->_data[$this->_name]);
         if ($this->_pointers[$this->_name] == ($count - 1))
             $this->_pointers[$this->_name] = 0;
         else
             $this->_pointers[$this->_name] = ++$this->_pointers[$this->_name];
-        return $this;
     }
 
     /**
@@ -184,7 +183,7 @@ class Zend_View_Helper_Cycle implements Iterator
      *
      * @return int
      */
-    public function key()
+    public function key(): mixed
     {
         if ($this->_pointers[$this->_name] < 0)
             return 0;
@@ -197,10 +196,9 @@ class Zend_View_Helper_Cycle implements Iterator
      *
      * @return Zend_View_Helper_Cycle
      */
-    public function rewind()
+    public function rewind(): void
     {
         $this->_pointers[$this->_name] = -1;
-        return $this;
     }
 
     /**
@@ -208,7 +206,7 @@ class Zend_View_Helper_Cycle implements Iterator
      *
      * @return bool
      */
-    public function valid()
+    public function valid(): bool
     {
         return isset($this->_data[$this->_name][$this->key()]);
     }
@@ -218,7 +216,7 @@ class Zend_View_Helper_Cycle implements Iterator
      *
      * @return mixed
      */
-    public function current()
+    public function current(): mixed
     {
         return $this->_data[$this->_name][$this->key()];
     }

--- a/library/Zend/View/Helper/HeadLink.php
+++ b/library/Zend/View/Helper/HeadLink.php
@@ -235,7 +235,7 @@ class Zend_View_Helper_HeadLink extends Zend_View_Helper_Placeholder_Container_S
      * @param  array $value
      * @return void
      */
-    public function offsetSet($index, $value)
+    public function offsetSet($index, $value): void
     {
         if (!$this->_isValid($value)) {
             require_once 'Zend/View/Exception.php';
@@ -244,7 +244,7 @@ class Zend_View_Helper_HeadLink extends Zend_View_Helper_Placeholder_Container_S
             throw $e;
         }
 
-        return $this->getContainer()->offsetSet($index, $value);
+        $this->getContainer()->offsetSet($index, $value);
     }
 
     /**

--- a/library/Zend/View/Helper/HeadMeta.php
+++ b/library/Zend/View/Helper/HeadMeta.php
@@ -276,7 +276,7 @@ class Zend_View_Helper_HeadMeta extends Zend_View_Helper_Placeholder_Container_S
      * @return void
      * @throws Zend_View_Exception
      */
-    public function offsetUnset($index)
+    public function offsetUnset($index): void
     {
         if (!in_array($index, $this->getContainer()->getKeys())) {
             require_once 'Zend/View/Exception.php';
@@ -285,7 +285,7 @@ class Zend_View_Helper_HeadMeta extends Zend_View_Helper_Placeholder_Container_S
             throw $e;
         }
 
-        return $this->getContainer()->offsetUnset($index);
+        $this->getContainer()->offsetUnset($index);
     }
 
     /**

--- a/library/Zend/View/Helper/HeadMeta.php
+++ b/library/Zend/View/Helper/HeadMeta.php
@@ -257,7 +257,7 @@ class Zend_View_Helper_HeadMeta extends Zend_View_Helper_Placeholder_Container_S
      * @return void
      * @throws Zend_View_Exception
      */
-    public function offsetSet($index, $value)
+    public function offsetSet($index, $value): void
     {
         if (!$this->_isValid($value)) {
             require_once 'Zend/View/Exception.php';
@@ -266,7 +266,7 @@ class Zend_View_Helper_HeadMeta extends Zend_View_Helper_Placeholder_Container_S
             throw $e;
         }
 
-        return $this->getContainer()->offsetSet($index, $value);
+        $this->getContainer()->offsetSet($index, $value);
     }
 
     /**

--- a/library/Zend/View/Helper/HeadScript.php
+++ b/library/Zend/View/Helper/HeadScript.php
@@ -370,7 +370,7 @@ class Zend_View_Helper_HeadScript extends Zend_View_Helper_Placeholder_Container
      * @param  mixed $value
      * @return void
      */
-    public function offsetSet($index, $value)
+    public function offsetSet($index, $value): void
     {
         if (!$this->_isValid($value)) {
             require_once 'Zend/View/Exception.php';
@@ -379,7 +379,7 @@ class Zend_View_Helper_HeadScript extends Zend_View_Helper_Placeholder_Container
             throw $e;
         }
 
-        return $this->getContainer()->offsetSet($index, $value);
+        $this->getContainer()->offsetSet($index, $value);
     }
 
     /**

--- a/library/Zend/View/Helper/HeadStyle.php
+++ b/library/Zend/View/Helper/HeadStyle.php
@@ -220,7 +220,7 @@ class Zend_View_Helper_HeadStyle extends Zend_View_Helper_Placeholder_Container_
      * @param  mixed $value
      * @return void
      */
-    public function offsetSet($index, $value)
+    public function offsetSet($index, $value): void
     {
         if (!$this->_isValid($value)) {
             require_once 'Zend/View/Exception.php';
@@ -229,7 +229,7 @@ class Zend_View_Helper_HeadStyle extends Zend_View_Helper_Placeholder_Container_
             throw $e;
         }
 
-        return $this->getContainer()->offsetSet($index, $value);
+        $this->getContainer()->offsetSet($index, $value);
     }
 
     /**

--- a/library/Zend/View/Helper/Placeholder/Container/Standalone.php
+++ b/library/Zend/View/Helper/Placeholder/Container/Standalone.php
@@ -261,7 +261,7 @@ abstract class Zend_View_Helper_Placeholder_Container_Standalone extends Zend_Vi
      *
      * @return int
      */
-    public function count()
+    public function count(): int
     {
         $container = $this->getContainer();
         return count($container);

--- a/library/Zend/View/Helper/Placeholder/Container/Standalone.php
+++ b/library/Zend/View/Helper/Placeholder/Container/Standalone.php
@@ -273,7 +273,7 @@ abstract class Zend_View_Helper_Placeholder_Container_Standalone extends Zend_Vi
      * @param  string|int $offset
      * @return bool
      */
-    public function offsetExists($offset)
+    public function offsetExists($offset): bool
     {
         return $this->getContainer()->offsetExists($offset);
     }
@@ -284,7 +284,7 @@ abstract class Zend_View_Helper_Placeholder_Container_Standalone extends Zend_Vi
      * @param  string|int $offset
      * @return mixed
      */
-    public function offsetGet($offset)
+    public function offsetGet($offset): mixed
     {
         return $this->getContainer()->offsetGet($offset);
     }
@@ -296,9 +296,9 @@ abstract class Zend_View_Helper_Placeholder_Container_Standalone extends Zend_Vi
      * @param  mixed $value
      * @return void
      */
-    public function offsetSet($offset, $value)
+    public function offsetSet($offset, $value): void
     {
-        return $this->getContainer()->offsetSet($offset, $value);
+        $this->getContainer()->offsetSet($offset, $value);
     }
 
     /**
@@ -307,9 +307,9 @@ abstract class Zend_View_Helper_Placeholder_Container_Standalone extends Zend_Vi
      * @param  string|int $offset
      * @return void
      */
-    public function offsetUnset($offset)
+    public function offsetUnset($offset): void
     {
-        return $this->getContainer()->offsetUnset($offset);
+        $this->getContainer()->offsetUnset($offset);
     }
 
     /**
@@ -317,7 +317,7 @@ abstract class Zend_View_Helper_Placeholder_Container_Standalone extends Zend_Vi
      *
      * @return Iterator
      */
-    public function getIterator()
+    public function getIterator(): Traversable
     {
         return $this->getContainer()->getIterator();
     }

--- a/tests/Zend/Dojo/DataTest.php
+++ b/tests/Zend/Dojo/DataTest.php
@@ -554,27 +554,27 @@ class Zend_Dojo_DataTest_DataCollection implements Iterator
         }
     }
 
-    public function current()
+    public function current(): mixed
     {
         return current($this->items);
     }
 
-    public function key()
+    public function key(): mixed
     {
         return key($this->items);
     }
 
-    public function next()
+    public function next(): void
     {
-        return next($this->items);
+        next($this->items);
     }
 
-    public function rewind()
+    public function rewind(): bool
     {
-        return reset($this->items);
+        reset($this->items);
     }
 
-    public function valid()
+    public function valid(): bool
     {
         return (bool) $this->current();
     }

--- a/tests/Zend/JsonTest.php
+++ b/tests/Zend/JsonTest.php
@@ -1043,7 +1043,7 @@ class ZF12347_IteratorAggregate implements IteratorAggregate
         'baz' => 5
     ];
 
-    public function getIterator() {
+    public function getIterator(): ArrayIterator {
         return new ArrayIterator($this->array);
     }
 }

--- a/tests/Zend/Loader/TestAsset/TestPluginMap.php
+++ b/tests/Zend/Loader/TestAsset/TestPluginMap.php
@@ -46,7 +46,7 @@ class ZendTest_Loader_TestAsset_TestPluginMap implements IteratorAggregate
      * 
      * @return Traversable
      */
-    public function getIterator()
+    public function getIterator(): ArrayIterator
     {
         return new ArrayIterator($this->map);
     }

--- a/tests/Zend/Queue/Custom/Messages.php
+++ b/tests/Zend/Queue/Custom/Messages.php
@@ -109,7 +109,7 @@ implements ArrayAccess
     /**
      * @see SPL ArrayIterator::append
      */
-    public function append($value) {
+    public function append($value): void {
         $this->_data[] = $value;
     }
 
@@ -120,7 +120,7 @@ implements ArrayAccess
     /**
      * @see SPL ArrayAccess::offsetSet
      */
-    public function offsetSet($offset, $value) {
+    public function offsetSet($offset, $value): void {
         if (! $value instanceof Custom_Message) {
             $msg = '$value must be a child or an instance of Custom_Messag';
             /**
@@ -131,20 +131,19 @@ implements ArrayAccess
         }
 
         $this->_data[$offset] = $value;
-        return $value;
     }
 
     /**
      * @see SPL ArrayAccess::offsetGet
      */
-    public function offsetGet($offset) {
+    public function offsetGet($offset): mixed {
         return $this->_data[$offset];
     }
 
     /**
      * @see SPL ArrayAccess::offsetUnset
      */
-    public function offsetUnset($offset) {
+    public function offsetUnset($offset): void {
         if (! $this->_connected) {
             $msg = 'Cannot delete message after serialization';
             /**
@@ -161,7 +160,7 @@ implements ArrayAccess
     /**
      * @see SPL ArrayAccess::offsetExists
      */
-    public function offsetExists($offset) {
+    public function offsetExists($offset): bool {
         return isSet($this->_data[$offset]);
     }
 
@@ -172,7 +171,7 @@ implements ArrayAccess
     /**
      * @see SPL SeekableIterator::seek
      */
-    public function seek($index) {
+    public function seek($index): void {
         $this->_pointer = $index;
     }
 }

--- a/tests/Zend/View/Helper/PartialLoopTest.php
+++ b/tests/Zend/View/Helper/PartialLoopTest.php
@@ -411,27 +411,27 @@ class Zend_View_Helper_PartialLoop_IteratorTest implements Iterator
         $this->items = $array;
     }
 
-    public function current()
+    public function current(): mixed
     {
         return current($this->items);
     }
 
-    public function key()
+    public function key(): mixed
     {
         return key($this->items);
     }
 
-    public function next()
+    public function next(): void
     {
-        return next($this->items);
+        next($this->items);
     }
 
-    public function rewind()
+    public function rewind(): void
     {
-        return reset($this->items);
+        reset($this->items);
     }
 
-    public function valid()
+    public function valid(): bool
     {
         return (current($this->items) !== false);
     }
@@ -457,27 +457,27 @@ class Zend_View_Helper_PartialLoop_RecursiveIteratorTest implements Iterator
         return $this;
     }
 
-    public function current()
+    public function current(): mixed
     {
         return current($this->items);
     }
 
-    public function key()
+    public function key(): mixed
     {
         return key($this->items);
     }
 
-    public function next()
+    public function next(): void
     {
-        return next($this->items);
+        next($this->items);
     }
 
-    public function rewind()
+    public function rewind(): void
     {
-        return reset($this->items);
+        reset($this->items);
     }
 
-    public function valid()
+    public function valid(): bool
     {
         return (current($this->items) !== false);
     }
@@ -514,27 +514,27 @@ class Zend_View_Helper_PartialLoop_IteratorWithToArrayTest implements Iterator
         return $this->items;
     }
 
-    public function current()
+    public function current(): mixed
     {
         return current($this->items);
     }
 
-    public function key()
+    public function key(): mixed
     {
         return key($this->items);
     }
 
-    public function next()
+    public function next(): void
     {
-        return next($this->items);
+        next($this->items);
     }
 
-    public function rewind()
+    public function rewind(): void
     {
-        return reset($this->items);
+        reset($this->items);
     }
 
-    public function valid()
+    public function valid(): bool
     {
         return (current($this->items) !== false);
     }


### PR DESCRIPTION
 PHP 8.1 compatibility
- added return type for Countable::count
- added return type for methods offsetExists,offsetGet,offsetSet,offsetUnset (interface ArrayAccess)
- added return type for methods rewind(),current(),key(),next(),valid() (interface Iterator)
- added return type for SeekableIterator::seek()
- added return type for methods getChildren(),hasChildren() (interface RecursiveFilterIterator)
- added return type for IteratorAggregate::getIterator()
- added return type for methods serialize(),unserialize() (interface Serializable)
- removed "return" in rewind(),next() methods