### PR TITLE
Fix for deprecation of ${var} string interpolation in PHP 8.2

### DIFF
--- a/demos/Zend/Gdata/BooksBrowser/index.php
+++ b/demos/Zend/Gdata/BooksBrowser/index.php
@@ -90,7 +90,7 @@ HTML;
             $thumbnail_img
         </div></td>
         <td width="100%">
-            <a href="${preview}">$title</a><br>
+            <a href="{$preview}">$title</a><br>
             $creators<br>
             $preview_link
         </td></tr>

--- a/demos/Zend/Gdata/YouTubeVideoApp/operations.php
+++ b/demos/Zend/Gdata/YouTubeVideoApp/operations.php
@@ -462,10 +462,10 @@ function createUploadForm($videoTitle, $videoDescription, $videoCategory, $video
     }
 
     print <<< END
-        <br /><form action="${postUrl}?nexturl=${nextUrl}"
+        <br /><form action="{$postUrl}?nexturl={$nextUrl}"
         method="post" enctype="multipart/form-data">
         <input name="file" type="file"/>
-        <input name="token" type="hidden" value="${tokenValue}"/>
+        <input name="token" type="hidden" value="{$tokenValue}"/>
         <input value="Upload Video File" type="submit" />
         </form>
 END;
@@ -747,9 +747,9 @@ function echoVideoPlayer($videoId)
     print <<<END
         <b>$videoTitle</b><br />
         <object width="425" height="350">
-        <param name="movie" value="${videoUrl}&autoplay=1"></param>
+        <param name="movie" value="{$videoUrl}&autoplay=1"></param>
         <param name="wmode" value="transparent"></param>
-        <embed src="${videoUrl}&autoplay=1" type="application/x-shockwave-flash" wmode="transparent"
+        <embed src="{$videoUrl}&autoplay=1" type="application/x-shockwave-flash" wmode="transparent"
         width="425" height="350"></embed>
         </object>
 END;
@@ -831,15 +831,15 @@ function echoVideoMetadata($entry)
     }
     $flashUrl = htmlspecialchars(findFlashUrl($entry));
     print <<<END
-        <b>Title:</b> ${title}<br />
-        <b>Description:</b> ${description}<br />
-        <b>Author:</b> <a href="${authorUrl}">${authorUsername}</a><br />
-        <b>Tags:</b> ${tags}<br />
-        <b>Duration:</b> ${duration} seconds<br />
-        <b>View count:</b> ${viewCount}<br />
-        <b>Rating:</b> ${rating} (${numRaters} ratings)<br />
-        <b>Flash:</b> <a href="${flashUrl}">${flashUrl}</a><br />
-        <b>Watch page:</b> <a href="${watchPage}">${watchPage}</a> <br />
+        <b>Title:</b> {$title}<br />
+        <b>Description:</b> {$description}<br />
+        <b>Author:</b> <a href="{$authorUrl}">{$authorUsername}</a><br />
+        <b>Tags:</b> {$tags}<br />
+        <b>Duration:</b> {$duration} seconds<br />
+        <b>View count:</b> {$viewCount}<br />
+        <b>Rating:</b> {$rating} ({$numRaters} ratings)<br />
+        <b>Flash:</b> <a href="{$flashUrl}">{$flashUrl}</a><br />
+        <b>Watch page:</b> <a href="{$watchPage}">{$watchPage}</a> <br />
 END;
 }
 

--- a/demos/Zend/Gdata/YouTubeVideoBrowser/index.php
+++ b/demos/Zend/Gdata/YouTubeVideoBrowser/index.php
@@ -141,9 +141,9 @@ function echoVideoPlayer($videoId)
     print <<<END
     <b>$videoTitle</b><br />
     <object width="425" height="350">
-      <param name="movie" value="${videoUrl}&autoplay=1"></param>
+      <param name="movie" value="{$videoUrl}&autoplay=1"></param>
       <param name="wmode" value="transparent"></param>
-      <embed src="${videoUrl}&autoplay=1" type="application/x-shockwave-flash" wmode="transparent"
+      <embed src="{$videoUrl}&autoplay=1" type="application/x-shockwave-flash" wmode="transparent"
         width=425" height="350"></embed>
     </object>
 END;
@@ -175,15 +175,15 @@ function echoVideoMetadata($entry)
     $numRaters = $entry->rating->numRaters;
     $flashUrl = findFlashUrl($entry);
     print <<<END
-    <b>Title:</b> ${title}<br />
-    <b>Description:</b> ${description}<br />
-    <b>Author:</b> <a href="${authorUrl}">${authorUsername}</a><br />
-    <b>Tags:</b> ${tags}<br />
-    <b>Duration:</b> ${duration} seconds<br />
-    <b>View count:</b> ${viewCount}<br />
-    <b>Rating:</b> ${rating} (${numRaters} ratings)<br />
-    <b>Flash:</b> <a href="${flashUrl}">${flashUrl}</a><br />
-    <b>Watch page:</b> <a href="${watchPage}">${watchPage}</a> <br />
+    <b>Title:</b> {$title}<br />
+    <b>Description:</b> {$description}<br />
+    <b>Author:</b> <a href="{$authorUrl}">{$authorUsername}</a><br />
+    <b>Tags:</b> {$tags}<br />
+    <b>Duration:</b> {$duration} seconds<br />
+    <b>View count:</b> {$viewCount}<br />
+    <b>Rating:</b> {$rating} ({$numRaters} ratings)<br />
+    <b>Flash:</b> <a href="{$flashUrl}">{$flashUrl}</a><br />
+    <b>Watch page:</b> <a href="{$watchPage}">{$watchPage}</a> <br />
 END;
 }
 
