### PR TITLE
PHP 8.1 Deprecations and invalid paramter usage

### DIFF
--- a/library/Zend/Controller/Router/Route/Module.php
+++ b/library/Zend/Controller/Router/Route/Module.php
@@ -266,7 +266,7 @@ class Zend_Controller_Router_Route_Module extends Zend_Controller_Router_Route_A
                     $url .= self::URI_DELIMITER . $arrayValue;
                 }
             } else {
-                if ($encode) {
+                if ($encode && is_string($value)) {
                     $value = urlencode($value);
                 }
                 $url .= self::URI_DELIMITER . $key;

--- a/library/Zend/Form.php
+++ b/library/Zend/Form.php
@@ -911,7 +911,9 @@ class Zend_Form implements Iterator, Countable, Zend_Validate_Interface
         $id = $this->getFullyQualifiedName();
 
         // Bail early if no array notation detected
-        if (!strstr($id, '[')) {
+        if (!is_string($id)
+            || !strstr($id, '[')
+        ) {
             return $id;
         }
 

--- a/library/Zend/Form/Decorator/Description.php
+++ b/library/Zend/Form/Decorator/Description.php
@@ -159,7 +159,9 @@ class Zend_Form_Decorator_Description extends Zend_Form_Decorator_Abstract
         }
 
         $description = $element->getDescription();
-        $description = trim($description);
+        if(is_string($description)) {
+            $description = trim($description);
+        }
 
         if (!empty($description) && (null !== ($translator = $element->getTranslator()))) {
             $description = $translator->translate($description);

--- a/library/Zend/Translate/Adapter/Csv.php
+++ b/library/Zend/Translate/Adapter/Csv.php
@@ -90,7 +90,7 @@ class Zend_Translate_Adapter_Csv extends Zend_Translate_Adapter
         }
 
         while(($data = fgetcsv($this->_file, $options['length'], $options['delimiter'], $options['enclosure'])) !== false) {
-            if (substr($data[0], 0, 1) === '#') {
+            if (is_string($data[0]) && substr($data[0], 0, 1) === '#') {
                 continue;
             }
 

--- a/library/Zend/View/Helper/FormElement.php
+++ b/library/Zend/View/Helper/FormElement.php
@@ -142,7 +142,7 @@ abstract class Zend_View_Helper_FormElement extends Zend_View_Helper_HtmlElement
         // Set ID for element
         if (array_key_exists('id', $attribs)) {
             $info['id'] = (string)$attribs['id'];
-        } else if ('' !== $info['name']) {
+        } else if (is_string($info['name']) && '' !== $info['name']) {
             $info['id'] = trim(strtr($info['name'],
                                      ['[' => '-', ']' => '']), '-');
         }


### PR DESCRIPTION
```
- library/Zend/Translate/Adapter/Csv.php on line 93 Deprecated: substr(): Passing null to parameter #1 ($string) of type string is deprecated
- strstr(): Passing null to parameter #1 ($haystack) of type string is deprecated in library/Zend/Form.php on line 914
- Deprecated: trim(): Passing null to parameter #1 ($string) of type string is deprecated in library/Zend/Form/Decorator/Description.php on line 162
- Deprecated: strtr(): Passing null to parameter #1 ($string) of type string is deprecated in library/Zend/View/Helper/FormElement.php on line 147
- Deprecated:  urlencode(): Passing null to parameter #1 ($string) of type string is deprecated in library/Zend/Controller/Router/Route/Module.php on line 270
```