### PR TITLE
Initial PHP 8.2 fixes

### DIFF
--- a/library/Zend/Application/Bootstrap/BootstrapAbstract.php
+++ b/library/Zend/Application/Bootstrap/BootstrapAbstract.php
@@ -98,6 +98,11 @@ abstract class Zend_Application_Bootstrap_BootstrapAbstract
     protected $_started = [];
 
     /**
+     * @var \Zend_Controller_Front
+     */
+    public $frontController = null;
+
+    /**
      * Constructor
      *
      * Sets application object, initializes options, and prepares list of

--- a/library/Zend/Controller/Router/Route/Chain.php
+++ b/library/Zend/Controller/Router/Route/Chain.php
@@ -49,6 +49,11 @@ class Zend_Controller_Router_Route_Chain extends Zend_Controller_Router_Route_Ab
     protected $_separators = [];
 
     /**
+     * @var Zend_Controller_Request_Abstract
+     */
+    protected $_request = null;
+
+    /**
      * Instantiates route based on passed Zend_Config structure
      *
      * @param  Zend_Config $config Configuration object

--- a/library/Zend/Form/Element.php
+++ b/library/Zend/Form/Element.php
@@ -206,6 +206,13 @@ class Zend_Form_Element implements Zend_Validate_Interface
     protected $_validatorRules = [];
 
     /**
+     * List of element attributes
+     *
+     * @var array
+     */
+    protected $_attributes = [];
+
+    /**
      * Element value
      * @var mixed
      */
@@ -869,9 +876,9 @@ class Zend_Form_Element implements Zend_Validate_Interface
         }
 
         if (null === $value) {
-            unset($this->$name);
+            unset($this->_attributes[$name]);
         } else {
-            $this->$name = $value;
+            $this->_attributes[$name] = $value;
         }
 
         return $this;