@@ -203,11 +203,11 @@ function echoVideoList($feed)
         $videoTitle = $entry->mediaGroup->title;
         $videoDescription = $entry->mediaGroup->description;
         print <<<END
-        <tr onclick="ytvbp.presentVideo('${videoId}')">
-        <td width="130"><img src="${thumbnailUrl}" /></td>
+        <tr onclick="ytvbp.presentVideo('{$videoId}')">
+        <td width="130"><img src="{$thumbnailUrl}" /></td>
         <td width="100%">
-        <a href="#">${videoTitle}</a>
-        <p class="videoDescription">${videoDescription}</p>
+        <a href="#">{$videoTitle}</a>
+        <p class="videoDescription">{$videoDescription}</p>
         </td>
         </tr>
 END;

--- a/library/Zend/Gdata/App.php
+++ b/library/Zend/Gdata/App.php
@@ -1084,11 +1084,11 @@ class Zend_Gdata_App
             } else {
                 require_once 'Zend/Gdata/App/Exception.php';
                 throw new Zend_Gdata_App_Exception(
-                        "Unable to find '${class}' in registered packages");
+                        "Unable to find '{$class}' in registered packages");
             }
         } else {
             require_once 'Zend/Gdata/App/Exception.php';
-            throw new Zend_Gdata_App_Exception("No such method ${method}");
+            throw new Zend_Gdata_App_Exception("No such method {$method}");
         }
     }
 

--- a/library/Zend/Gdata/App/Base.php
+++ b/library/Zend/Gdata/App/Base.php
@@ -480,7 +480,7 @@ abstract class Zend_Gdata_App_Base
         $method = 'get'.ucfirst($name);
         if (method_exists($this, $method)) {
             return call_user_func([&$this, $method]);
-        } else if (property_exists($this, "_${name}")) {
+        } else if (property_exists($this, "_{$name}")) {
             return $this->{'_' . $name};
         } else {
             require_once 'Zend/Gdata/App/InvalidArgumentException.php';

--- a/library/Zend/Gdata/App/BaseMediaSource.php
+++ b/library/Zend/Gdata/App/BaseMediaSource.php
@@ -113,7 +113,7 @@ abstract class Zend_Gdata_App_BaseMediaSource implements Zend_Gdata_App_MediaSou
         $method = 'get'.ucfirst($name);
         if (method_exists($this, $method)) {
             return call_user_func([&$this, $method]);
-        } else if (property_exists($this, "_${name}")) {
+        } else if (property_exists($this, "_{$name}")) {
             return $this->{'_' . $name};
         } else {
             require_once 'Zend/Gdata/App/InvalidArgumentException.php';

--- a/library/Zend/Gdata/App/LoggingHttpClientAdapterSocket.php
+++ b/library/Zend/Gdata/App/LoggingHttpClientAdapterSocket.php
@@ -73,7 +73,7 @@ class Zend_Gdata_App_LoggingHttpClientAdapterSocket extends Zend_Http_Client_Ada
      */
     public function connect($host, $port = 80, $secure = false)
     {
-        $this->log("Connecting to: ${host}:${port}");
+        $this->log("Connecting to: {$host}:{$port}");
         return parent::connect($host, $port, $secure);
     }
 
@@ -102,7 +102,7 @@ class Zend_Gdata_App_LoggingHttpClientAdapterSocket extends Zend_Http_Client_Ada
     public function read()
     {
         $response = parent::read();
-        $this->log("${response}\n\n");
+        $this->log("{$response}\n\n");
         return $response;
     }
 

--- a/library/Zend/Gdata/Gapps.php
+++ b/library/Zend/Gdata/Gapps.php
@@ -881,7 +881,7 @@ class Zend_Gdata_Gapps extends Zend_Gdata
             } else {
                 require_once 'Zend/Gdata/App/Exception.php';
                 throw new Zend_Gdata_App_Exception(
-                        "Unable to find '${class}' in registered packages");
+                        "Unable to find '{$class}' in registered packages");
             }
         } else {
             return parent::__call($method, $args);


### PR DESCRIPTION
This PR fixes the usage of deprecated (in php 8.2)  `"${var}"` notation, in favour of `"{$var}"`.

There are 2 occurrences of the deprecated notation in some unit tests that I didn't change:
 <img width="740" alt="Schermata 2022-08-11 alle 14 57 58" src="https://user-images.githubusercontent.com/909743/184150610-d0f6aac8-0369-44ea-bf38-4e0f8f1ed753.png">

I'm also not sure about this 2 lines, but they seem not to trigger the deprecation notice:
<img width="726" alt="Schermata 2022-08-11 alle 14 59 11" src="https://user-images.githubusercontent.com/909743/184150745-680a3018-deb9-4440-96fd-8d2efcce76b2.png">

