### PR TITLE
Check for null before using it as parameter in Router

### DIFF
--- a/library/Zend/Controller/Router/Route.php
+++ b/library/Zend/Controller/Router/Route.php
@@ -285,7 +285,7 @@ class Zend_Controller_Router_Route extends Zend_Controller_Router_Route_Abstract
                     }
                 }
 
-                if (substr($part, 0, 2) === '@@') {
+                if ($part !== null && substr($part, 0, 2) === '@@') {
                     $part = substr($part, 1);
                 }
 


### PR DESCRIPTION
Fixes #212
