### PR TITLE
Avoid a deprecation notice in `Zend_Http_Response` when there is no `Content-Encoding` header

### DIFF
--- a/library/Zend/Http/Response.php
+++ b/library/Zend/Http/Response.php
@@ -267,7 +267,7 @@ class Zend_Http_Response
         }
 
         // Decode any content-encoding (gzip or deflate) if needed
-        switch (strtolower($this->getHeader('content-encoding'))) {
+        switch (strtolower((string) $this->getHeader('content-encoding'))) {
 
             // Handle gzip encoding
             case 'gzip':


### PR DESCRIPTION
The `(string)` cast deals with a `null` value then.