### PR TITLE
PHP8.1 compatibility for PgSQL.

### DIFF
--- a/library/Zend/Db/Adapter/Pdo/Pgsql.php
+++ b/library/Zend/Db/Adapter/Pdo/Pgsql.php
@@ -196,14 +196,14 @@ class Zend_Db_Adapter_Pdo_Pgsql extends Zend_Db_Adapter_Pdo_Abstract
         foreach ($result as $key => $row) {
             $defaultValue = $row[$default_value];
             if ($row[$type] == 'varchar' || $row[$type] == 'bpchar' ) {
-                if (preg_match('/character(?: varying)?(?:\((\d+)\))?/', $row[$complete_type], $matches)) {
+                if (preg_match('/character(?: varying)?(?:\((\d+)\))?/', $row[$complete_type] ?? "", $matches)) {
                     if (isset($matches[1])) {
                         $row[$length] = $matches[1];
                     } else {
                         $row[$length] = null; // unlimited
                     }
                 }
-                if (preg_match("/^'(.*?)'::(?:character varying|bpchar)$/", $defaultValue, $matches)) {
+                if (preg_match("/^'(.*?)'::(?:character varying|bpchar)$/", $defaultValue ?? "", $matches)) {
                     $defaultValue = $matches[1];
                 }
             }
@@ -211,7 +211,7 @@ class Zend_Db_Adapter_Pdo_Pgsql extends Zend_Db_Adapter_Pdo_Abstract
             if ($row[$contype] == 'p') {
                 $primary = true;
                 $primaryPosition = array_search($row[$attnum], explode(',', $row[$conkey])) + 1;
-                $identity = (bool) (preg_match('/^nextval/', $row[$default_value]));
+                $identity = (bool) (preg_match('/^nextval/', $row[$default_value] ?? ""));
             }
             $desc[$this->foldCase($row[$colname])] = [
                 'SCHEMA_NAME'      => $this->foldCase($row[$nspname]),


### PR DESCRIPTION
This PR aims to fix https://github.com/Shardj/zf1-future/issues/214#issuecomment-1094169082.
Since PHP8.1, passing null to preg_match occurs an error `preg_match(): Passing null to parameter #2 ($subject) of type string is deprecated`.
So, I replace `preg_match($regex, $subjectThatCanBeNull)` to `preg_match($regex, $subjectThatCanBeNull ?? "")`