### PR TITLE
fix php 8.1 issue. Return type of Zend_Soap_Client_Common::__doRequest($request, $location, $action, $version, $oneWay = false)

### DIFF
--- a/library/Zend/Soap/Client/Common.php
+++ b/library/Zend/Soap/Client/Common.php
@@ -59,17 +59,12 @@ class Zend_Soap_Client_Common extends SoapClient
      * @param string $location
      * @param string $action
      * @param int    $version
-     * @param int    $one_way
-     * @return mixed
+     * @param bool   $oneWay
+     * @return string|null
      */
-    #[\ReturnTypeWillChange]
-    function __doRequest($request, $location, $action, $version, $one_way = null)
+    function __doRequest($request, $location, $action, $version, $oneWay = false) : ?string
     {
-        if ($one_way === null) {
-            return call_user_func($this->_doRequestCallback, $this, $request, $location, $action, $version);
-        } else {
-            return call_user_func($this->_doRequestCallback, $this, $request, $location, $action, $version, $one_way);
-        }
+        return call_user_func($this->_doRequestCallback, $this, $request, $location, $action, $version, $oneWay);
     }
 
 }


### PR DESCRIPTION
- fix php 8.1 issue. Return type of Zend_Soap_Client_Common::__doRequest($request, $location, $action, $version, $oneWay = false) should either be compatible with SoapClient::__doRequest(string $request, string $location, string $action, int $version, bool $oneWay = false): ?string, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice
