### PR TITLE
Fix typo attribute '_mbStringFunctionsOverloaded' typo

### DIFF
--- a/library/Zend/Amf/Parse/Serializer.php
+++ b/library/Zend/Amf/Parse/Serializer.php
@@ -42,7 +42,7 @@ abstract class Zend_Amf_Parse_Serializer
      *
      * @var bool
      */
-    protected $mbStringFunctionsOverloaded;
+    protected $_mbStringFunctionsOverloaded;
 
     /**
      * Constructor


### PR DESCRIPTION
Extracted from https://github.com/Shardj/zf1-future/pull/275, created by @hungtrinh

See:
- https://github.com/Shardj/zf1-future/pull/275#pullrequestreview-1179839160

> - Correct property name is `$_mbStringFunctionsOverloaded`
> - `$mbStringFunctionsOverloaded` is typo from Rob Allen, it's ok with php < 8.2 but will raise 'deprecated' on php 8.2
> - https://github.com/Shardj/zf1-future/commit/5a9cf80e4646667e3b4be18c3fedd0e4b2403287#diff-b2f175f1769a1de6580426d48387c7977c6cf21685557f608aaef3a116f82b71