### PR TITLE
PHP 8.2 - Fix deprecated callable patterns in unit test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,7 +10,7 @@ tests/Zend/Translate/Adapter/_files/zend_cache---testid
 tests/TestConfiguration.php
 tests/Zend/Cache/zend_cache_tmp_dir*
 tests/Zend/Filter/_files/traversed.*
-tests/Zend/Filter/_files/app/tests/Zend/Filter/_files/zipextracted.txt
+tests/Zend/Filter/_files/**/zipextracted.txt
 tests/Zend/Mail/_files/test.tmp/INBOX
 tests/Zend/Paginator/_files/test-write-tmp.sqlite
 vendor/*

--- a/tests/Zend/EventManager/EventManagerTest.php
+++ b/tests/Zend/EventManager/EventManagerTest.php
@@ -64,13 +64,13 @@ class Zend_EventManager_EventManagerTest extends TestCase
 
     public function testAttachShouldReturnCallbackHandler()
     {
-        $listener = $this->events->attach('test', [$this, __METHOD__]);
+        $listener = $this->events->attach('test', [$this, __FUNCTION__]);
         $this->assertTrue($listener instanceof Zend_Stdlib_CallbackHandler);
     }
 
     public function testAttachShouldAddListenerToEvent()
     {
-        $listener = $this->events->attach('test', [$this, __METHOD__]);
+        $listener = $this->events->attach('test', [$this, __FUNCTION__]);
         $listeners = $this->events->getListeners('test');
         $this->assertEquals(1, count($listeners));
         $this->assertContains($listener, $listeners);
@@ -80,7 +80,7 @@ class Zend_EventManager_EventManagerTest extends TestCase
     {
         $events = $this->events->getEvents();
         $this->assertTrue(empty($events), var_export($events, 1));
-        $listener = $this->events->attach('test', [$this, __METHOD__]);
+        $listener = $this->events->attach('test', [$this, __FUNCTION__]);
         $events = $this->events->getEvents();
         $this->assertFalse(empty($events));
         $this->assertContains('test', $events);
@@ -115,7 +115,7 @@ class Zend_EventManager_EventManagerTest extends TestCase
 
     public function testDetachShouldRemoveListenerFromEvent()
     {
-        $listener = $this->events->attach('test', [$this, __METHOD__]);
+        $listener = $this->events->attach('test', [$this, __FUNCTION__]);
         $listeners = $this->events->getListeners('test');
         $this->assertContains($listener, $listeners);
         $this->events->detach($listener);
@@ -125,14 +125,14 @@ class Zend_EventManager_EventManagerTest extends TestCase
 
     public function testDetachShouldReturnFalseIfEventDoesNotExist()
     {
-        $listener = $this->events->attach('test', [$this, __METHOD__]);
+        $listener = $this->events->attach('test', [$this, __FUNCTION__]);
         $this->events->clearListeners('test');
         $this->assertFalse($this->events->detach($listener));
     }
 
     public function testDetachShouldReturnFalseIfListenerDoesNotExist()
     {
-        $listener1 = $this->events->attach('test', [$this, __METHOD__]);
+        $listener1 = $this->events->attach('test', [$this, __FUNCTION__]);
         $this->events->clearListeners('test');
         $listener2 = $this->events->attach('test', [$this, 'handleTestEvent']);
         $this->assertFalse($this->events->detach($listener1));

--- a/tests/Zend/EventManager/FilterChainTest.php
+++ b/tests/Zend/EventManager/FilterChainTest.php
@@ -59,13 +59,13 @@ class Zend_EventManager_FilterChainTest extends TestCase
 
     public function testSubscribeShouldReturnCallbackHandler()
     {
-        $handle = $this->filterchain->attach([ $this, __METHOD__ ]);
+        $handle = $this->filterchain->attach([ $this, __FUNCTION__ ]);
         $this->assertTrue($handle instanceof Zend_Stdlib_CallbackHandler);
     }
 
     public function testSubscribeShouldAddCallbackHandlerToFilters()
     {
-        $handler = $this->filterchain->attach([$this, __METHOD__]);
+        $handler = $this->filterchain->attach([$this, __FUNCTION__]);
         $handlers = $this->filterchain->getFilters();
         $this->assertEquals(1, count($handlers));
         $this->assertTrue($handlers->contains($handler));
@@ -73,7 +73,7 @@ class Zend_EventManager_FilterChainTest extends TestCase
 
     public function testDetachShouldRemoveCallbackHandlerFromFilters()
     {
-        $handle = $this->filterchain->attach([ $this, __METHOD__ ]);
+        $handle = $this->filterchain->attach([ $this, __FUNCTION__ ]);
         $handles = $this->filterchain->getFilters();
         $this->assertTrue($handles->contains($handle));
         $this->filterchain->detach($handle);
@@ -83,7 +83,7 @@ class Zend_EventManager_FilterChainTest extends TestCase
 
     public function testDetachShouldReturnFalseIfCallbackHandlerDoesNotExist()
     {
-        $handle1 = $this->filterchain->attach([ $this, __METHOD__ ]);
+        $handle1 = $this->filterchain->attach([ $this, __FUNCTION__ ]);
         $this->filterchain->clearFilters();
         $handle2 = $this->filterchain->attach([ $this, 'handleTestTopic' ]);
         $this->assertFalse($this->filterchain->detach($handle1));


### PR DESCRIPTION
Fix "Known issue" section of PR #275

### Expected Result

Those test case bellow pass without "deprecated message" on php 8.2 (same as php 7.4, php 8.0, php 8.1)

- [tests/Zend/EventManager/EventManagerTest.php](https://github.com/Shardj/zf1-future/blob/355b75a5f5af60380e803cbf9a5f8175c04aad00/tests/Zend/EventManager/EventManagerTest.php)
- [tests/Zend/EventManager/FilterChainTest.php](https://github.com/Shardj/zf1-future/blob/355b75a5f5af60380e803cbf9a5f8175c04aad00/tests/Zend/EventManager/FilterChainTest.php)

### Actual Result

```bash
$ docker run -v $(pwd):$(pwd) -w $(pwd) -t --rm php:8.2-rc-cli-alpine -d memory_limit=-1 ./bin/phpunit -v --bootstrap tests/TestHelper.php tests/Zend/EventManager/EventManagerTest.php    

PHPUnit 9.5.25 #StandWithUkraine

.
Deprecated: Callables of the form ["Zend_EventManager_EventManagerTest", "Zend_EventManager_EventManagerTest::testAttachShouldReturnCallbackHandler"] are deprecated in /Users/trinhhung/Projects/zf1-future/library/Zend/Stdlib/CallbackHandler.php on line 97
.
Deprecated: Callables of the form ["Zend_EventManager_EventManagerTest", "Zend_EventManager_EventManagerTest::testAttachShouldAddListenerToEvent"] are deprecated in /Users/trinhhung/Projects/zf1-future/library/Zend/Stdlib/CallbackHandler.php on line 97
.
Deprecated: Callables of the form ["Zend_EventManager_EventManagerTest", "Zend_EventManager_EventManagerTest::testAttachShouldAddEventIfItDoesNotExist"] are deprecated in /Users/trinhhung/Projects/zf1-future/library/Zend/Stdlib/CallbackHandler.php on line 97
...
Deprecated: Callables of the form ["Zend_EventManager_EventManagerTest", "Zend_EventManager_EventManagerTest::testDetachShouldRemoveListenerFromEvent"] are deprecated in /Users/trinhhung/Projects/zf1-future/library/Zend/Stdlib/CallbackHandler.php on line 97
.
Deprecated: Callables of the form ["Zend_EventManager_EventManagerTest", "Zend_EventManager_EventManagerTest::testDetachShouldReturnFalseIfEventDoesNotExist"] are deprecated in /Users/trinhhung/Projects/zf1-future/library/Zend/Stdlib/CallbackHandler.php on line 97
.
Deprecated: Callables of the form ["Zend_EventManager_EventManagerTest", "Zend_EventManager_EventManagerTest::testDetachShouldReturnFalseIfListenerDoesNotExist"] are deprecated in /Users/trinhhung/Projects/zf1-future/library/Zend/Stdlib/CallbackHandler.php on line 97
...........................S......                        42 / 42 (100%)

Time: 00:00.097, Memory: 6.00 MB

OK, but incomplete, skipped, or risky tests!
Tests: 42, Assertions: 119, Skipped: 1.
```

```bash
docker run -v $(pwd):$(pwd) -w $(pwd) -t --rm php:8.2-rc-cli-alpine -d memory_limit=-1 ./bin/phpunit -v --bootstrap tests/TestHelper.php tests/Zend/EventManager/FilterChainTest.php

PHPUnit 9.5.25 #StandWithUkraine

.
Deprecated: Callables of the form ["Zend_EventManager_FilterChainTest", "Zend_EventManager_FilterChainTest::testSubscribeShouldReturnCallbackHandler"] are deprecated in /Users/trinhhung/Projects/zf1-future/library/Zend/Stdlib/CallbackHandler.php on line 97
.
Deprecated: Callables of the form ["Zend_EventManager_FilterChainTest", "Zend_EventManager_FilterChainTest::testSubscribeShouldAddCallbackHandlerToFilters"] are deprecated in /Users/trinhhung/Projects/zf1-future/library/Zend/Stdlib/CallbackHandler.php on line 97
.
Deprecated: Callables of the form ["Zend_EventManager_FilterChainTest", "Zend_EventManager_FilterChainTest::testDetachShouldRemoveCallbackHandlerFromFilters"] are deprecated in /Users/trinhhung/Projects/zf1-future/library/Zend/Stdlib/CallbackHandler.php on line 97
.
Deprecated: Callables of the form ["Zend_EventManager_FilterChainTest", "Zend_EventManager_FilterChainTest::testDetachShouldReturnFalseIfCallbackHandlerDoesNotExist"] are deprecated in /Users/trinhhung/Projects/zf1-future/library/Zend/Stdlib/CallbackHandler.php on line 97
.....                                                           9 / 9 (100%)

Time: 00:00.110, Memory: 6.00 MB

OK (9 tests, 13 assertions)
```

### List test case raise deprecated message

https://github.com/Shardj/zf1-future/blob/f6f029cf332403536871b997cf59f49820a7e6b0/tests/Zend/EventManager/EventManagerTest.php#L65-L87

https://github.com/Shardj/zf1-future/blob/f6f029cf332403536871b997cf59f49820a7e6b0/tests/Zend/EventManager/EventManagerTest.php#L116-L139

https://github.com/Shardj/zf1-future/blob/f6f029cf332403536871b997cf59f49820a7e6b0/tests/Zend/EventManager/FilterChainTest.php#L60-L90

### PHP call stack raise deprecated message 

Sample 1 test case only:

**CALL STACK**

- Zend_Stdlib_CallbackHandler->registerCallback ([library/Zend/Stdlib/CallbackHandler.php:97](https://github.com/Shardj/zf1-future/blob/f6f029cf332403536871b997cf59f49820a7e6b0/library/Zend/Stdlib/CallbackHandler.php#L97))
- Zend_Stdlib_CallbackHandler->__construct ([library/Zend/Stdlib/CallbackHandler.php:64](https://github.com/Shardj/zf1-future/blob/f6f029cf332403536871b997cf59f49820a7e6b0/library/Zend/Stdlib/CallbackHandler.php#L64))
- Zend_EventManager_EventManager->attach ([library/Zend/EventManager/EventManager.php:303](https://github.com/Shardj/zf1-future/blob/f6f029cf332403536871b997cf59f49820a7e6b0/library/Zend/EventManager/EventManager.php#L303))
- Zend_EventManager_EventManagerTest->testAttachShouldReturnCallbackHandler ([tests/Zend/EventManager/EventManagerTest.php:67](https://github.com/Shardj/zf1-future/blob/f6f029cf332403536871b997cf59f49820a7e6b0/tests/Zend/EventManager/EventManagerTest.php#L67))

### Solution

Deprecated pattern: [is_callable([new MyClass(), "MyOtherClass::myMethod"])](https://php.watch/versions/8.2/partially-supported-callable-deprecation#deprecated-patterns)
Migrate to pattern: [is_callable([new MyClass(), "myMethod"])](https://php.watch/versions/8.2/partially-supported-callable-deprecation#unaffected-patterns)