### PR TITLE
PHP 8.1: Resolve deprecation notices in several classes

### DIFF
--- a/library/Zend/EventManager/ResponseCollection.php
+++ b/library/Zend/EventManager/ResponseCollection.php
@@ -283,7 +283,12 @@ if (version_compare(PHP_VERSION, '5.3.0', '<')) {
          */
         public function serialize(): ?string
         {
-            return serialize($this->data);
+            return serialize($this->__serialize());
+        }
+
+        public function __serialize(): array
+        {
+            return $this->data;
         }
 
         /**
@@ -321,7 +326,12 @@ if (version_compare(PHP_VERSION, '5.3.0', '<')) {
          */
         public function unserialize($serialized): void
         {
-            $this->data  = unserialize($serialized);
+            $this->__unserialize(unserialize($serialized));
+        }
+
+        public function __unserialize(array $data): void
+        {
+            $this->data = $data;
             $this->stack = false;
         }
 

--- a/library/Zend/File/ClassFileLocator.php
+++ b/library/Zend/File/ClassFileLocator.php
@@ -81,7 +81,7 @@ class Zend_File_ClassFileLocator extends FilterIterator
      *
      * @return bool
      */
-    public function accept()
+    public function accept(): bool
     {
         $file = $this->getInnerIterator()->current();
         // If we somehow have something other than an SplFileInfo object, just

--- a/library/Zend/Http/UserAgent.php
+++ b/library/Zend/Http/UserAgent.php
@@ -171,6 +171,11 @@ class Zend_Http_UserAgent implements Serializable
      */
     public function serialize(): ?string
     {
+        return serialize($this->__serialize());
+    }
+
+    public function __serialize(): array
+    {
         $device = $this->getDevice();
         $spec = [
             'browser_type' => $this->_browserType,
@@ -180,7 +185,7 @@ class Zend_Http_UserAgent implements Serializable
             'user_agent'   => $this->getServerValue('http_user_agent'),
             'http_accept'  => $this->getServerValue('http_accept'),
         ];
-        return serialize($spec);
+        return $spec;
     }
 
     /**
@@ -191,8 +196,11 @@ class Zend_Http_UserAgent implements Serializable
      */
     public function unserialize($serialized): void
     {
-        $spec = unserialize($serialized);
+        $this->__unserialize(unserialize($serialized));
+    }
 
+    public function __unserialize(array $spec): void
+    {
         $this->setOptions($spec);
 
         // Determine device class and ensure the class is loaded

--- a/library/Zend/Http/UserAgent/AbstractDevice.php
+++ b/library/Zend/Http/UserAgent/AbstractDevice.php
@@ -126,6 +126,11 @@ abstract class Zend_Http_UserAgent_AbstractDevice
      */
     public function serialize(): ?string
     {
+        return serialize($this->__serialize());
+    }
+
+    public function __serialize(): array
+    {
         $spec = [
             '_aFeatures'      => $this->_aFeatures,
             '_aGroup'         => $this->_aGroup,
@@ -134,7 +139,7 @@ abstract class Zend_Http_UserAgent_AbstractDevice
             '_userAgent'      => $this->_userAgent,
             '_images'         => $this->_images,
         ];
-        return serialize($spec);
+        return $spec;
     }
 
     /**
@@ -145,7 +150,11 @@ abstract class Zend_Http_UserAgent_AbstractDevice
      */
     public function unserialize($serialized): void
     {
-        $spec = unserialize($serialized);
+        $this->__unserialize(unserialize($serialized));
+    }
+
+    public function __unserialize(array $spec): void
+    {
         $this->_restoreFromArray($spec);
     }
 

--- a/library/Zend/Ldap/Node.php
+++ b/library/Zend/Ldap/Node.php
@@ -1012,7 +1012,7 @@ class Zend_Ldap_Node extends Zend_Ldap_Node_Abstract implements Iterator, Recurs
      * @return boolean
      * @throws Zend_Ldap_Exception
      */
-    public function hasChildren()
+    public function hasChildren(): bool
     {
         if (!is_array($this->_children)) {
             if ($this->isAttached()) {
@@ -1033,7 +1033,7 @@ class Zend_Ldap_Node extends Zend_Ldap_Node_Abstract implements Iterator, Recurs
      * @return Zend_Ldap_Node_ChildrenIterator
      * @throws Zend_Ldap_Exception
      */
-    public function getChildren()
+    public function getChildren(): ?\RecursiveIterator
     {
         if (!is_array($this->_children)) {
             $this->_children = [];

--- a/library/Zend/Ldap/Node/ChildrenIterator.php
+++ b/library/Zend/Ldap/Node/ChildrenIterator.php
@@ -125,7 +125,7 @@ class Zend_Ldap_Node_ChildrenIterator implements Iterator, Countable, RecursiveI
      *
      * @return boolean
      */
-    public function hasChildren()
+    public function hasChildren(): bool
     {
         if ($this->current() instanceof Zend_Ldap_Node) {
             return $this->current()->hasChildren();
@@ -139,7 +139,7 @@ class Zend_Ldap_Node_ChildrenIterator implements Iterator, Countable, RecursiveI
      *
      * @return Zend_Ldap_Node_ChildrenIterator
      */
-    public function getChildren()
+    public function getChildren(): ?\RecursiveIterator
     {
         if ($this->current() instanceof Zend_Ldap_Node) {
             return $this->current()->getChildren();

--- a/library/Zend/Mail/Part.php
+++ b/library/Zend/Mail/Part.php
@@ -509,7 +509,7 @@ class Zend_Mail_Part implements RecursiveIterator, Zend_Mail_Part_Interface
      *
      * @return bool current element has children/is multipart
      */
-    public function hasChildren()
+    public function hasChildren(): bool
     {
         $current = $this->current();
         return $current && $current instanceof Zend_Mail_Part && $current->isMultipart();
@@ -520,7 +520,7 @@ class Zend_Mail_Part implements RecursiveIterator, Zend_Mail_Part_Interface
      *
      * @return Zend_Mail_Part same as self::current()
      */
-    public function getChildren()
+    public function getChildren(): ?\RecursiveIterator
     {
         return $this->current();
     }

--- a/library/Zend/Mail/Storage/Folder.php
+++ b/library/Zend/Mail/Storage/Folder.php
@@ -75,7 +75,7 @@ class Zend_Mail_Storage_Folder implements RecursiveIterator
      *
      * @return bool current element has children
      */
-    public function hasChildren()
+    public function hasChildren(): bool
     {
         $current = $this->current();
         return $current && $current instanceof Zend_Mail_Storage_Folder && !$current->isLeaf();
@@ -86,7 +86,7 @@ class Zend_Mail_Storage_Folder implements RecursiveIterator
      *
      * @return Zend_Mail_Storage_Folder same as self::current()
      */
-    public function getChildren()
+    public function getChildren(): ?\RecursiveIterator
     {
         return $this->current();
     }

--- a/library/Zend/Markup/TokenList.php
+++ b/library/Zend/Markup/TokenList.php
@@ -56,7 +56,7 @@ class Zend_Markup_TokenList implements RecursiveIterator
      *
      * @return Zend_Markup_TokenList
      */
-    public function getChildren()
+    public function getChildren(): ?\RecursiveIterator
     {
         return current($this->_tokens)->getChildren();
     }
@@ -78,7 +78,7 @@ class Zend_Markup_TokenList implements RecursiveIterator
      *
      * @return bool
      */
-    public function hasChildren()
+    public function hasChildren(): bool
     {
         return current($this->_tokens)->hasChildren();
     }

--- a/library/Zend/Navigation/Container.php
+++ b/library/Zend/Navigation/Container.php
@@ -586,7 +586,7 @@ abstract class Zend_Navigation_Container implements RecursiveIterator, Countable
      *
      * @return bool  whether container has any pages
      */
-    public function hasChildren()
+    public function hasChildren(): bool
     {
         return $this->hasPages();
     }
@@ -598,7 +598,7 @@ abstract class Zend_Navigation_Container implements RecursiveIterator, Countable
      *
      * @return Zend_Navigation_Page|null
      */
-    public function getChildren()
+    public function getChildren(): ?\RecursiveIterator
     {
         $hash = key($this->_index);
 

--- a/library/Zend/Paginator/SerializableLimitIterator.php
+++ b/library/Zend/Paginator/SerializableLimitIterator.php
@@ -62,12 +62,17 @@ class Zend_Paginator_SerializableLimitIterator extends LimitIterator implements 
      */
     public function serialize(): ?string
     {
-        return serialize([
+        return serialize($this->__serialize());
+    }
+
+    public function __serialize(): array
+    {
+        return [
             'it'     => $this->getInnerIterator(),
             'offset' => $this->_offset,
             'count'  => $this->_count,
             'pos'    => $this->getPosition(),
-        ]);
+        ];
     }
 
     /**
@@ -76,6 +81,11 @@ class Zend_Paginator_SerializableLimitIterator extends LimitIterator implements 
     public function unserialize($data): void
     {
         $dataArr = unserialize($data);
+        $this->__unserialize($dataArr);
+    }
+
+    public function __unserialize(array $dataArr): void
+    {
         $this->__construct($dataArr['it'], $dataArr['offset'], $dataArr['count']);
         $this->seek($dataArr['pos']+$dataArr['offset']);
     }

--- a/library/Zend/Pdf/Action.php
+++ b/library/Zend/Pdf/Action.php
@@ -376,7 +376,7 @@ abstract class Zend_Pdf_Action extends Zend_Pdf_Target implements RecursiveItera
      *
      * @return Zend_Pdf_Action|null
      */
-    public function getChildren()
+    public function getChildren(): ?\RecursiveIterator
     {
         return current($this->next);
     }
@@ -386,7 +386,7 @@ abstract class Zend_Pdf_Action extends Zend_Pdf_Target implements RecursiveItera
      *
      * @return bool  whether container has any pages
      */
-    public function hasChildren()
+    public function hasChildren(): bool
     {
         return count($this->next) > 0;
     }

--- a/library/Zend/Pdf/Outline.php
+++ b/library/Zend/Pdf/Outline.php
@@ -345,7 +345,7 @@ abstract class Zend_Pdf_Outline implements RecursiveIterator, Countable
      *
      * @return Zend_Pdf_Outline|null
      */
-    public function getChildren()
+    public function getChildren(): ?\RecursiveIterator
     {
         return current($this->childOutlines);
     }
@@ -355,7 +355,7 @@ abstract class Zend_Pdf_Outline implements RecursiveIterator, Countable
      *
      * @return bool  whether container has any pages
      */
-    public function hasChildren()
+    public function hasChildren(): bool
     {
         return count($this->childOutlines) > 0;
     }

--- a/library/Zend/Pdf/RecursivelyIteratableObjectsContainer.php
+++ b/library/Zend/Pdf/RecursivelyIteratableObjectsContainer.php
@@ -42,8 +42,8 @@ class Zend_Pdf_RecursivelyIteratableObjectsContainer implements RecursiveIterato
     #[\ReturnTypeWillChange]
     public function rewind()       { return reset($this->_objects);              }
     public function valid(): bool  { return current($this->_objects) !== false;  }
-    public function getChildren()  { return current($this->_objects);            }
-    public function hasChildren()  { return count($this->_objects) > 0;          }
+    public function getChildren(): ?RecursiveIterator  { return current($this->_objects); }
+    public function hasChildren(): bool  { return count($this->_objects) > 0;    }
 
     public function count(): int   { return count($this->_objects);              }
 }

--- a/library/Zend/Reflection/Class.php
+++ b/library/Zend/Reflection/Class.php
@@ -85,6 +85,7 @@ class Zend_Reflection_Class extends ReflectionClass
      * @param bool $includeDocComment
      * @return int
      */
+    #[\ReturnTypeWillChange]
     public function getStartLine($includeDocComment = false)
     {
         if ($includeDocComment) {
@@ -118,7 +119,7 @@ class Zend_Reflection_Class extends ReflectionClass
      * @param  string $reflectionClass Name of reflection class to use
      * @return array Array of Zend_Reflection_Class
      */
-    public function getInterfaces($reflectionClass = 'Zend_Reflection_Class')
+    public function getInterfaces($reflectionClass = 'Zend_Reflection_Class'): array
     {
         $phpReflections  = parent::getInterfaces();
         $zendReflections = [];
@@ -142,7 +143,7 @@ class Zend_Reflection_Class extends ReflectionClass
      * @param  string $reflectionClass Reflection class to utilize
      * @return Zend_Reflection_Method
      */
-    public function getMethod($name, $reflectionClass = 'Zend_Reflection_Method')
+    public function getMethod($name, $reflectionClass = 'Zend_Reflection_Method'): \ReflectionMethod
     {
         $phpReflection  = parent::getMethod($name);
         $zendReflection = new $reflectionClass($this->getName(), $phpReflection->getName());
@@ -163,7 +164,7 @@ class Zend_Reflection_Class extends ReflectionClass
      * @param  string $reflectionClass Reflection class to use for methods
      * @return array Array of Zend_Reflection_Method objects
      */
-    public function getMethods($filter = -1, $reflectionClass = 'Zend_Reflection_Method')
+    public function getMethods($filter = -1, $reflectionClass = 'Zend_Reflection_Method'): array
     {
         $phpReflections  = parent::getMethods($filter);
         $zendReflections = [];
@@ -186,6 +187,7 @@ class Zend_Reflection_Class extends ReflectionClass
      * @param  string $reflectionClass Name of Reflection class to use
      * @return Zend_Reflection_Class
      */
+    #[\ReturnTypeWillChange]
     public function getParentClass($reflectionClass = 'Zend_Reflection_Class')
     {
         $phpReflection = parent::getParentClass();
@@ -209,7 +211,7 @@ class Zend_Reflection_Class extends ReflectionClass
      * @param  string $reflectionClass Name of reflection class to use
      * @return Zend_Reflection_Property
      */
-    public function getProperty($name, $reflectionClass = 'Zend_Reflection_Property')
+    public function getProperty($name, $reflectionClass = 'Zend_Reflection_Property'): \ReflectionProperty
     {
         $phpReflection  = parent::getProperty($name);
         $zendReflection = new $reflectionClass($this->getName(), $phpReflection->getName());
@@ -228,7 +230,7 @@ class Zend_Reflection_Class extends ReflectionClass
      * @param  string $reflectionClass Name of reflection class to use
      * @return array Array of Zend_Reflection_Property
      */
-    public function getProperties($filter = -1, $reflectionClass = 'Zend_Reflection_Property')
+    public function getProperties($filter = -1, $reflectionClass = 'Zend_Reflection_Property'): array
     {
         $phpReflections = parent::getProperties($filter);
         $zendReflections = [];

--- a/library/Zend/Reflection/Extension.php
+++ b/library/Zend/Reflection/Extension.php
@@ -43,7 +43,7 @@ class Zend_Reflection_Extension extends ReflectionExtension
      * @param  string $reflectionClass Name of reflection class to use
      * @return array Array of Zend_Reflection_Function objects
      */
-    public function getFunctions($reflectionClass = 'Zend_Reflection_Function')
+    public function getFunctions($reflectionClass = 'Zend_Reflection_Function'): array
     {
         $phpReflections  = parent::getFunctions();
         $zendReflections = [];
@@ -66,7 +66,7 @@ class Zend_Reflection_Extension extends ReflectionExtension
      * @param  string $reflectionClass Name of reflection class to use
      * @return array Array of Zend_Reflection_Class objects
      */
-    public function getClasses($reflectionClass = 'Zend_Reflection_Class')
+    public function getClasses($reflectionClass = 'Zend_Reflection_Class'): array
     {
         $phpReflections  = parent::getClasses();
         $zendReflections = [];

--- a/library/Zend/Reflection/Function.php
+++ b/library/Zend/Reflection/Function.php
@@ -58,6 +58,7 @@ class Zend_Reflection_Function extends ReflectionFunction
      * @param  bool $includeDocComment
      * @return int
      */
+    #[\ReturnTypeWillChange]
     public function getStartLine($includeDocComment = false)
     {
         if ($includeDocComment) {
@@ -93,7 +94,7 @@ class Zend_Reflection_Function extends ReflectionFunction
      * @param  string $reflectionClass Name of reflection class to use
      * @return array Array of Zend_Reflection_Parameter
      */
-    public function getParameters($reflectionClass = 'Zend_Reflection_Parameter')
+    public function getParameters($reflectionClass = 'Zend_Reflection_Parameter'): array
     {
         $phpReflections  = parent::getParameters();
         $zendReflections = [];

--- a/library/Zend/Reflection/Method.php
+++ b/library/Zend/Reflection/Method.php
@@ -69,6 +69,7 @@ class Zend_Reflection_Method extends ReflectionMethod
      * @param  bool $includeDocComment
      * @return int
      */
+    #[\ReturnTypeWillChange]
     public function getStartLine($includeDocComment = false)
     {
         if ($includeDocComment) {
@@ -86,7 +87,7 @@ class Zend_Reflection_Method extends ReflectionMethod
      * @param  string $reflectionClass Name of reflection class to use
      * @return Zend_Reflection_Class
      */
-    public function getDeclaringClass($reflectionClass = 'Zend_Reflection_Class')
+    public function getDeclaringClass($reflectionClass = 'Zend_Reflection_Class'): \ReflectionClass
     {
         $phpReflection  = parent::getDeclaringClass();
         $zendReflection = new $reflectionClass($phpReflection->getName());
@@ -104,7 +105,7 @@ class Zend_Reflection_Method extends ReflectionMethod
      * @param  string $reflectionClass Name of reflection class to use
      * @return array of Zend_Reflection_Parameter objects
      */
-    public function getParameters($reflectionClass = 'Zend_Reflection_Parameter')
+    public function getParameters($reflectionClass = 'Zend_Reflection_Parameter'): array
     {
         $phpReflections  = parent::getParameters();
         $zendReflections = [];

--- a/library/Zend/Reflection/Parameter.php
+++ b/library/Zend/Reflection/Parameter.php
@@ -38,7 +38,7 @@ class Zend_Reflection_Parameter extends ReflectionParameter
      * @param  string $reflectionClass Reflection class to use
      * @return Zend_Reflection_Class
      */
-    public function getDeclaringClass($reflectionClass = 'Zend_Reflection_Class')
+    public function getDeclaringClass($reflectionClass = 'Zend_Reflection_Class'): ?\ReflectionClass
     {
         $phpReflection  = parent::getDeclaringClass();
         $zendReflection = new $reflectionClass($phpReflection->getName());
@@ -56,7 +56,7 @@ class Zend_Reflection_Parameter extends ReflectionParameter
      * @param  string $reflectionClass Reflection class to use
      * @return Zend_Reflection_Class
      */
-    public function getClass($reflectionClass = 'Zend_Reflection_Class')
+    public function getClass($reflectionClass = 'Zend_Reflection_Class'): ?\ReflectionClass
     {
         if (PHP_VERSION_ID < 80000) {
             $phpReflection  = parent::getClass();
@@ -86,7 +86,7 @@ class Zend_Reflection_Parameter extends ReflectionParameter
      * @param  string $reflectionClass Reflection class to use
      * @return Zend_Reflection_Function|Zend_Reflection_Method
      */
-    public function getDeclaringFunction($reflectionClass = null)
+    public function getDeclaringFunction($reflectionClass = null): \ReflectionFunctionAbstract
     {
         $phpReflection = parent::getDeclaringFunction();
         if ($phpReflection instanceof ReflectionMethod) {
@@ -115,7 +115,7 @@ class Zend_Reflection_Parameter extends ReflectionParameter
      *
      * @return string
      */
-    public function getType()
+    public function getType(): ?\ReflectionType
     {
         try {
             if ($docblock = $this->getDeclaringFunction()->getDocblock()) {

--- a/library/Zend/Reflection/Property.php
+++ b/library/Zend/Reflection/Property.php
@@ -33,7 +33,7 @@ class Zend_Reflection_Property extends ReflectionProperty
      *
      * @return Zend_Reflection_Class
      */
-    public function getDeclaringClass($reflectionClass = 'Zend_Reflection_Class')
+    public function getDeclaringClass($reflectionClass = 'Zend_Reflection_Class'): \ReflectionClass
     {
         $phpReflection  = parent::getDeclaringClass();
         $zendReflection = new $reflectionClass($phpReflection->getName());
@@ -51,6 +51,7 @@ class Zend_Reflection_Property extends ReflectionProperty
      * @param  string $reflectionClass
      * @return Zend_Reflection_Docblock|false False if no docblock defined
      */
+    #[\ReturnTypeWillChange]
     public function getDocComment($reflectionClass = 'Zend_Reflection_Docblock')
     {
         $docblock = parent::getDocComment();

--- a/library/Zend/Service/Console/Command.php
+++ b/library/Zend/Service/Console/Command.php
@@ -363,7 +363,7 @@ class Zend_Service_Console_Command
 	 * @command-name -help
 	 * @command-description Displays the current help information.
 	 */
-	public function helpCommand() {
+	public function helpCommand(...$args) {
 		$handler = $this->getHandler();
 		$newline = "\r\n";
 

--- a/library/Zend/Service/WindowsAzure/CommandLine/Certificate.php
+++ b/library/Zend/Service/WindowsAzure/CommandLine/Certificate.php
@@ -144,7 +144,7 @@ class Zend_Service_WindowsAzure_CommandLine_Certificate
 	 * @command-example Get certificate for service name "phptest":
 	 * @command-example Get -sid:"<your_subscription_id>" -cert:"mycert.pem" -sn:"phptest" --CertificateThumbprint:"<thumbprint>" --CertificateAlgorithm:"sha1"
 	 */
-	public function getCertificatePropertyCommand($subscriptionId, $certificate, $certificatePassphrase, $serviceName, $thumbprint, $algorithm = "sha1", $property)
+	public function getCertificatePropertyCommand($subscriptionId, $certificate, $certificatePassphrase, $serviceName, $thumbprint, $algorithm, $property)
 	{
 		$client = new Zend_Service_WindowsAzure_Management_Client($subscriptionId, $certificate, $certificatePassphrase);
 		$result = $client->getCertificate($serviceName, $algorithm, $thumbprint);

--- a/library/Zend/Service/WindowsAzure/CommandLine/Deployment.php
+++ b/library/Zend/Service/WindowsAzure/CommandLine/Deployment.php
@@ -79,7 +79,7 @@ class Zend_Service_WindowsAzure_CommandLine_Deployment
 	 * @command-example --PackageUrl:"http://acct.blob.core.windows.net/pkgs/service.cspkg"
 	 * @command-example --ServiceConfigLocation:".\ServiceConfiguration.cscfg" --StartImmediately --WaitFor
 	 */
-	public function createFromStorageCommand($subscriptionId, $certificate, $certificatePassphrase, $serviceName, $deploymentName, $label, $staging = false, $production = false, $packageUrl, $serviceConfigurationLocation, $startImmediately = true, $warningsAsErrors = false, $waitForOperation = false)
+	public function createFromStorageCommand($subscriptionId, $certificate, $certificatePassphrase, $serviceName, $deploymentName, $label, $staging, $production, $packageUrl, $serviceConfigurationLocation, $startImmediately = true, $warningsAsErrors = false, $waitForOperation = false)
 	{
 		$deploymentSlot = 'staging';
 		if (!$staging && !$production) {
@@ -123,7 +123,7 @@ class Zend_Service_WindowsAzure_CommandLine_Deployment
 	 * @command-example --ServiceConfigLocation:".\ServiceConfiguration.cscfg" --StorageAccount:"mystorage"
 	 * @command-example --StartImmediately --WaitFor
 	 */
-	public function createFromLocalCommand($subscriptionId, $certificate, $certificatePassphrase, $serviceName, $deploymentName, $label, $staging = false, $production = false, $packageLocation, $serviceConfigurationLocation, $storageAccount, $startImmediately = true, $warningsAsErrors = false, $waitForOperation = false)
+	public function createFromLocalCommand($subscriptionId, $certificate, $certificatePassphrase, $serviceName, $deploymentName, $label, $staging, $production, $packageLocation, $serviceConfigurationLocation, $storageAccount, $startImmediately = true, $warningsAsErrors = false, $waitForOperation = false)
 	{
 		$deploymentSlot = 'staging';
 		if (!$staging && !$production) {

--- a/library/Zend/Service/WindowsAzure/Diagnostics/Manager.php
+++ b/library/Zend/Service/WindowsAzure/Diagnostics/Manager.php
@@ -209,7 +209,7 @@ class Zend_Service_WindowsAzure_Diagnostics_Manager
 	 * @param Zend_Service_WindowsAzure_Diagnostics_ConfigurationInstance $configuration Configuration to apply
 	 * @throws Zend_Service_WindowsAzure_Diagnostics_Exception
 	 */
-	public function setConfigurationForRoleInstance($roleInstance = null, Zend_Service_WindowsAzure_Diagnostics_ConfigurationInstance $configuration)
+	public function setConfigurationForRoleInstance($roleInstance, Zend_Service_WindowsAzure_Diagnostics_ConfigurationInstance $configuration)
 	{
 		if (is_null($roleInstance)) {
 			require_once 'Zend/Service/WindowsAzure/Diagnostics/Exception.php';

--- a/library/Zend/Stdlib/PriorityQueue.php
+++ b/library/Zend/Stdlib/PriorityQueue.php
@@ -184,7 +184,12 @@ class Zend_Stdlib_PriorityQueue implements Countable, IteratorAggregate, Seriali
      */
     public function serialize(): ?string
     {
-        return serialize($this->items);
+        return serialize($this->__serialize());
+    }
+
+    public function __serialize(): array
+    {
+        return $this->items;
     }
 
     /**
@@ -197,7 +202,12 @@ class Zend_Stdlib_PriorityQueue implements Countable, IteratorAggregate, Seriali
      */
     public function unserialize($data): void
     {
-        foreach (unserialize($data) as $item) {
+        $this->__unserialize(unserialize($data));
+    }
+
+    public function __unserialize(array $data): void
+    {
+        foreach ($data as $item) {
             $this->insert($item['data'], $item['priority']);
         }
     }

--- a/library/Zend/Stdlib/SplPriorityQueue.php
+++ b/library/Zend/Stdlib/SplPriorityQueue.php
@@ -239,7 +239,8 @@ if (!is_array($this->preparedQueue)) {
          *
          * @return void
          */
-        public function next(): void
+        #[\ReturnTypeWillChange]
+        public function next()
         {
             $this->count--;
         }

--- a/library/Zend/Stdlib/SplPriorityQueue.php
+++ b/library/Zend/Stdlib/SplPriorityQueue.php
@@ -470,6 +470,11 @@ class Zend_Stdlib_SplPriorityQueue extends SplPriorityQueue implements Serializa
      */
     public function serialize(): ?string
     {
+        return serialize($this->__serialize());
+    }
+
+    public function __serialize(): array
+    {
         $data = [];
         $this->setExtractFlags(self::EXTR_BOTH);
         while ($this->valid()) {
@@ -483,7 +488,7 @@ class Zend_Stdlib_SplPriorityQueue extends SplPriorityQueue implements Serializa
             $this->insert($item['data'], $item['priority']);
         }
 
-        return serialize($data);
+        return $data;
     }
 
     /**
@@ -494,7 +499,12 @@ class Zend_Stdlib_SplPriorityQueue extends SplPriorityQueue implements Serializa
      */
     public function unserialize($data): void
     {
-        foreach (unserialize($data) as $item) {
+        $this->__unserialize(unserialize($data));
+    }
+
+    public function __unserialize(array $data): void
+    {
+        foreach ($data as $item) {
             $this->insert($item['data'], $item['priority']);
         }
     }

--- a/library/Zend/Tool/Framework/Loader/IncludePathLoader/RecursiveFilterIterator.php
+++ b/library/Zend/Tool/Framework/Loader/IncludePathLoader/RecursiveFilterIterator.php
@@ -51,7 +51,7 @@ class Zend_Tool_Framework_Loader_IncludePathLoader_RecursiveFilterIterator exten
      *
      * @return bool
      */
-    public function accept()
+    public function accept(): bool
     {
         $currentNode = $this->current();
         $currentNodeRealPath = $currentNode->getRealPath();
@@ -73,7 +73,7 @@ class Zend_Tool_Framework_Loader_IncludePathLoader_RecursiveFilterIterator exten
      *
      * @return object
      */
-    public function getChildren()
+    public function getChildren(): ?\RecursiveFilterIterator
     {
         if (empty($this->ref)) {
             $this->ref = new ReflectionClass($this);

--- a/library/Zend/Tool/Project/Profile/Iterator/ContextFilter.php
+++ b/library/Zend/Tool/Project/Profile/Iterator/ContextFilter.php
@@ -165,7 +165,7 @@ class Zend_Tool_Project_Profile_Iterator_ContextFilter extends RecursiveFilterIt
      *
      * @return bool
      */
-    public function accept()
+    public function accept(): bool
     {
         $currentItem = $this->current();
 
@@ -199,7 +199,7 @@ class Zend_Tool_Project_Profile_Iterator_ContextFilter extends RecursiveFilterIt
      * @link
      *
      */
-    function getChildren()
+    function getChildren(): ?\RecursiveFilterIterator
     {
 
         if (empty($this->ref)) {

--- a/library/Zend/Tool/Project/Profile/Iterator/EnabledResourceFilter.php
+++ b/library/Zend/Tool/Project/Profile/Iterator/EnabledResourceFilter.php
@@ -36,7 +36,7 @@ class Zend_Tool_Project_Profile_Iterator_EnabledResourceFilter extends Recursive
      *
      * @return bool
      */
-    public function accept()
+    public function accept(): bool
     {
         return $this->current()->isEnabled();
     }

--- a/library/Zend/Tool/Project/Profile/Resource/Container.php
+++ b/library/Zend/Tool/Project/Profile/Resource/Container.php
@@ -385,7 +385,7 @@ class Zend_Tool_Project_Profile_Resource_Container implements RecursiveIterator,
      *
      * @return bool
      */
-    public function hasChildren()
+    public function hasChildren(): bool
     {
         return (count($this->_subResources) > 0) ? true : false;
     }
@@ -395,7 +395,7 @@ class Zend_Tool_Project_Profile_Resource_Container implements RecursiveIterator,
      *
      * @return Zend_Tool_Project_Profile_Resource
      */
-    public function getChildren()
+    public function getChildren(): ?\RecursiveIterator
     {
         return $this->current();
     }


### PR DESCRIPTION
## This PR
This is a follow-up to #205, in which I apparently missed a LOT of deprecations. The command I used to list them doesn't seem to work properly on my local system, using a fresh php8.1 docker imaged worked (thanks @alexgit2k)

This should resolve all compile-time deprecation errors up to php 8.1, without breaking compatibility with php7.1+. This time actually closing #189

## Resolved issues

### Added missing return types

<details>
<summary>Using Rector, added return types for: (collapsed)</summary>

FilterIterator::accept
RecursiveIterator::getChildren
RecursiveIterator::hasChildren
ReflectionClass::getInterfaces
ReflectionClass::getMethod
ReflectionClass::getMethods
ReflectionClass::getParentClass
ReflectionClass::getProperties
ReflectionClass::getProperty
ReflectionClass::getStartLine
ReflectionExtension::getClasses
ReflectionExtension::getFunctions
ReflectionFunctionAbstract::getParameters
ReflectionFunctionAbstract::getStartLine
ReflectionMethod::getDeclaringClass
ReflectionParameter::getClass
ReflectionParameter::getDeclaringClass
ReflectionParameter::getDeclaringFunction
ReflectionParameter::getType
ReflectionProperty::getDeclaringClass
ReflectionProperty::getDocComment
RecursiveFilterIterator::getChildren
</details>

### Add `__serialize` and `__unserialize` to `Serializable` classes
Adds __serialize and __unserialize implementations (identical to existing)
for any classes implementing Serializable

### Remove default values followed by mandatory arguments

See https://www.php.net/manual/en/functions.arguments.php:
> As of PHP 8.0 declaring mandatory arguments after optional arguments is
  deprecated. [...]


### Make `Command::helpCommand` variadic

Made helpCommand() variadic in order to be compatible with the
call_user_func_array on line 191

this resolves:
Error: Unknown named parameter $argv

### replace `: void` with `ReturnTypeWillChange` on `SplPriorityQueue::next`

Required because \Zend_EventManager_Filter_FilterIterator::next extends
SplPriorityQueue but returns a value


---
Fixes #189
CC @Shardj @alexgit2k @Hikariii