@@ -901,8 +908,8 @@ class Zend_Form_Element implements Zend_Validate_Interface
     public function getAttrib($name)
     {
         $name = (string) $name;
-        if (isset($this->$name)) {
-            return $this->$name;
+        if (isset($this->_attributes[$name])) {
+            return $this->_attributes[$name];
         }
 
         return null;
@@ -915,15 +922,7 @@ class Zend_Form_Element implements Zend_Validate_Interface
      */
     public function getAttribs()
     {
-        $attribs = get_object_vars($this);
-        unset($attribs['helper']);
-        foreach ($attribs as $key => $value) {
-            if ('_' == substr($key, 0, 1)) {
-                unset($attribs[$key]);
-            }
-        }
-
-        return $attribs;
+        return $this->_attributes;
     }
 
     /**
@@ -963,11 +962,11 @@ class Zend_Form_Element implements Zend_Validate_Interface
             throw new Zend_Form_Exception(sprintf('Cannot retrieve value for protected/private property "%s"', $key));
         }
 
-        if (!isset($this->$key)) {
+        if (!isset($this->_attributes[$key])) {
             return null;
         }
 
-        return $this->$key;
+        return $this->_attributes[$key];
     }
 
     /**
@@ -980,6 +979,33 @@ class Zend_Form_Element implements Zend_Validate_Interface
     public function __set($key, $value)
     {
         $this->setAttrib($key, $value);
+    }
+
+    /**
+     * Check for set attribute
+     *
+     * @param  string $key
+     * @return bool
+     */
+    public function __isset($key)
+    {
+        return isset($this->_attributes[$key]);
+    }
+
+    /**
+     * Unset attribute
+     *
+     * @param  string $key
+     * @return void
+     */
+    public function __unset($key)
+    {
+        if ('_' == $key[0]) {
+            require_once 'Zend/Form/Exception.php';
+            throw new Zend_Form_Exception(sprintf('Cannot unset value for protected/private property "%s"', $key));
+        }
+
+        unset($this->_attributes[$name]);
     }
 
     /**

--- a/library/Zend/View.php
+++ b/library/Zend/View.php
@@ -98,13 +98,6 @@ class Zend_View extends Zend_View_Abstract
     private $_useStreamWrapper = false;
 
     /**
-     * Data container
-     *
-     * @var array
-     */
-    private $_data = [];
-
-    /**
      * Constructor
      *
      * Register Zend_View_Stream stream wrapper if short tags are disabled.
@@ -127,37 +120,6 @@ class Zend_View extends Zend_View_Abstract
         }
 
         parent::__construct($config);
-    }
-
-    /**
-     * Catch property change calls and prevent creation of dynamic properties (PHP 8.2)
-     *
-     * @param string $key
-     * @param mixed $val
-     */
-    public function __set($key, $val)
-    {
-        if (property_exists($this, $key)) {
-            $this->$key = $val;
-            return;
-        }
-
-        $this->_data[$key] = $val;
-    }
-
-    /**
-     * Catch property access calls and return the right values
-     *
-     * @param  string $key
-     * @return mixed
-     */
-    public function __get($key)
-    {
-        if (property_exists($this, $key)) {
-            return $this->$key;
-        }
-
-        return $this->_data[$key] ?? null;
     }
 
     /**

--- a/library/Zend/View.php
+++ b/library/Zend/View.php
@@ -98,6 +98,13 @@ class Zend_View extends Zend_View_Abstract
     private $_useStreamWrapper = false;
 
     /**
+     * Data container
+     *
+     * @var array
+     */
+    private $_data = [];
+
+    /**
      * Constructor
      *
      * Register Zend_View_Stream stream wrapper if short tags are disabled.
@@ -120,6 +127,37 @@ class Zend_View extends Zend_View_Abstract
         }
 
         parent::__construct($config);
+    }
+
+    /**
+     * Catch property change calls and prevent creation of dynamic properties (PHP 8.2)
+     *
+     * @param string $key
+     * @param mixed $val
+     */
+    public function __set($key, $val)
+    {
+        if (property_exists($this, $key)) {
+            $this->$key = $val;
+            return;
+        }
+
+        $this->_data[$key] = $val;
+    }
+
+    /**
+     * Catch property access calls and return the right values
+     *
+     * @param  string $key
+     * @return mixed
+     */
+    public function __get($key)
+    {
+        if (property_exists($this, $key)) {
+            return $this->$key;
+        }
+
+        return $this->_data[$key] ?? null;
     }
 
     /**

--- a/library/Zend/View/Abstract.php
+++ b/library/Zend/View/Abstract.php
@@ -140,6 +140,13 @@ abstract class Zend_View_Abstract implements Zend_View_Interface
     private $_strictVars = false;
 
     /**
+     * Data container
+     *
+     * @var array
+     */
+    private $_data = [];
+
+    /**
      * Constructor.
      *
      * @param array $config Configuration key-value pairs.
@@ -266,6 +273,10 @@ abstract class Zend_View_Abstract implements Zend_View_Interface
      */
     public function __get($key)
     {
+        if ('_' != substr($key, 0, 1) && isset($this->_data[$key])) {
+            return $this->_data[$key];
+        }
+
         if ($this->_strictVars) {
             trigger_error('Key "' . $key . '" does not exist', E_USER_NOTICE);
         }
@@ -283,7 +294,7 @@ abstract class Zend_View_Abstract implements Zend_View_Interface
     public function __isset($key)
     {
         if ('_' != substr($key, 0, 1)) {
-            return isset($this->$key);
+            return isset($this->_data[$key]);
         }
 
         return false;
@@ -305,7 +316,7 @@ abstract class Zend_View_Abstract implements Zend_View_Interface
     public function __set($key, $val)
     {
         if ('_' != substr($key, 0, 1)) {
-            $this->$key = $val;
+            $this->_data[$key] = $val;
             return;
         }
 
@@ -323,8 +334,8 @@ abstract class Zend_View_Abstract implements Zend_View_Interface
      */
     public function __unset($key)
     {
-        if ('_' != substr($key, 0, 1) && isset($this->$key)) {
-            unset($this->$key);
+        if ('_' != substr($key, 0, 1) && isset($this->_data[$key])) {
+            unset($this->_data[$key]);
         }
     }
 
@@ -836,21 +847,11 @@ abstract class Zend_View_Abstract implements Zend_View_Interface
     /**
      * Return list of all assigned variables
      *
-     * Returns all public properties of the object. Reflection is not used
-     * here as testing reflection properties for visibility is buggy.
-     *
      * @return array
      */
     public function getVars()
     {
-        $vars   = get_object_vars($this);
-        foreach ($vars as $key => $value) {
-            if ('_' == substr($key, 0, 1)) {
-                unset($vars[$key]);
-            }
-        }
-
-        return $vars;
+        return $this->_data;
     }
 
     /**
@@ -863,12 +864,7 @@ abstract class Zend_View_Abstract implements Zend_View_Interface
      */
     public function clearVars()
     {
-        $vars   = get_object_vars($this);
-        foreach ($vars as $key => $value) {
-            if ('_' != substr($key, 0, 1)) {
-                unset($this->$key);
-            }
-        }
+        $this->_data = [];
     }
 
     /**


### PR DESCRIPTION
PHP 8.2 release is closing in and this PR is fixing some of the warnings (all encountered during the initial testing of our application) that are present when running zf1-future under PHP 8.2.

Will update, if any other warnings/errors arise. Currently, fixes only "Creation of dynamic property ..." warnings.

Any notes are appreciated!