### PR TITLE
Add docblock (soft) return type in the PDO MySQL adapter

### DIFF
--- a/library/Zend/Db/Adapter/Pdo/Mysql.php
+++ b/library/Zend/Db/Adapter/Pdo/Mysql.php
@@ -79,6 +79,8 @@ class Zend_Db_Adapter_Pdo_Mysql extends Zend_Db_Adapter_Pdo_Abstract
     /**
      * Override _dsn() and ensure that charset is incorporated in mysql
      * @see Zend_Db_Adapter_Pdo_Abstract::_dsn()
+     *
+     * @return string
      */
     protected function _dsn()
     {


### PR DESCRIPTION
This avoids deprecation notices by Symfony's `DebugClassLoader` which gives a heads-up notice for possible (future) strong return type hints.