### PR TITLE
Revert unnecessary change from 29854a8

### DIFF
--- a/library/Zend/Form/Element.php
+++ b/library/Zend/Form/Element.php
@@ -2116,7 +2116,7 @@ class Zend_Form_Element implements Zend_Validate_Interface
         } else {
             $r = new ReflectionClass($name);
             if ($r->hasMethod('__construct')) {
-                $instance = $r->newInstanceArgs((array) [$filter['options']]);
+                $instance = $r->newInstanceArgs((array) $filter['options']);
             } else {
                 $instance = $r->newInstance();
             }


### PR DESCRIPTION
This change breaks filters with options. ZF1 allows filters to be added by name with an array for the options which are then passed to the constructor. This change broke this and passed everything as one array (i.e. the first parameter became an array of all the otpions).