### PR TITLE
fix: Zend_Db_Statement_Mysqli with named params

### DIFF
--- a/library/Zend/Db/Statement/Mysqli.php
+++ b/library/Zend/Db/Statement/Mysqli.php
@@ -200,7 +200,7 @@ class Zend_Db_Statement_Mysqli extends Zend_Db_Statement
             }
             call_user_func_array(
                 [$this->_stmt, 'bind_param'],
-                $stmtParams
+                array_values($stmtParams)
                 );
         }
 


### PR DESCRIPTION
mysqli_stmt::bind_param() does not accept unknown named parameters
When $params contains non numeric (named) array keys, PHP 8 will
not pass them positional and tries to map it to named parameters
of mysqli_stmt::bind_param which fails.
https://www.php.net/manual/de/mysqli-stmt.bind-param.php
array_values() will make sure a numeric array is passed. It should
not change the position of the params inside the array.