### PR TITLE
class Zend_Cache_Frontend does not exist, removed from PHPDoc

### DIFF
--- a/library/Zend/Cache.php
+++ b/library/Zend/Cache.php
@@ -86,7 +86,7 @@ abstract class Zend_Cache
      * @param boolean $customBackendNaming if true, the backend argument is used as a complete class name ; if false, the backend argument is used as the end of "Zend_Cache_Backend_[...]" class name
      * @param boolean $autoload if true, there will no require_once for backend and frontend (useful only for custom backends/frontends)
      * @throws Zend_Cache_Exception
-     * @return Zend_Cache_Core|Zend_Cache_Frontend
+     * @return Zend_Cache_Core
      */
     public static function factory($frontend, $backend, $frontendOptions = [], $backendOptions = [], $customFrontendNaming = false, $customBackendNaming = false, $autoload = false)
     {
@@ -160,7 +160,7 @@ abstract class Zend_Cache
      * @param array   $frontendOptions
      * @param boolean $customFrontendNaming
      * @param boolean $autoload
-     * @return Zend_Cache_Core|Zend_Cache_Frontend
+     * @return Zend_Cache_Core
      */
     public static function _makeFrontend($frontend, $frontendOptions = [], $customFrontendNaming = false, $autoload = false)
     {


### PR DESCRIPTION
The remaining Zend_Cache_Core return class should be fine