### PR TITLE
Accept HTTP 2 in Zend_Http_Response; closes Shardj/zf1-future#244

### DIFF
--- a/library/Zend/Http/Response.php
+++ b/library/Zend/Http/Response.php
@@ -183,7 +183,7 @@ class Zend_Http_Response
         $this->body = $body;
 
         // Set the HTTP version
-        if (! preg_match('|^\d\.\d$|', $version)) {
+        if (! preg_match('|^\d(\.\d)?$|', $version)) {
             require_once 'Zend/Http/Exception.php';
             throw new Zend_Http_Exception("Invalid HTTP response version: $version");
         }
@@ -506,7 +506,7 @@ class Zend_Http_Response
         $last_header = null;
 
         foreach($lines as $index => $line) {
-            if ($index === 0 && preg_match('#^HTTP/\d+(?:\.\d+) [1-5]\d+#', $line)) {
+            if ($index === 0 && preg_match('#^HTTP/\d+(?:\.\d+)? [1-5]\d+#', $line)) {
                 // Status line; ignore
                 continue;
             }
@@ -690,6 +690,8 @@ class Zend_Http_Response
         $body    = self::extractBody($response_str);
         $version = self::extractVersion($response_str);
         $message = self::extractMessage($response_str);
+
+        var_dump($version);
 
         return new Zend_Http_Response($code, $headers, $body, $version, $message);
     }

--- a/tests/Zend/Http/ResponseTest.php
+++ b/tests/Zend/Http/ResponseTest.php
@@ -482,4 +482,11 @@ class Zend_Http_ResponseTest extends PHPUnit_Framework_TestCase
         $this->assertArrayHasKey('imagetoolbar', $headers);
         $this->assertEmpty($headers['imagetoolbar']);
     }
+
+    public function testHttp2()
+    {
+        $response = Zend_Http_Response::fromString($this->readResponse('response_http2'));
+
+        $this->assertEquals("2", $response->getVersion());
+    }
 }

--- a/tests/Zend/Http/_files/response_http2
+++ b/tests/Zend/Http/_files/response_http2
@@ -1,0 +1,13 @@
+HTTP/2 200 OK
+Content-Length: 264
+content-type: text/html; charset=UTF-8
+
+<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
+<html><head>
+<title>550 Printer On Fire</title>
+</head><body>
+<h1>Help! Help!</h1>
+<p>Please call the fire brigade</p>
+<hr>
+<address>Apache Server at shahar.local Port 80</address>
+</body></html>


### PR DESCRIPTION
Allow HTTP versions without '.'