### PR TITLE
PHP 8.1 Fixed deprecation warnings

### DIFF
--- a/library/Zend/Mail.php
+++ b/library/Zend/Mail.php
@@ -685,7 +685,7 @@ class Zend_Mail extends Zend_Mime_Message
         }
 
         $email = $this->_filterEmail($email);
-        $name  = $this->_filterName($name);
+        $name  = $this->_filterName($name ?? '');
         $this->_from = $email;
         $this->_storeHeader('From', $this->_formatAddress($email, $name), true);
 


### PR DESCRIPTION
currently migrating a bigger project... i'm gonna collect everything i discover in this PR...

- fixed `strtr(): Passing null to parameter #1 ($string) of type string…`