### PR TITLE
Fix str_split('') logic to keep same as PHP before 8.2 on PHP 8.2

### DIFF
--- a/library/Zend/Console/Getopt.php
+++ b/library/Zend/Console/Getopt.php
@@ -789,7 +789,8 @@ class Zend_Console_Getopt
     protected function _parseShortOptionCluster(&$argv)
     {
         $flagCluster = ltrim(array_shift($argv), '-');
-        foreach (str_split($flagCluster) as $flag) {
+        $listFlagChar = $flagCluster === '' ?  [''] : str_split($flagCluster);
+        foreach ($listFlagChar as $flag) {
             $this->_parseSingleOption($flag, $argv);
         }
     }


### PR DESCRIPTION
Reference:
-  https://php.watch/versions/8.2/str_split-empty-string-empty-array

Fixes:
- https://github.com/Shardj/zf1-future/issues/276

Picked only relevant change from https://github.com/Shardj/zf1-future/pull/275 created by @hungtrinh