### PR TITLE
Use integer parameter for flags parameter of preg_match()

### DIFF
--- a/library/Zend/Markup/Parser/Bbcode.php
+++ b/library/Zend/Markup/Parser/Bbcode.php
@@ -215,7 +215,7 @@ class Zend_Markup_Parser_Bbcode implements Zend_Markup_Parser_ParserInterface
                 case self::STATE_SCAN:
                     $matches = [];
                     $regex   = '#\G(?<text>[^\[]*)(?<open>\[(?<name>[' . self::NAME_CHARSET . ']+)?)?#';
-                    preg_match($regex, $this->_value, $matches, null, $this->_pointer);
+                    preg_match($regex, $this->_value, $matches, 0, $this->_pointer);
 
                     $this->_pointer += strlen($matches[0]);
 
@@ -257,7 +257,7 @@ class Zend_Markup_Parser_Bbcode implements Zend_Markup_Parser_ParserInterface
                 case self::STATE_SCANATTRS:
                     $matches = [];
                     $regex   = '#\G((?<end>\s*\])|\s+(?<attribute>[' . self::NAME_CHARSET . ']+)(?<eq>=?))#';
-                    if (!preg_match($regex, $this->_value, $matches, null, $this->_pointer)) {
+                    if (!preg_match($regex, $this->_value, $matches, 0, $this->_pointer)) {
                         break 2;
                     }
 
@@ -296,7 +296,7 @@ class Zend_Markup_Parser_Bbcode implements Zend_Markup_Parser_ParserInterface
                 case self::STATE_PARSEVALUE:
                     $matches = [];
                     $regex   = '#\G((?<quote>"|\')(?<valuequote>.*?)\\2|(?<value>[^\]\s]+))#';
-                    if (!preg_match($regex, $this->_value, $matches, null, $this->_pointer)) {
+                    if (!preg_match($regex, $this->_value, $matches, 0, $this->_pointer)) {
                         $this->_state = self::STATE_SCANATTRS;
                         break;
                     }


### PR DESCRIPTION
To prevent the error "preg_match(): Passing null to parameter #4 ($flags) of type int is deprecated"