### PR TITLE
Remove support for legacy and risky HTTP headers

### DIFF
--- a/library/Zend/Controller/Request/Http.php
+++ b/library/Zend/Controller/Request/Http.php
@@ -382,7 +382,7 @@ class Zend_Controller_Request_Http extends Zend_Controller_Request_Abstract
      * Set the REQUEST_URI on which the instance operates
      *
      * If no request URI is passed, uses the value in $_SERVER['REQUEST_URI'],
-     * $_SERVER['HTTP_X_REWRITE_URL'], or $_SERVER['ORIG_PATH_INFO'] + $_SERVER['QUERY_STRING'].
+     *  or $_SERVER['ORIG_PATH_INFO'] + $_SERVER['QUERY_STRING'].
      *
      * @param string $requestUri
      * @return Zend_Controller_Request_Http
@@ -390,13 +390,7 @@ class Zend_Controller_Request_Http extends Zend_Controller_Request_Abstract
     public function setRequestUri($requestUri = null)
     {
         if ($requestUri === null) {
-            if (isset($_SERVER['HTTP_X_ORIGINAL_URL'])) {
-                // IIS with Microsoft Rewrite Module
-                $requestUri = $_SERVER['HTTP_X_ORIGINAL_URL'];
-            } elseif (isset($_SERVER['HTTP_X_REWRITE_URL'])) {
-                // IIS with ISAPI_Rewrite
-                $requestUri = $_SERVER['HTTP_X_REWRITE_URL'];
-            } elseif (
+            if (
                 // IIS7 with URL Rewrite: make sure we get the unencoded url (double slash problem)
                 isset($_SERVER['IIS_WasUrlRewritten'])
                 && $_SERVER['IIS_WasUrlRewritten'] == '1'

--- a/tests/Zend/Controller/Request/HttpTest.php
+++ b/tests/Zend/Controller/Request/HttpTest.php
@@ -534,35 +534,6 @@ class Zend_Controller_Request_HttpTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('/index.php', $request->getBaseUrl());
     }
 
-    public function testSetBaseUrlAutoDiscoveryUsingXRewriteUrl()
-    {
-        unset($_SERVER['REQUEST_URI']);
-        $_SERVER['HTTP_X_REWRITE_URL'] = '/index.php/news/3?var1=val1&var2=val2';
-        $_SERVER['PHP_SELF']           = '/index.php/news/3';
-        $_SERVER['SCRIPT_FILENAME']    = '/var/web/html/index.php';
-        $_GET = [
-            'var1' => 'val1',
-            'var2' => 'val2'
-        ];
-        $request = new Zend_Controller_Request_Http();
-
-        $this->assertEquals('/index.php', $request->getBaseUrl());
-    }
-
-    public function testSetBaseUrlAutoDiscoveryUsingXOriginalUrl()
-    {
-        unset($_SERVER['REQUEST_URI']);
-        $_SERVER['HTTP_X_ORIGINAL_URL'] = '/index.php/news/3?var1=val1&var2=val2';
-        $_SERVER['PHP_SELF']           = '/index.php/news/3';
-        $_SERVER['SCRIPT_FILENAME']    = '/var/web/html/index.php';
-        $_GET = [
-            'var1' => 'val1',
-            'var2' => 'val2'
-        ];
-        $request = new Zend_Controller_Request_Http();
-
-        $this->assertEquals('/index.php', $request->getBaseUrl());
-    }
 
     public function testSetBaseUrlAutoDiscoveryUsingOrigPathInfo()
     {


### PR DESCRIPTION
https://symfony.com/blog/cve-2018-14773-remove-support-for-legacy-and-risky-http-headers
https://github.com/symfony/symfony/commit/e447e8b92148ddb3d1956b96638600ec95e08f6b