### PR TITLE
Add AllowDynamicProperties Attribute to classes

### DIFF
--- a/library/Zend/Application/Bootstrap/Bootstrap.php
+++ b/library/Zend/Application/Bootstrap/Bootstrap.php
@@ -37,6 +37,7 @@ require_once 'Zend/Application/Bootstrap/BootstrapAbstract.php';
  * @copyright  Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
+#[AllowDynamicProperties]
 class Zend_Application_Bootstrap_Bootstrap
     extends Zend_Application_Bootstrap_BootstrapAbstract
 {

--- a/library/Zend/Http/Client.php
+++ b/library/Zend/Http/Client.php
@@ -69,6 +69,7 @@ require_once 'Zend/Http/Response/Stream.php';
  * @copyright  Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
+#[AllowDynamicProperties]
 class Zend_Http_Client
 {
     /**

--- a/library/Zend/Http/Header/SetCookie.php
+++ b/library/Zend/Http/Header/SetCookie.php
@@ -49,6 +49,7 @@ require_once "Zend/Http/Header/HeaderValue.php";
  * @copyright  Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
+#[AllowDynamicProperties]
 class Zend_Http_Header_SetCookie
 {
 

--- a/library/Zend/Json/Decoder.php
+++ b/library/Zend/Json/Decoder.php
@@ -32,6 +32,7 @@ require_once 'Zend/Json.php';
  * @copyright  Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
+#[AllowDynamicProperties]
 class Zend_Json_Decoder
 {
     /**

--- a/library/Zend/Loader/Autoloader/Resource.php
+++ b/library/Zend/Loader/Autoloader/Resource.php
@@ -32,6 +32,7 @@ require_once 'Zend/Loader/Autoloader/Interface.php';
  * @copyright  Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
+#[AllowDynamicProperties]
 class Zend_Loader_Autoloader_Resource implements Zend_Loader_Autoloader_Interface
 {
     /**

--- a/library/Zend/Pdf.php
+++ b/library/Zend/Pdf.php
@@ -81,6 +81,7 @@ require_once 'Zend/Pdf/Element/String.php';
  * @copyright  Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
+#[AllowDynamicProperties]
 class Zend_Pdf
 {
   /**** Class Constants ****/

--- a/library/Zend/Pdf/Parser.php
+++ b/library/Zend/Pdf/Parser.php
@@ -35,6 +35,7 @@ require_once 'Zend/Pdf/StringParser.php';
  * @copyright  Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
+#[AllowDynamicProperties]
 class Zend_Pdf_Parser
 {
     /**

--- a/library/Zend/Pdf/Resource/Font/CidFont.php
+++ b/library/Zend/Pdf/Resource/Font/CidFont.php
@@ -54,6 +54,7 @@ require_once 'Zend/Pdf/Resource/Font.php';
  * @copyright  Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
+#[AllowDynamicProperties]
 abstract class Zend_Pdf_Resource_Font_CidFont extends Zend_Pdf_Resource_Font
 {
     /**

--- a/library/Zend/Pdf/Resource/Font/Simple/Standard/Courier.php
+++ b/library/Zend/Pdf/Resource/Font/Simple/Standard/Courier.php
@@ -46,6 +46,7 @@ require_once 'Zend/Pdf/Resource/Font/Simple/Standard.php';
  * @copyright  Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
+#[AllowDynamicProperties]
 class Zend_Pdf_Resource_Font_Simple_Standard_Courier extends Zend_Pdf_Resource_Font_Simple_Standard
 {
   /**** Public Interface ****/

--- a/library/Zend/Pdf/Resource/Font/Simple/Standard/CourierBold.php
+++ b/library/Zend/Pdf/Resource/Font/Simple/Standard/CourierBold.php
@@ -46,6 +46,7 @@ require_once 'Zend/Pdf/Resource/Font/Simple/Standard.php';
  * @copyright  Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
+#[AllowDynamicProperties]
 class Zend_Pdf_Resource_Font_Simple_Standard_CourierBold extends Zend_Pdf_Resource_Font_Simple_Standard
 {
   /**** Public Interface ****/

--- a/library/Zend/Pdf/Resource/Font/Simple/Standard/CourierBoldOblique.php
+++ b/library/Zend/Pdf/Resource/Font/Simple/Standard/CourierBoldOblique.php
@@ -46,6 +46,7 @@ require_once 'Zend/Pdf/Resource/Font/Simple/Standard.php';
  * @copyright  Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
+#[AllowDynamicProperties]
 class Zend_Pdf_Resource_Font_Simple_Standard_CourierBoldOblique extends Zend_Pdf_Resource_Font_Simple_Standard
 {
   /**** Public Interface ****/

--- a/library/Zend/Pdf/Resource/Font/Simple/Standard/CourierOblique.php
+++ b/library/Zend/Pdf/Resource/Font/Simple/Standard/CourierOblique.php
@@ -46,6 +46,7 @@ require_once 'Zend/Pdf/Resource/Font/Simple/Standard.php';
  * @copyright  Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
+#[AllowDynamicProperties]
 class Zend_Pdf_Resource_Font_Simple_Standard_CourierOblique extends Zend_Pdf_Resource_Font_Simple_Standard
 {
   /**** Public Interface ****/

--- a/library/Zend/Pdf/Resource/Font/Simple/Standard/Helvetica.php
+++ b/library/Zend/Pdf/Resource/Font/Simple/Standard/Helvetica.php
@@ -46,6 +46,7 @@ require_once 'Zend/Pdf/Resource/Font/Simple/Standard.php';
  * @copyright  Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
+#[AllowDynamicProperties]
 class Zend_Pdf_Resource_Font_Simple_Standard_Helvetica extends Zend_Pdf_Resource_Font_Simple_Standard
 {
   /**** Public Interface ****/

--- a/library/Zend/Pdf/Resource/Font/Simple/Standard/HelveticaBold.php
+++ b/library/Zend/Pdf/Resource/Font/Simple/Standard/HelveticaBold.php
@@ -45,6 +45,7 @@ require_once 'Zend/Pdf/Resource/Font/Simple/Standard.php';
  * @copyright  Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
+#[AllowDynamicProperties]
 class Zend_Pdf_Resource_Font_Simple_Standard_HelveticaBold extends Zend_Pdf_Resource_Font_Simple_Standard
 {
   /**** Public Interface ****/

--- a/library/Zend/Pdf/Resource/Font/Simple/Standard/HelveticaBoldOblique.php
+++ b/library/Zend/Pdf/Resource/Font/Simple/Standard/HelveticaBoldOblique.php
@@ -46,6 +46,7 @@ require_once 'Zend/Pdf/Resource/Font/Simple/Standard.php';
  * @copyright  Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
+#[AllowDynamicProperties]
 class Zend_Pdf_Resource_Font_Simple_Standard_HelveticaBoldOblique extends Zend_Pdf_Resource_Font_Simple_Standard
 {
   /**** Public Interface ****/

--- a/library/Zend/Pdf/Resource/Font/Simple/Standard/HelveticaOblique.php
+++ b/library/Zend/Pdf/Resource/Font/Simple/Standard/HelveticaOblique.php
@@ -46,6 +46,7 @@ require_once 'Zend/Pdf/Resource/Font/Simple/Standard.php';
  * @copyright  Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
+#[AllowDynamicProperties]
 class Zend_Pdf_Resource_Font_Simple_Standard_HelveticaOblique extends Zend_Pdf_Resource_Font_Simple_Standard
 {
   /**** Public Interface ****/

--- a/library/Zend/Pdf/Resource/Font/Simple/Standard/Symbol.php
+++ b/library/Zend/Pdf/Resource/Font/Simple/Standard/Symbol.php
@@ -46,6 +46,7 @@ require_once 'Zend/Pdf/Resource/Font/Simple/Standard.php';
  * @copyright  Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
+#[AllowDynamicProperties]
 class Zend_Pdf_Resource_Font_Simple_Standard_Symbol extends Zend_Pdf_Resource_Font_Simple_Standard
 {
   /**** Instance Variables ****/

--- a/library/Zend/Pdf/Resource/Font/Simple/Standard/TimesBold.php
+++ b/library/Zend/Pdf/Resource/Font/Simple/Standard/TimesBold.php
@@ -46,6 +46,7 @@ require_once 'Zend/Pdf/Resource/Font/Simple/Standard.php';
  * @copyright  Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
+#[AllowDynamicProperties]
 class Zend_Pdf_Resource_Font_Simple_Standard_TimesBold extends Zend_Pdf_Resource_Font_Simple_Standard
 {
   /**** Public Interface ****/

--- a/library/Zend/Pdf/Resource/Font/Simple/Standard/TimesBoldItalic.php
+++ b/library/Zend/Pdf/Resource/Font/Simple/Standard/TimesBoldItalic.php
@@ -46,6 +46,7 @@ require_once 'Zend/Pdf/Resource/Font/Simple/Standard.php';
  * @copyright  Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
+#[AllowDynamicProperties]
 class Zend_Pdf_Resource_Font_Simple_Standard_TimesBoldItalic extends Zend_Pdf_Resource_Font_Simple_Standard
 {
   /**** Public Interface ****/

--- a/library/Zend/Pdf/Resource/Font/Simple/Standard/TimesItalic.php
+++ b/library/Zend/Pdf/Resource/Font/Simple/Standard/TimesItalic.php
@@ -46,6 +46,7 @@ require_once 'Zend/Pdf/Resource/Font/Simple/Standard.php';
  * @copyright  Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
+#[AllowDynamicProperties]
 class Zend_Pdf_Resource_Font_Simple_Standard_TimesItalic extends Zend_Pdf_Resource_Font_Simple_Standard
 {
   /**** Public Interface ****/

--- a/library/Zend/Pdf/Resource/Font/Simple/Standard/TimesRoman.php
+++ b/library/Zend/Pdf/Resource/Font/Simple/Standard/TimesRoman.php
@@ -46,6 +46,7 @@ require_once 'Zend/Pdf/Resource/Font/Simple/Standard.php';
  * @copyright  Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
+#[AllowDynamicProperties]
 class Zend_Pdf_Resource_Font_Simple_Standard_TimesRoman extends Zend_Pdf_Resource_Font_Simple_Standard
 {
   /**** Public Interface ****/

--- a/library/Zend/Pdf/Resource/Font/Simple/Standard/ZapfDingbats.php
+++ b/library/Zend/Pdf/Resource/Font/Simple/Standard/ZapfDingbats.php
@@ -46,6 +46,7 @@ require_once 'Zend/Pdf/Resource/Font/Simple/Standard.php';
  * @copyright  Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
+#[AllowDynamicProperties]
 class Zend_Pdf_Resource_Font_Simple_Standard_ZapfDingbats extends Zend_Pdf_Resource_Font_Simple_Standard
 {
   /**** Instance Variables ****/

--- a/library/Zend/Pdf/Resource/Font/Type0.php
+++ b/library/Zend/Pdf/Resource/Font/Type0.php
@@ -60,6 +60,7 @@ require_once 'Zend/Pdf/Resource/Font.php';
  * @copyright  Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
+#[AllowDynamicProperties]
 class Zend_Pdf_Resource_Font_Type0 extends Zend_Pdf_Resource_Font
 {
     /**

--- a/library/Zend/Stdlib/CallbackHandler.php
+++ b/library/Zend/Stdlib/CallbackHandler.php
@@ -30,6 +30,7 @@
  * @copyright  Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
+#[AllowDynamicProperties]
 class Zend_Stdlib_CallbackHandler
 {
     /**

--- a/tests/Zend/AllTests/StreamWrapper/PhpInput.php
+++ b/tests/Zend/AllTests/StreamWrapper/PhpInput.php
@@ -49,6 +49,7 @@
  * @copyright  Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
+#[AllowDynamicProperties]
 class Zend_AllTests_StreamWrapper_PhpInput
 {
     protected static $_data;

--- a/tests/Zend/Application/Bootstrap/BootstrapTest.php
+++ b/tests/Zend/Application/Bootstrap/BootstrapTest.php
@@ -42,6 +42,7 @@ require_once 'Zend/Loader/Autoloader.php';
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  * @group      Zend_Application
  */
+#[AllowDynamicProperties]
 class Zend_Application_Bootstrap_BootstrapTest extends TestCase
 {
     public static function main()

--- a/tests/Zend/Cache/ClassFrontendTest.php
+++ b/tests/Zend/Cache/ClassFrontendTest.php
@@ -82,6 +82,7 @@ class test
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  * @group      Zend_Cache
  */
+#[AllowDynamicProperties]
 class Zend_Cache_ClassFrontendTest extends TestCase
 {
     private $_instance1;

--- a/tests/Zend/Cache/CoreTest.php
+++ b/tests/Zend/Cache/CoreTest.php
@@ -41,6 +41,7 @@ require_once 'Zend/Config.php';
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  * @group      Zend_Cache
  */
+#[AllowDynamicProperties]
 class Zend_Cache_CoreTest extends TestCase
 {
     private $_instance;

--- a/tests/Zend/Cache/FileFrontendTest.php
+++ b/tests/Zend/Cache/FileFrontendTest.php
@@ -38,6 +38,7 @@ require_once 'Zend/Cache/Backend/Test.php';
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  * @group      Zend_Cache
  */
+#[AllowDynamicProperties]
 class Zend_Cache_FileFrontendTest extends TestCase
 {
     private $_instance1;

--- a/tests/Zend/Cache/FunctionFrontendTest.php
+++ b/tests/Zend/Cache/FunctionFrontendTest.php
@@ -60,6 +60,7 @@ class fooclass
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  * @group      Zend_Cache
  */
+#[AllowDynamicProperties]
 class Zend_Cache_FunctionFrontendTest extends TestCase
 {
     private $_instance;

--- a/tests/Zend/Cache/ManagerTest.php
+++ b/tests/Zend/Cache/ManagerTest.php
@@ -32,6 +32,7 @@ require_once 'Zend/Config.php';
  * @copyright  Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
+#[AllowDynamicProperties]
 class Zend_Cache_ManagerTest extends TestCase
 {
     protected function setUp(): void

--- a/tests/Zend/Cache/OutputFrontendTest.php
+++ b/tests/Zend/Cache/OutputFrontendTest.php
@@ -38,6 +38,7 @@ require_once 'Zend/Cache/Backend/Test.php';
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  * @group      Zend_Cache
  */
+#[AllowDynamicProperties]
 class Zend_Cache_OutputFrontendTest extends TestCase
 {
     private $_instance;

--- a/tests/Zend/Cache/PageFrontendTest.php
+++ b/tests/Zend/Cache/PageFrontendTest.php
@@ -38,6 +38,7 @@ require_once 'Zend/Cache/Backend/Test.php';
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  * @group      Zend_Cache
  */
+#[AllowDynamicProperties]
 class Zend_Cache_PageFrontendTest extends TestCase
 {
     private $_instance;

--- a/tests/Zend/Captcha/DumbTest.php
+++ b/tests/Zend/Captcha/DumbTest.php
@@ -41,6 +41,7 @@ require_once 'Zend/View.php';
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  * @group      Zend_Captcha
  */
+#[AllowDynamicProperties]
 class Zend_Captcha_DumbTest extends TestCase
 {
     /**
@@ -127,6 +128,7 @@ class Zend_Captcha_DumbTest extends TestCase
     }
 }
 
+#[AllowDynamicProperties]
 class Zend_Captcha_DumbTest_SessionContainer
 {
     protected static $_word;

--- a/tests/Zend/Captcha/FigletTest.php
+++ b/tests/Zend/Captcha/FigletTest.php
@@ -42,6 +42,7 @@ require_once 'Zend/Config.php';
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  * @group      Zend_Captcha
  */
+#[AllowDynamicProperties]
 class Zend_Captcha_FigletTest extends TestCase
 {
     /**
@@ -326,6 +327,7 @@ class Zend_Captcha_FigletTest extends TestCase
     }
 }
 
+#[AllowDynamicProperties]
 class Zend_Captcha_FigletTest_SessionContainer
 {
     protected static $_word;

--- a/tests/Zend/Captcha/ReCaptchaTest.php
+++ b/tests/Zend/Captcha/ReCaptchaTest.php
@@ -41,6 +41,7 @@ require_once 'Zend/View.php';
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  * @group      Zend_Captcha
  */
+#[AllowDynamicProperties]
 class Zend_Captcha_ReCaptchaTest extends TestCase
 {
     /**

--- a/tests/Zend/Config/IniTest.php
+++ b/tests/Zend/Config/IniTest.php
@@ -36,6 +36,7 @@ require_once 'Zend/Config/Ini.php';
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  * @group      Zend_Config
  */
+#[AllowDynamicProperties]
 class Zend_Config_IniTest extends TestCase
 {
     protected $_iniFileConfig;

--- a/tests/Zend/Config/JsonTest.php
+++ b/tests/Zend/Config/JsonTest.php
@@ -35,6 +35,7 @@ require_once 'Zend/Config/Json.php';
  * @copyright  Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
+#[AllowDynamicProperties]
 class Zend_Config_JsonTest extends TestCase
 {
     protected $_iniFileConfig;

--- a/tests/Zend/Config/XmlTest.php
+++ b/tests/Zend/Config/XmlTest.php
@@ -36,6 +36,7 @@ require_once 'Zend/Config/Xml.php';
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  * @group      Zend_Config
  */
+#[AllowDynamicProperties]
 class Zend_Config_XmlTest extends TestCase
 {
     protected $_xmlFileConfig;

--- a/tests/Zend/Config/YamlTest.php
+++ b/tests/Zend/Config/YamlTest.php
@@ -36,6 +36,7 @@ require_once 'Zend/Config/Yaml.php';
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  * @group      Zend_Config
  */
+#[AllowDynamicProperties]
 class Zend_Config_YamlTest extends TestCase
 {
     protected function setUp(): void

--- a/tests/Zend/Controller/Action/Helper/AjaxContextTest.php
+++ b/tests/Zend/Controller/Action/Helper/AjaxContextTest.php
@@ -55,6 +55,7 @@ require_once 'Zend/View.php';
  * @group      Zend_Controller_Action
  * @group      Zend_Controller_Action_Helper
  */
+#[AllowDynamicProperties]
 class Zend_Controller_Action_Helper_AjaxContextTest extends TestCase
 {
     /**
@@ -246,6 +247,7 @@ class ZendTest_Controller_Request_SimpleMock_AjaxTest extends Zend_Controller_Re
     }
 }
 
+#[AllowDynamicProperties]
 class Zend_Controller_Action_Helper_AjaxContextTestController extends Zend_Controller_Action
 {
     public $ajaxable = [

--- a/tests/Zend/Controller/Action/Helper/AutoCompleteTest.php
+++ b/tests/Zend/Controller/Action/Helper/AutoCompleteTest.php
@@ -54,6 +54,7 @@ require_once 'Zend/Layout.php';
  * @group      Zend_Controller_Action
  * @group      Zend_Controller_Action_Helper
  */
+#[AllowDynamicProperties]
 class Zend_Controller_Action_Helper_AutoCompleteTest extends TestCase
 {
     /**

--- a/tests/Zend/Controller/Action/Helper/CacheTest.php
+++ b/tests/Zend/Controller/Action/Helper/CacheTest.php
@@ -20,6 +20,7 @@ require_once 'Zend/Cache/Backend.php';
 /**
  * Test class for Zend_Controller_Action_Helper_Cache
  */
+#[AllowDynamicProperties]
 class Zend_Controller_Action_Helper_CacheTest extends TestCase
 {
     protected $_requestUriOld;

--- a/tests/Zend/Controller/Action/Helper/ContextSwitchTest.php
+++ b/tests/Zend/Controller/Action/Helper/ContextSwitchTest.php
@@ -56,6 +56,7 @@ require_once 'Zend/View/Interface.php';
  * @group      Zend_Controller_Action
  * @group      Zend_Controller_Action_Helper
  */
+#[AllowDynamicProperties]
 class Zend_Controller_Action_Helper_ContextSwitchTest extends TestCase
 {
     /**
@@ -927,6 +928,7 @@ class Zend_Controller_Action_Helper_ContextSwitchTest extends TestCase
     }
 }
 
+#[AllowDynamicProperties]
 class Zend_Controller_Action_Helper_ContextSwitchTestController extends Zend_Controller_Action
 {
     public $contextSwitch;

--- a/tests/Zend/Controller/Action/Helper/JsonTest.php
+++ b/tests/Zend/Controller/Action/Helper/JsonTest.php
@@ -51,6 +51,7 @@ require_once 'Zend/Layout.php';
  * @group      Zend_Controller_Action
  * @group      Zend_Controller_Action_Helper
  */
+#[AllowDynamicProperties]
 class Zend_Controller_Action_Helper_JsonTest extends TestCase
 {
     /**

--- a/tests/Zend/Controller/Action/Helper/RedirectorTest.php
+++ b/tests/Zend/Controller/Action/Helper/RedirectorTest.php
@@ -49,6 +49,7 @@ require_once 'Zend/Controller/Response/Http.php';
  * @group      Zend_Controller_Action
  * @group      Zend_Controller_Action_Helper
  */
+#[AllowDynamicProperties]
 class Zend_Controller_Action_Helper_RedirectorTest extends TestCase
 {
     /**

--- a/tests/Zend/Controller/Action/Helper/UrlTest.php
+++ b/tests/Zend/Controller/Action/Helper/UrlTest.php
@@ -47,6 +47,7 @@ require_once 'Zend/Controller/Request/Http.php';
  * @group      Zend_Controller_Action
  * @group      Zend_Controller_Action_Helper
  */
+#[AllowDynamicProperties]
 class Zend_Controller_Action_Helper_UrlTest extends TestCase
 {
     /**

--- a/tests/Zend/Controller/ActionTest.php
+++ b/tests/Zend/Controller/ActionTest.php
@@ -46,6 +46,7 @@ require_once 'Zend/Controller/Response/Cli.php';
  * @group      Zend_Controller
  * @group      Zend_Controller_Action
  */
+#[AllowDynamicProperties]
 class Zend_Controller_ActionTest extends TestCase
 {
     /**

--- a/tests/Zend/Controller/Request/HttpTest.php
+++ b/tests/Zend/Controller/Request/HttpTest.php
@@ -41,6 +41,7 @@ require_once 'Zend/Controller/Request/Http.php';
  * @group      Zend_Controller
  * @group      Zend_Controller_Request
  */
+#[AllowDynamicProperties]
 class Zend_Controller_Request_HttpTest extends TestCase
 {
     /**

--- a/tests/Zend/Controller/Request/HttpTestCaseTest.php
+++ b/tests/Zend/Controller/Request/HttpTestCaseTest.php
@@ -44,6 +44,7 @@ require_once 'Zend/Controller/Request/HttpTestCase.php';
  * @group      Zend_Controller
  * @group      Zend_Controller_Request
  */
+#[AllowDynamicProperties]
 class Zend_Controller_Request_HttpTestCaseTest extends TestCase
 {
     /**

--- a/tests/Zend/Controller/Response/HttpTestCaseTest.php
+++ b/tests/Zend/Controller/Response/HttpTestCaseTest.php
@@ -44,6 +44,7 @@ require_once 'Zend/Controller/Response/HttpTestCase.php';
  * @group      Zend_Controller
  * @group      Zend_Controller_Response
  */
+#[AllowDynamicProperties]
 class Zend_Controller_Response_HttpTestCaseTest extends TestCase
 {
     /**

--- a/tests/Zend/Crypt/Rsa/RsaTest.php
+++ b/tests/Zend/Crypt/Rsa/RsaTest.php
@@ -34,6 +34,7 @@ require_once 'Zend/Crypt/Rsa.php';
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  * @group      Zend_Crypt
  */
+#[AllowDynamicProperties]
 class Zend_Crypt_RsaTest extends TestCase
 {
     protected $_testPemString = null;

--- a/tests/Zend/CurrencyTest.php
+++ b/tests/Zend/CurrencyTest.php
@@ -38,6 +38,7 @@ require_once 'Zend/Currency.php';
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  * @group      Zend_Currency
  */
+#[AllowDynamicProperties]
 class Zend_CurrencyTest extends TestCase
 {
     protected function setUp(): void

--- a/tests/Zend/Date/DateObjectTest.php
+++ b/tests/Zend/Date/DateObjectTest.php
@@ -36,6 +36,7 @@ require_once 'Zend/Date.php';
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  * @group      Zend_Date
  */
+#[AllowDynamicProperties]
 class Zend_Date_DateObjectTest extends TestCase
 {
     protected function setUp(): void

--- a/tests/Zend/DateTest.php
+++ b/tests/Zend/DateTest.php
@@ -56,6 +56,7 @@ require_once 'Zend/TimeSync.php';
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  * @group      Zend_Date
  */
+#[AllowDynamicProperties]
 class Zend_DateTest extends TestCase
 {
     private $_cache = null;

--- a/tests/Zend/Dom/QueryTest.php
+++ b/tests/Zend/Dom/QueryTest.php
@@ -43,6 +43,7 @@ require_once 'Zend/Dom/Query.php';
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  * @group      Zend_Dom
  */
+#[AllowDynamicProperties]
 class Zend_Dom_QueryTest extends TestCase
 {
     public $html;

--- a/tests/Zend/EventManager/EventManagerTest.php
+++ b/tests/Zend/EventManager/EventManagerTest.php
@@ -44,6 +44,7 @@ require_once 'Zend/Stdlib/CallbackHandler.php';
  * @copyright  Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
+#[AllowDynamicProperties]
 class Zend_EventManager_EventManagerTest extends TestCase
 {
     public static function main()

--- a/tests/Zend/EventManager/FilterChainTest.php
+++ b/tests/Zend/EventManager/FilterChainTest.php
@@ -40,6 +40,7 @@ require_once 'Zend/Stdlib/CallbackHandler.php';
  * @copyright  Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
+#[AllowDynamicProperties]
 class Zend_EventManager_FilterChainTest extends TestCase
 {
     public static function main()

--- a/tests/Zend/EventManager/GlobalEventManagerTest.php
+++ b/tests/Zend/EventManager/GlobalEventManagerTest.php
@@ -39,6 +39,7 @@ require_once 'Zend/EventManager/EventManager.php';
  * @copyright  Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
+#[AllowDynamicProperties]
 class Zend_EventManager_GlobalEventManagerTest extends TestCase
 {
     public static function main()

--- a/tests/Zend/EventManager/StaticEventManagerTest.php
+++ b/tests/Zend/EventManager/StaticEventManagerTest.php
@@ -39,6 +39,7 @@ require_once 'Zend/EventManager/StaticEventManager.php';
  * @copyright  Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
+#[AllowDynamicProperties]
 class Zend_EventManager_StaticEventManagerTest extends TestCase
 {
     public static function main()

--- a/tests/Zend/EventManager/StaticIntegrationTest.php
+++ b/tests/Zend/EventManager/StaticIntegrationTest.php
@@ -41,6 +41,7 @@ require_once 'Zend/EventManager/TestAsset/StaticEventsMock.php';
  * @copyright  Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
+#[AllowDynamicProperties]
 class Zend_EventManager_StaticIntegrationTest extends TestCase
 {
     public static function main()

--- a/tests/Zend/Filter/InflectorTest.php
+++ b/tests/Zend/Filter/InflectorTest.php
@@ -52,6 +52,7 @@ require_once 'Zend/Config.php';
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  * @group      Zend_Filter
  */
+#[AllowDynamicProperties]
 class Zend_Filter_InflectorTest extends TestCase
 {
     /**

--- a/tests/Zend/Filter/PregReplaceTest.php
+++ b/tests/Zend/Filter/PregReplaceTest.php
@@ -47,6 +47,7 @@ require_once 'Zend/Filter/PregReplace.php';
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  * @group      Zend_Filter
  */
+#[AllowDynamicProperties]
 class Zend_Filter_PregReplaceTest extends TestCase
 {
     /**

--- a/tests/Zend/FilterTest.php
+++ b/tests/Zend/FilterTest.php
@@ -37,6 +37,7 @@ require_once 'Zend/Filter.php';
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  * @group      Zend_Filter
  */
+#[AllowDynamicProperties]
 class Zend_FilterTest extends TestCase
 {
     /**

--- a/tests/Zend/Form/DisplayGroupTest.php
+++ b/tests/Zend/Form/DisplayGroupTest.php
@@ -51,6 +51,7 @@ require_once 'Zend/View.php';
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  * @group      Zend_Form
  */
+#[AllowDynamicProperties]
 class Zend_Form_DisplayGroupTest extends TestCase
 {
     public static function main()

--- a/tests/Zend/Http/Client/ClientTest.php
+++ b/tests/Zend/Http/Client/ClientTest.php
@@ -34,6 +34,7 @@ require_once 'Zend/Http/Client.php';
  * @group      Zend_Http
  * @group      Zend_Http_Client
  */
+#[AllowDynamicProperties]
 class Zend_Http_Client_ClientTest extends TestCase
 {
     /**

--- a/tests/Zend/Http/Header/SetCookieTest.php
+++ b/tests/Zend/Http/Header/SetCookieTest.php
@@ -46,6 +46,7 @@ require_once 'Zend/Controller/Response/HttpTestCase.php';
  * @group      Zend_Http_Header
  * @group      ZF-4520
  */
+#[AllowDynamicProperties]
 class Zend_Http_Header_SetCookieTest extends TestCase
 {
     /**

--- a/tests/Zend/Http/UserAgentTest.php
+++ b/tests/Zend/Http/UserAgentTest.php
@@ -42,6 +42,7 @@ require_once dirname(__FILE__) . '/TestAsset/PopulatedStorage.php';
  * @group      Zend_Http
  * @group      Zend_Http_UserAgent
  */
+#[AllowDynamicProperties]
 class Zend_Http_UserAgentTest extends TestCase
 {
     protected function setUp(): void

--- a/tests/Zend/Json/Server/CacheTest.php
+++ b/tests/Zend/Json/Server/CacheTest.php
@@ -44,6 +44,7 @@ require_once 'Zend/Json/Server.php';
  * @group      Zend_Json
  * @group      Zend_Json_Server
  */
+#[AllowDynamicProperties]
 class Zend_Json_Server_CacheTest extends TestCase
 {
     /**

--- a/tests/Zend/Json/Server/ErrorTest.php
+++ b/tests/Zend/Json/Server/ErrorTest.php
@@ -44,6 +44,7 @@ require_once 'Zend/Json.php';
  * @group      Zend_Json
  * @group      Zend_Json_Server
  */
+#[AllowDynamicProperties]
 class Zend_Json_Server_ErrorTest extends TestCase
 {
     /**

--- a/tests/Zend/Json/Server/RequestTest.php
+++ b/tests/Zend/Json/Server/RequestTest.php
@@ -42,6 +42,7 @@ require_once 'Zend/Json.php';
  * @group      Zend_Json
  * @group      Zend_Json_Server
  */
+#[AllowDynamicProperties]
 class Zend_Json_Server_RequestTest extends TestCase
 {
     /**

--- a/tests/Zend/Json/Server/ResponseTest.php
+++ b/tests/Zend/Json/Server/ResponseTest.php
@@ -45,6 +45,7 @@ require_once 'Zend/Json.php';
  * @group      Zend_Json
  * @group      Zend_Json_Server
  */
+#[AllowDynamicProperties]
 class Zend_Json_Server_ResponseTest extends TestCase
 {
     /**

--- a/tests/Zend/Json/Server/Smd/ServiceTest.php
+++ b/tests/Zend/Json/Server/Smd/ServiceTest.php
@@ -45,6 +45,7 @@ require_once 'Zend/Json.php';
  * @group      Zend_Json
  * @group      Zend_Json_Server
  */
+#[AllowDynamicProperties]
 class Zend_Json_Server_Smd_ServiceTest extends TestCase
 {
     /**

--- a/tests/Zend/Json/Server/SmdTest.php
+++ b/tests/Zend/Json/Server/SmdTest.php
@@ -45,6 +45,7 @@ require_once 'Zend/Json.php';
  * @group      Zend_Json
  * @group      Zend_Json_Server
  */
+#[AllowDynamicProperties]
 class Zend_Json_Server_SmdTest extends TestCase
 {
     /**

--- a/tests/Zend/Json/ServerTest.php
+++ b/tests/Zend/Json/ServerTest.php
@@ -47,6 +47,7 @@ require_once 'Zend/Server/Exception.php';
  * @group      Zend_Json
  * @group      Zend_Json_Server
  */
+#[AllowDynamicProperties]
 class Zend_Json_ServerTest extends TestCase
 {
     /**

--- a/tests/Zend/Loader/Autoloader/ResourceTest.php
+++ b/tests/Zend/Loader/Autoloader/ResourceTest.php
@@ -55,6 +55,7 @@ require_once 'Zend/Config.php';
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  * @group      Zend_Loader
  */
+#[AllowDynamicProperties]
 class Zend_Loader_Autoloader_ResourceTest extends TestCase
 {
     public static function main()

--- a/tests/Zend/Loader/AutoloaderFactoryTest.php
+++ b/tests/Zend/Loader/AutoloaderFactoryTest.php
@@ -43,6 +43,7 @@ require_once 'Zend/Loader/StandardAutoloader.php';
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  * @group      Loader
  */
+#[AllowDynamicProperties]
 class Zend_Loader_AutoloaderFactoryTest extends TestCase
 {
     public static function main()

--- a/tests/Zend/Loader/AutoloaderMultiVersionTest.php
+++ b/tests/Zend/Loader/AutoloaderMultiVersionTest.php
@@ -42,6 +42,7 @@ require_once 'Zend/Loader/Autoloader.php';
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  * @group      Zend_Loader
  */
+#[AllowDynamicProperties]
 class Zend_Loader_AutoloaderMultiVersionTest extends TestCase
 {
     public static function main()

--- a/tests/Zend/Loader/AutoloaderTest.php
+++ b/tests/Zend/Loader/AutoloaderTest.php
@@ -47,6 +47,7 @@ require_once 'Zend/Loader/Autoloader/Interface.php';
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  * @group      Zend_Loader
  */
+#[AllowDynamicProperties]
 class Zend_Loader_AutoloaderTest extends TestCase
 {
     public static function main()

--- a/tests/Zend/Loader/ClassMapAutoloaderTest.php
+++ b/tests/Zend/Loader/ClassMapAutoloaderTest.php
@@ -39,6 +39,7 @@ require_once 'Zend/Loader/ClassMapAutoloader.php';
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  * @group      Loader
  */
+#[AllowDynamicProperties]
 class Zend_Loader_ClassMapAutoloaderTest extends TestCase
 {
     /**

--- a/tests/Zend/Loader/PluginLoaderTest.php
+++ b/tests/Zend/Loader/PluginLoaderTest.php
@@ -42,6 +42,7 @@ require_once 'Zend/Loader/PluginLoader.php';
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  * @group      Zend_Loader
  */
+#[AllowDynamicProperties]
 class Zend_Loader_PluginLoaderTest extends TestCase
 {
     protected $_includeCache;

--- a/tests/Zend/Loader/StandardAutoloaderTest.php
+++ b/tests/Zend/Loader/StandardAutoloaderTest.php
@@ -38,6 +38,7 @@ require_once 'Zend/Loader/TestAsset/StandardAutoloader.php';
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  * @group      Loader
  */
+#[AllowDynamicProperties]
 class Zend_Loader_StandardAutoloaderTest extends TestCase
 {
     protected function setUp(): void

--- a/tests/Zend/LoaderTest.php
+++ b/tests/Zend/LoaderTest.php
@@ -48,6 +48,7 @@ require_once 'Zend/Loader/Autoloader.php';
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  * @group      Zend_Loader
  */
+#[AllowDynamicProperties]
 class Zend_LoaderTest extends TestCase
 {
     /**

--- a/tests/Zend/Log/Filter/ChainingTest.php
+++ b/tests/Zend/Log/Filter/ChainingTest.php
@@ -43,6 +43,7 @@ require_once 'Zend/Log/Writer/Stream.php';
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  * @group      Zend_Log
  */
+#[AllowDynamicProperties]
 class Zend_Log_Filter_ChainingTest extends TestCase
 {
     public static function main()

--- a/tests/Zend/Log/Filter/SuppressTest.php
+++ b/tests/Zend/Log/Filter/SuppressTest.php
@@ -43,6 +43,7 @@ require_once 'Zend/Log/Filter/Suppress.php';
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  * @group      Zend_Log
  */
+#[AllowDynamicProperties]
 class Zend_Log_Filter_SuppressTest extends TestCase
 {
     public static function main()

--- a/tests/Zend/Log/LogTest.php
+++ b/tests/Zend/Log/LogTest.php
@@ -49,6 +49,7 @@ require_once 'Zend/Log/FactoryInterface.php';
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  * @group      Zend_Log
  */
+#[AllowDynamicProperties]
 class Zend_Log_LogTest extends TestCase
 {
     public static function main()

--- a/tests/Zend/Log/Writer/DbTest.php
+++ b/tests/Zend/Log/Writer/DbTest.php
@@ -41,6 +41,7 @@ require_once 'Zend/Log/Writer/Db.php';
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  * @group      Zend_Log
  */
+#[AllowDynamicProperties]
 class Zend_Log_Writer_DbTest extends TestCase
 {
     public static function main()

--- a/tests/Zend/Mail/FileTransportTest.php
+++ b/tests/Zend/Mail/FileTransportTest.php
@@ -41,6 +41,7 @@ require_once 'Zend/Mail/Transport/File.php';
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  * @group      Zend_Mail
  */
+#[AllowDynamicProperties]
 class Zend_Mail_FileTransportTest extends TestCase
 {
     protected $_params;


### PR DESCRIPTION
_Extracted from https://github.com/Shardj/zf1-future/pull/275_ created by @hungtrinh

This is to fix issue:
> Deprecated: Creation of dynamic property {x} is deprecated
