### PR TITLE
github action, run php-lint on php 7.1, php 7.2, php 7.3, php 7.4, php 8.0, php 8.1 in parallel mode

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -3,36 +3,57 @@ name: run PHP lint with supported PHP versions
 on: [push, pull_request]
 
 jobs:
-  php-lint:
+  php-lint-php71:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@v1
-      with:
-        fetch-depth: 0
+      uses: actions/checkout@v3
     - name: PHP syntax checker 7.1
       uses: prestashop/github-action-php-lint/7.1@v1.1
       with:
         folder-to-exclude: "! -path \"./tests/Zend/Loader/_files/*\""
+  php-lint-php72:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
     - name: PHP syntax checker 7.2
       uses: prestashop/github-action-php-lint/7.2@v1.1
       with:
         folder-to-exclude: "! -path \"./tests/Zend/Loader/_files/*\""
+  php-lint-php73:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
     - name: PHP syntax checker 7.3
       uses: prestashop/github-action-php-lint/7.3@v1.1
       with:
         folder-to-exclude: "! -path \"./tests/Zend/Loader/_files/*\""
+  php-lint-php74:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
     - name: PHP syntax checker 7.4
       uses: prestashop/github-action-php-lint/7.4@v1.1
       with:
         folder-to-exclude: "! -path \"./tests/Zend/Loader/_files/*\""
+  php-lint-php80:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
     - name: PHP syntax checker 8.0
       uses: prestashop/github-action-php-lint/8.0@v1.1
       with:
         folder-to-exclude: "! -path \"./tests/Zend/Loader/_files/*\""
+  php-lint-php81:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
     - name: PHP syntax checker 8.1
       uses: prestashop/github-action-php-lint/8.1@v1.1
       with:
         folder-to-exclude: "! -path \"./tests/Zend/Loader/_files/*\""
-
-# excluding the folder ./tests/Zend/Loader/_files/ because of ./tests/Zend/Loader/_files/ParseError.php


### PR DESCRIPTION
Setting github action `php-lint` in parallel mode to reduce time execute from 7-10 minutes to 1-2 minutes
