### PR TITLE
GitHub actions phpunit on php 8.2 & Fix bug on php 8.2

### DIFF
--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -3,6 +3,20 @@ name: PHPUnit-9
 on: [push, pull_request]
 
 jobs:
+  phpunit-php82:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Download phpunit
+        run: |
+          wget -O phpunit https://phar.phpunit.de/phpunit-9.5.26.phar
+          chmod +x phpunit
+        shell: bash
+      - name: PHPUnit 9 on php 8.2
+        uses: docker://php:8.2-rc-cli-alpine
+        with:
+          args: -d memory_limit=-1 ./phpunit --bootstrap tests/TestHelper.php tests/Zend/AllTests.php
   phpunit-php81:
     runs-on: ubuntu-latest
     steps:

--- a/tests/Zend/LocaleTest.php
+++ b/tests/Zend/LocaleTest.php
@@ -94,7 +94,7 @@ class Zend_LocaleTest extends TestCase
             $locales = [];
             foreach (explode(';', $this->_locale) as $l) {
                 $tmp = explode('=', $l);
-                $locales[$tmp[0]] = $tmp[1];
+                $locales[$tmp[0]] = count($tmp) > 1 ? $tmp[1] : $tmp[0];
             }
             setlocale(LC_ALL, $locales);
             return;

--- a/tests/Zend/Reflection/_files/FunctionWithEmbeddedVariableInString.php
+++ b/tests/Zend/Reflection/_files/FunctionWithEmbeddedVariableInString.php
@@ -3,10 +3,10 @@
 function firstOne()
 {
     $substitute = "Testing";
-    $varA = "${substitute} 123!";
+    $varA = "{$substitute} 123!";
     $varB = "{$substitute} 123!";
     $varC = "$substitute 123!";
-    $varD = "${substitute}";
+    $varD = "{$substitute}";
 }
 
 function secondOne()

--- a/tests/Zend/Validate/FloatTest.php
+++ b/tests/Zend/Validate/FloatTest.php
@@ -74,7 +74,7 @@ class Zend_Validate_FloatTest extends TestCase
             $locales = [];
             foreach (explode(';', $this->_locale) as $l) {
                 $tmp = explode('=', $l);
-                $locales[$tmp[0]] = $tmp[1];
+                $locales[$tmp[0]] = count($tmp) > 1 ? $tmp[1] : $tmp[0];
             }
             setlocale(LC_ALL, $locales);
             return;


### PR DESCRIPTION
Follow up PR #240, PR #269 

This PR focus on running PHPUnit 9 on PHP 8.2 without fail test case, reduce a deprecated message when run on PHP 8.2.

To save time,  i used [Classes with #[AllowDynamicProperties] attribute](https://php.watch/versions/8.2/dynamic-properties-deprecated#AllowDynamicProperties) to resolve issue  `Deprecated: Creation of dynamic property {x} is deprecated` on PHP 8.2

### Work done

- [x] Add github action run PHPUnit 9 on PHP 8.2
- [x] Fixed bug on php 8.2: `Deprecated: Creation of dynamic property {x} is deprecated`
- [x] resolved #276

### How to show all deprecated message on php 8.2 before apply this PR

```bash
cd zf1-future

echo "Checkout to commit before merge this PR"
git checkout b1d3fcc1cc4825b04f3da594b80f178ef8f47f95

echo "Install phpunit on your pc"
composer i

echo "Use docker to run PHPUnit 9 on PHP 8.2"
docker run -e CI=true -v $(pwd):$(pwd) -w $(pwd) -t --rm php:8.2-rc-cli-alpine -d memory_limit=-1 ./bin/phpunit -v --bootstrap tests/TestHelper.php tests/Zend/AllTests.php
```

[Result? You will see something like that :)](https://github.com/hungtrinh/zf1-future/actions/runs/3461208809/jobs/5778524314)

### Known issue

- [ ] Run PHPUnit on php 8.2 show this message. [PHP 8.2: Partially-supported callable are deprecated](https://php.watch/versions/8.2/partially-supported-callable-deprecation#deprecated-patterns)

```bash
Deprecated: Callables of the form ["Zend_EventManager_EventManagerTest", "Zend_EventManager_EventManagerTest::testAttachShouldReturnCallbackHandler"] are deprecated in /github/workspace/library/Zend/Stdlib/CallbackHandler.php on line 97
.
Deprecated: Callables of the form ["Zend_EventManager_EventManagerTest", "Zend_EventManager_EventManagerTest::testAttachShouldAddListenerToEvent"] are deprecated in /github/workspace/library/Zend/Stdlib/CallbackHandler.php on line 97
.
Deprecated: Callables of the form ["Zend_EventManager_EventManagerTest", "Zend_EventManager_EventManagerTest::testAttachShouldAddEventIfItDoesNotExist"] are deprecated in /github/workspace/library/Zend/Stdlib/CallbackHandler.php on line 97
...
Deprecated: Callables of the form ["Zend_EventManager_EventManagerTest", "Zend_EventManager_EventManagerTest::testDetachShouldRemoveListenerFromEvent"] are deprecated in /github/workspace/library/Zend/Stdlib/CallbackHandler.php on line 97
.
Deprecated: Callables of the form ["Zend_EventManager_EventManagerTest", "Zend_EventManager_EventManagerTest::testDetachShouldReturnFalseIfEventDoesNotExist"] are deprecated in /github/workspace/library/Zend/Stdlib/CallbackHandler.php on line 97
.
Deprecated: Callables of the form ["Zend_EventManager_EventManagerTest", "Zend_EventManager_EventManagerTest::testDetachShouldReturnFalseIfListenerDoesNotExist"] are deprecated in /github/workspace/library/Zend/Stdlib/CallbackHandler.php on line 97
...........................S.......  3658 / 10[79](https://github.com/Shardj/zf1-future/actions/runs/3467598245/jobs/5792619404#step:5:80)1 ( 33%)

Deprecated: Callables of the form ["Zend_EventManager_FilterChainTest", "Zend_EventManager_FilterChainTest::testSubscribeShouldReturnCallbackHandler"] are deprecated in /github/workspace/library/Zend/Stdlib/CallbackHandler.php on line 97
.
Deprecated: Callables of the form ["Zend_EventManager_FilterChainTest", "Zend_EventManager_FilterChainTest::testSubscribeShouldAddCallbackHandlerToFilters"] are deprecated in /github/workspace/library/Zend/Stdlib/CallbackHandler.php on line 97
.
Deprecated: Callables of the form ["Zend_EventManager_FilterChainTest", "Zend_EventManager_FilterChainTest::testDetachShouldRemoveCallbackHandlerFromFilters"] are deprecated in /github/workspace/library/Zend/Stdlib/CallbackHandler.php on line 97
.
Deprecated: Callables of the form ["Zend_EventManager_FilterChainTest", "Zend_EventManager_FilterChainTest::testDetachShouldReturnFalseIfCallbackHandlerDoesNotExist"] are deprecated in /github/workspace/library/Zend/Stdlib/CallbackHandler.php on line 97
```