### PR TITLE
Update PDOStatement::fetch for PHP 8.1

### DIFF
--- a/library/Zend/Db/Statement/Pdo.php
+++ b/library/Zend/Db/Statement/Pdo.php
@@ -245,7 +245,7 @@ class Zend_Db_Statement_Pdo extends Zend_Db_Statement implements IteratorAggrega
      * @return mixed Array, object, or scalar depending on fetch mode.
      * @throws Zend_Db_Statement_Exception
      */
-    public function fetch($style = null, $cursor = null, $offset = null)
+    public function fetch($style = null, $cursor = \PDO::FETCH_ORI_NEXT, $offset = 0)
     {
         if ($style === null) {
             $style = $this->_fetchMode;


### PR DESCRIPTION
This PR try to fix:
```
Deprecated functionality: PDOStatement::fetch(): Passing null to parameter #2 ($cursorOrientation)
  of type int is deprecated in lib/Zend/Db/Statement/Pdo.php on line 254
```

Solution found here: https://github.com/matomo-org/matomo/pull/17689
It seems to work with PHP 7.2+ (not tested with 7 or 7.1).