### PR TITLE
CI: Remove fetch-depth: 0

### DIFF
--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -8,8 +8,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
       - name: Prevent entrypoint issue on load docker image jakzal/phpqa:php
         run: mv composer.json composer.json.bk
       - name: PHPUnit 9 on php 8.1
@@ -21,8 +19,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
       - name: Prevent entrypoint issue on load docker image jakzal/phpqa:php
         run: mv composer.json composer.json.bk
       - name: PHPUnit 9 on php 8.0
@@ -34,8 +30,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
       - name: Prevent entrypoint issue on load docker image jakzal/phpqa:php
         run: mv composer.json composer.json.bk
       - name: PHPUnit 9 on php 7.4


### PR DESCRIPTION
_Extracted from https://github.com/Shardj/zf1-future/pull/275_, which was created by @hungtrinh

Use the default value fetch-depth: 1,
to use git shallow clone to improve performance.

It was originally added in 6bfadb153b805969a018457de425cea1606c1189