### PR TITLE
Fix for utf8_encode() and utf8_decode() deprecation in PHP 8.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,8 @@
     "license": "BSD-3-Clause",
     "require": {
         "php": ">=7.1",
-        "symfony/polyfill-php81": "^1.24"
+        "symfony/polyfill-php81": "^1.24",
+        "symfony/polyfill-mbstring": "^1.26"
     },
     "autoload": {
         "psr-0": {

--- a/composer.json
+++ b/composer.json
@@ -13,6 +13,9 @@
         "symfony/polyfill-php81": "^1.24",
         "symfony/polyfill-mbstring": "^1.26"
     },
+    "suggest": {
+        "ext-mbstring": "Multibyte strings handling"
+    },
     "autoload": {
         "psr-0": {
             "Zend_": "library/"

--- a/library/Zend/Console/Getopt.php
+++ b/library/Zend/Console/Getopt.php
@@ -524,10 +524,10 @@ class Zend_Console_Getopt
 
         foreach ($this->_options as $flag => $value) {
             $optionNode = $doc->createElement('option');
-            $optionNode->setAttribute('flag', utf8_encode($flag));
+            $optionNode->setAttribute('flag', mb_convert_encoding($flag, 'UTF-8', 'ISO-8859-1'));
 
             if ($value !== true) {
-                $optionNode->setAttribute('parameter', utf8_encode($value));
+                $optionNode->setAttribute('parameter', mb_convert_encoding($value, 'UTF-8', 'ISO-8859-1'));
             }
             $optionsNode->appendChild($optionNode);
         }

--- a/library/Zend/Service/Amazon/Authentication/S3.php
+++ b/library/Zend/Service/Amazon/Authentication/S3.php
@@ -104,7 +104,7 @@ class Zend_Service_Amazon_Authentication_S3 extends Zend_Service_Amazon_Authenti
                     $sig_str .= '?torrent';
                 }
 
-        $signature = base64_encode(Zend_Crypt_Hmac::compute($this->_secretKey, 'sha1', utf8_encode($sig_str), Zend_Crypt_Hmac::BINARY));
+        $signature = base64_encode(Zend_Crypt_Hmac::compute($this->_secretKey, 'sha1', mb_convert_encoding($sig_str, 'UTF-8', 'ISO-8859-1'), Zend_Crypt_Hmac::BINARY));
         $headers['Authorization'] = 'AWS ' . $this->_accessKey . ':' . $signature;
 
         return $sig_str;

--- a/library/Zend/Service/Amazon/S3.php
+++ b/library/Zend/Service/Amazon/S3.php
@@ -782,7 +782,7 @@ class Zend_Service_Amazon_S3 extends Zend_Service_Amazon_Abstract
             $sig_str .= '?versions';
         }
 
-        $signature = base64_encode(Zend_Crypt_Hmac::compute($this->_getSecretKey(), 'sha1', utf8_encode($sig_str), Zend_Crypt_Hmac::BINARY));
+        $signature = base64_encode(Zend_Crypt_Hmac::compute($this->_getSecretKey(), 'sha1', mb_convert_encoding($sig_str, 'UTF-8', 'ISO-8859-1'), Zend_Crypt_Hmac::BINARY));
         $headers['Authorization'] = 'AWS '.$this->_getAccessKey().':'.$signature;
 
         return $sig_str;

--- a/library/Zend/Service/Amazon/SimpleDb.php
+++ b/library/Zend/Service/Amazon/SimpleDb.php
@@ -452,7 +452,7 @@ class Zend_Service_Amazon_SimpleDb extends Zend_Service_Amazon_Abstract
         // UTF-8 encode all parameters and replace '+' characters
         foreach ($params as $name => $value) {
             unset($params[$name]);
-            $params[utf8_encode($name)] = $value;
+            $params[mb_convert_encoding($name, 'UTF-8', 'ISO-8859-1')] = $value;
         }
 
         $params = $this->_addRequiredParameters($params);

--- a/library/Zend/Service/WindowsAzure/Management/Client.php
+++ b/library/Zend/Service/WindowsAzure/Management/Client.php
@@ -1008,7 +1008,7 @@ class Zend_Service_WindowsAzure_Management_Client
     	}
 
     	if (@file_exists($configuration)) {
-    		$configuration = utf8_decode(file_get_contents($configuration));
+    		$configuration = mb_convert_encoding(file_get_contents($configuration), 'ISO-8859-1', 'UTF-8');
     	}
 
     	// Clean up the configuration
@@ -1480,7 +1480,7 @@ class Zend_Service_WindowsAzure_Management_Client
     	}
 
         if (@file_exists($configuration)) {
-    		$configuration = utf8_decode(file_get_contents($configuration));
+            $configuration = mb_convert_encoding(file_get_contents($configuration), 'ISO-8859-1', 'UTF-8');
     	}
 
     	$operationUrl = self::OP_HOSTED_SERVICES . '/' . $serviceName . '/deploymentslots/' . $deploymentSlot;
@@ -1513,7 +1513,7 @@ class Zend_Service_WindowsAzure_Management_Client
     	}
 
         if (@file_exists($configuration)) {
-    		$configuration = utf8_decode(file_get_contents($configuration));
+            $configuration = mb_convert_encoding(file_get_contents($configuration), 'ISO-8859-1', 'UTF-8');
     	}
 
     	$operationUrl = self::OP_HOSTED_SERVICES . '/' . $serviceName . '/deployments/' . $deploymentId;
@@ -1591,7 +1591,7 @@ class Zend_Service_WindowsAzure_Management_Client
     	}
 
     	if (@file_exists($configuration)) {
-    		$configuration = utf8_decode(file_get_contents($configuration));
+            $configuration = mb_convert_encoding(file_get_contents($configuration), 'ISO-8859-1', 'UTF-8');
     	}
 
 		$operationUrl = self::OP_HOSTED_SERVICES . '/' . $serviceName . '/deploymentslots/' . $deploymentSlot;
@@ -1643,7 +1643,7 @@ class Zend_Service_WindowsAzure_Management_Client
     	}
 
     	if (@file_exists($configuration)) {
-    		$configuration = utf8_decode(file_get_contents($configuration));
+            $configuration = mb_convert_encoding(file_get_contents($configuration), 'ISO-8859-1', 'UTF-8');
     	}
 
 		$operationUrl = self::OP_HOSTED_SERVICES . '/' . $serviceName . '/deployments/' . $deploymentId;

--- a/library/Zend/Service/WindowsAzure/Storage/Blob.php
+++ b/library/Zend/Service/WindowsAzure/Storage/Blob.php
@@ -887,12 +887,12 @@ class Zend_Service_WindowsAzure_Storage_Blob extends Zend_Service_WindowsAzure_S
 		}
 
 		// Generate block list request
-		$fileContents = utf8_encode(implode("\n", [
+		$fileContents = mb_convert_encoding(implode("\n", [
 				'<?xml version="1.0" encoding="utf-8"?>',
 				'<BlockList>',
 				$blocks,
 				'</BlockList>'
-			]));
+			]), 'UTF-8', 'ISO-8859-1');
 
 			// Create metadata headers
 			$headers = [];


### PR DESCRIPTION
PHP 8.2 will deprecate utf8_encode() and utf8_decode() and this will emit a deprecation notice:
https://php.watch/versions/8.2/utf8_encode-utf8_decode-deprecated

This PR:
- converts all the calls to mbstring calls (the officially suggested switch)
- adds the symfony/polyfill-mbstring polyfill in composer.json for system that don't have the mbstring extension installed
- suggests to install the mbstring extension in composer.json