### PR TITLE
Complete dynamic properties for tests/Zend/**

### DIFF
--- a/tests/Zend/Amf/Adobe/IntrospectorTest.php
+++ b/tests/Zend/Amf/Adobe/IntrospectorTest.php
@@ -45,6 +45,11 @@ require_once 'Zend/Amf/Adobe/Introspector.php';
  */
 class Zend_Amf_Adobe_IntrospectorTest extends TestCase
 {
+    /**
+     * @var \Zend_Amf_Adobe_Introspector|mixed
+     */
+    protected $introspector;
+
     public static function main()
     {
         $suite = new TestSuite(__CLASS__);

--- a/tests/Zend/Amf/AuthTest.php
+++ b/tests/Zend/Amf/AuthTest.php
@@ -51,6 +51,11 @@ require_once 'Zend/Acl/Role.php';
 class Zend_Amf_AuthTest extends TestCase
 {
     /**
+     * @var \Zend_Acl|mixed
+     */
+    protected $_acl;
+
+    /**
      * Enter description here...
      *
      * @var Zend_Amf_Server
@@ -301,6 +306,14 @@ class WrongPassword extends Zend_Amf_Auth_Abstract
 
 class RightPassword extends Zend_Amf_Auth_Abstract
 {
+    /**
+     * @var mixed
+     */
+    protected $_name;
+    /**
+     * @var mixed
+     */
+    protected $_role;
     public function __construct($name, $role)
     {
         $this->_name = $name;

--- a/tests/Zend/Amf/ResponseTest.php
+++ b/tests/Zend/Amf/ResponseTest.php
@@ -51,6 +51,16 @@ require_once 'Zend/Date.php';
  */
 class Zend_Amf_ResponseTest extends TestCase
 {
+    /**
+     * @var \Zend_Amf_Value_MessageHeader|mixed
+     */
+    protected $header1;
+
+    /**
+     * @var \Zend_Amf_Value_MessageHeader|mixed
+     */
+    protected $header2;
+
     // The message response status code.
     public $responseURI = "/2/onResult";
 

--- a/tests/Zend/Amf/Value/MessageBodyTest.php
+++ b/tests/Zend/Amf/Value/MessageBodyTest.php
@@ -44,6 +44,11 @@ require_once 'Zend/Amf/Value/MessageBody.php';
 class Zend_Amf_Value_MessageBodyTest extends TestCase
 {
     /**
+     * @var \Zend_Amf_Value_MessageBody|mixed
+     */
+    protected $body;
+
+    /**
      * Runs the test methods of this class.
      *
      * @return void

--- a/tests/Zend/Application/Bootstrap/BootstrapTest.php
+++ b/tests/Zend/Application/Bootstrap/BootstrapTest.php
@@ -42,9 +42,28 @@ require_once 'Zend/Loader/Autoloader.php';
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  * @group      Zend_Application
  */
-#[AllowDynamicProperties]
 class Zend_Application_Bootstrap_BootstrapTest extends TestCase
 {
+    /**
+     * @var mixed[]|mixed
+     */
+    protected $loaders;
+
+    /**
+     * @var \Zend_Loader_Autoloader
+     */
+    protected $autoloader;
+
+    /**
+     * @var \Zend_Application|mixed
+     */
+    protected $application;
+
+    /**
+     * @var \Zend_Application_Bootstrap_Bootstrap|mixed
+     */
+    protected $bootstrap;
+
     public static function main()
     {
         $suite = new TestSuite(__CLASS__);

--- a/tests/Zend/Cache/ClassFrontendTest.php
+++ b/tests/Zend/Cache/ClassFrontendTest.php
@@ -82,9 +82,18 @@ class test
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  * @group      Zend_Cache
  */
-#[AllowDynamicProperties]
 class Zend_Cache_ClassFrontendTest extends TestCase
 {
+    /**
+     * @var \Zend_Cache_Backend_Test|mixed
+     */
+    protected $_backend1;
+
+    /**
+     * @var \Zend_Cache_Backend_Test|mixed
+     */
+    protected $_backend2;
+
     private $_instance1;
     private $_instance2;
 

--- a/tests/Zend/Cache/CoreTest.php
+++ b/tests/Zend/Cache/CoreTest.php
@@ -41,9 +41,13 @@ require_once 'Zend/Config.php';
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  * @group      Zend_Cache
  */
-#[AllowDynamicProperties]
 class Zend_Cache_CoreTest extends TestCase
 {
+    /**
+     * @var \Zend_Cache_Backend_Test|mixed
+     */
+    protected $_backend;
+
     private $_instance;
 
     protected function setUp(): void

--- a/tests/Zend/Cache/FileFrontendTest.php
+++ b/tests/Zend/Cache/FileFrontendTest.php
@@ -38,9 +38,13 @@ require_once 'Zend/Cache/Backend/Test.php';
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  * @group      Zend_Cache
  */
-#[AllowDynamicProperties]
 class Zend_Cache_FileFrontendTest extends TestCase
 {
+    /**
+     * @var \Zend_Cache_Backend_Test|mixed
+     */
+    protected $_backend;
+
     private $_instance1;
     private $_instance2;
     private $_instance3;

--- a/tests/Zend/Cache/FunctionFrontendTest.php
+++ b/tests/Zend/Cache/FunctionFrontendTest.php
@@ -60,9 +60,13 @@ class fooclass
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  * @group      Zend_Cache
  */
-#[AllowDynamicProperties]
 class Zend_Cache_FunctionFrontendTest extends TestCase
 {
+    /**
+     * @var \Zend_Cache_Backend_Test|mixed
+     */
+    protected $_backend;
+
     private $_instance;
 
     protected function setUp(): void

--- a/tests/Zend/Cache/ManagerTest.php
+++ b/tests/Zend/Cache/ManagerTest.php
@@ -32,9 +32,16 @@ require_once 'Zend/Config.php';
  * @copyright  Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
-#[AllowDynamicProperties]
+
 class Zend_Cache_ManagerTest extends TestCase
 {
+    protected $_cache_dir;
+
+    /**
+     * @var \Zend_Cache_Core|null|mixed
+     */
+    protected $_cache;
+
     protected function setUp(): void
     {
         $this->_cache_dir = $this->mkdir();

--- a/tests/Zend/Cache/OutputFrontendTest.php
+++ b/tests/Zend/Cache/OutputFrontendTest.php
@@ -38,9 +38,13 @@ require_once 'Zend/Cache/Backend/Test.php';
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  * @group      Zend_Cache
  */
-#[AllowDynamicProperties]
 class Zend_Cache_OutputFrontendTest extends TestCase
 {
+    /**
+     * @var \Zend_Cache_Backend_Test|mixed
+     */
+    protected $_backend;
+
     private $_instance;
 
     protected function setUp(): void

--- a/tests/Zend/Cache/PageFrontendTest.php
+++ b/tests/Zend/Cache/PageFrontendTest.php
@@ -38,9 +38,13 @@ require_once 'Zend/Cache/Backend/Test.php';
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  * @group      Zend_Cache
  */
-#[AllowDynamicProperties]
 class Zend_Cache_PageFrontendTest extends TestCase
 {
+    /**
+     * @var \Zend_Cache_Backend_Test|mixed
+     */
+    protected $_backend;
+
     private $_instance;
 
     protected function setUp(): void

--- a/tests/Zend/Captcha/DumbTest.php
+++ b/tests/Zend/Captcha/DumbTest.php
@@ -41,9 +41,18 @@ require_once 'Zend/View.php';
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  * @group      Zend_Captcha
  */
-#[AllowDynamicProperties]
 class Zend_Captcha_DumbTest extends TestCase
 {
+    protected $word;
+
+    /**
+     * @var \Zend_Form_Element_Captcha|mixed
+     */
+    protected $element;
+    /**
+     * @var \Zend_Captcha_Adapter|mixed
+     */
+    protected $captcha;
     /**
      * Runs the test methods of this class.
      *

--- a/tests/Zend/Captcha/FigletTest.php
+++ b/tests/Zend/Captcha/FigletTest.php
@@ -42,9 +42,28 @@ require_once 'Zend/Config.php';
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  * @group      Zend_Captcha
  */
-#[AllowDynamicProperties]
 class Zend_Captcha_FigletTest extends TestCase
 {
+    /**
+     * @var mixed|string
+     */
+    protected $word;
+
+    /**
+     * @var \Zend_Form_Element_Captcha|mixed
+     */
+    protected $element;
+
+    /**
+     * @var \Zend_Captcha_Adapter|mixed
+     */
+    protected $captcha;
+
+    /**
+     * @var string
+     */
+    protected $id;
+
     /**
      * Runs the test methods of this class.
      *

--- a/tests/Zend/Captcha/ImageTest.php
+++ b/tests/Zend/Captcha/ImageTest.php
@@ -43,6 +43,31 @@ require_once 'Zend/Captcha/Adapter.php';
  */
 class Zend_Captcha_ImageTest extends TestCase
 {
+    /**
+     * @var mixed|string
+     */
+    protected $word;
+
+    /**
+     * @var string|mixed
+     */
+    protected $testDir;
+
+    /**
+     * @var \Zend_Form_Element_Captcha|mixed
+     */
+    protected $element;
+
+    /**
+     * @var \Zend_Captcha_Adapter|mixed
+     */
+    protected $captcha;
+
+    /**
+     * @var string
+     */
+    protected $id;
+
     protected $_tmpDir;
 
     /**
@@ -102,7 +127,7 @@ class Zend_Captcha_ImageTest extends TestCase
     protected function tearDown(): void
     {
         // remove chaptcha images
-        foreach (new DirectoryIterator($this->testDir) as $file) {
+        foreach (new DirectoryIterator((string) $this->testDir) as $file) {
             if (!$file->isDot() && !$file->isDir()) {
                 unlink($file->getPathname());
             }

--- a/tests/Zend/Captcha/ReCaptchaTest.php
+++ b/tests/Zend/Captcha/ReCaptchaTest.php
@@ -41,9 +41,20 @@ require_once 'Zend/View.php';
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  * @group      Zend_Captcha
  */
-#[AllowDynamicProperties]
 class Zend_Captcha_ReCaptchaTest extends TestCase
 {
+    protected $word;
+
+    /**
+     * @var \Zend_Form_Element_Captcha|mixed
+     */
+    protected $element;
+
+    /**
+     * @var \Zend_Captcha_Adapter
+     */
+    protected $captcha;
+
     /**
      * Runs the test methods of this class.
      *

--- a/tests/Zend/Config/IniTest.php
+++ b/tests/Zend/Config/IniTest.php
@@ -36,9 +36,33 @@ require_once 'Zend/Config/Ini.php';
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  * @group      Zend_Config
  */
-#[AllowDynamicProperties]
 class Zend_Config_IniTest extends TestCase
 {
+    /**
+     * @var string|mixed
+     */
+    protected $_iniFileMultipleInheritanceConfig;
+
+    /**
+     * @var string|mixed
+     */
+    protected $_iniFileSeparatorConfig;
+
+    /**
+     * @var string
+     */
+    protected $_nonReadableConfig;
+
+    /**
+     * @var string|mixed
+     */
+    protected $_iniFileNoSectionsConfig;
+
+    /**
+     * @var string|mixed
+     */
+    protected $_iniFileInvalid;
+
     protected $_iniFileConfig;
     protected $_iniFileAllSectionsConfig;
     protected $_iniFileCircularConfig;

--- a/tests/Zend/Config/JsonTest.php
+++ b/tests/Zend/Config/JsonTest.php
@@ -35,9 +35,28 @@ require_once 'Zend/Config/Json.php';
  * @copyright  Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
-#[AllowDynamicProperties]
 class Zend_Config_JsonTest extends TestCase
 {
+    /**
+     * @var string|mixed
+     */
+    protected $_iniFileMultipleInheritanceConfig;
+
+    /**
+     * @var string
+     */
+    protected $_nonReadableConfig;
+
+    /**
+     * @var string|mixed
+     */
+    protected $_iniFileNoSectionsConfig;
+
+    /**
+     * @var string|mixed
+     */
+    protected $_iniFileInvalid;
+
     protected $_iniFileConfig;
     protected $_iniFileAllSectionsConfig;
     protected $_iniFileCircularConfig;

--- a/tests/Zend/Config/XmlTest.php
+++ b/tests/Zend/Config/XmlTest.php
@@ -36,9 +36,38 @@ require_once 'Zend/Config/Xml.php';
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  * @group      Zend_Config
  */
-#[AllowDynamicProperties]
 class Zend_Config_XmlTest extends TestCase
 {
+    /**
+     * @var string|mixed
+     */
+    protected $_xmlFileTopLevelStringConfig;
+
+    /**
+     * @var string|mixed
+     */
+    protected $_xmlFileOneTopLevelStringConfig;
+
+    /**
+     * @var string
+     */
+    protected $_nonReadableConfig;
+
+    /**
+     * @var string|mixed
+     */
+    protected $_xmlFileSameNameKeysConfig;
+
+    /**
+     * @var string|mixed
+     */
+    protected $_xmlFileShortParamsOneConfig;
+
+    /**
+     * @var string|mixed
+     */
+    protected $_xmlFileShortParamsTwoConfig;
+
     protected $_xmlFileConfig;
     protected $_xmlFileAllSectionsConfig;
     protected $_xmlFileCircularConfig;

--- a/tests/Zend/Config/YamlTest.php
+++ b/tests/Zend/Config/YamlTest.php
@@ -36,9 +36,79 @@ require_once 'Zend/Config/Yaml.php';
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  * @group      Zend_Config
  */
-#[AllowDynamicProperties]
 class Zend_Config_YamlTest extends TestCase
 {
+    /**
+     * @var string|mixed
+     */
+    protected $_iniFileConfig;
+
+    /**
+     * @var string|mixed
+     */
+
+     protected $_iniFileAllSectionsConfig;
+
+     /**
+     * @var string|mixed
+     */
+    protected $_iniFileCircularConfig;
+
+    /**
+     * @var string
+     */
+    protected $_nonReadableConfig;
+
+    /**
+     * @var string|mixed
+     */
+    protected $_iniFileInvalid;
+
+    /**
+     * @var string|mixed
+     */
+    protected $_iniFileSameNameKeysConfig;
+
+    /**
+     * @var string|mixed
+     */
+    protected $_badIndentationConfig;
+
+    /**
+     * @var string|mixed
+     */
+    protected $_booleansConfig;
+
+    /**
+     * @var string|mixed
+     */
+    protected $_constantsConfig;
+
+    /**
+     * @var string|mixed
+     */
+    protected $_yamlInlineCommentsConfig;
+
+    /**
+     * @var string|mixed
+     */
+    protected $_yamlIndentedCommentsConfig;
+
+    /**
+     * @var string|mixed
+     */
+    protected $_yamlListConstantsConfig;
+
+    /**
+     * @var string|mixed
+     */
+    protected $_listBooleansConfig;
+
+    /**
+     * @var string|mixed
+     */
+    protected $_yamlSingleQuotedString;
+
     protected function setUp(): void
     {
         $this->_iniFileConfig = dirname(__FILE__) . '/_files/config.yaml';

--- a/tests/Zend/Controller/Action/Helper/AjaxContextTest.php
+++ b/tests/Zend/Controller/Action/Helper/AjaxContextTest.php
@@ -55,9 +55,48 @@ require_once 'Zend/View.php';
  * @group      Zend_Controller_Action
  * @group      Zend_Controller_Action_Helper
  */
-#[AllowDynamicProperties]
 class Zend_Controller_Action_Helper_AjaxContextTest extends TestCase
 {
+    /**
+     * @var \Zend_Controller_Front|mixed
+     */
+    protected $front;
+
+    /**
+     * @var \Zend_Layout|mixed
+     */
+    protected $layout;
+
+    /**
+     * @var \Zend_Controller_Action_Helper_AjaxContext|mixed
+     */
+    protected $helper;
+
+    /**
+     * @var \Zend_Controller_Request_Http|mixed
+     */
+    protected $request;
+
+    /**
+     * @var \Zend_Controller_Response_Cli|mixed
+     */
+    protected $response;
+
+    /**
+     * @var \Zend_VIew|mixed
+     */
+    protected $view;
+
+    /**
+     * @var \Zend_Controller_Action_Helper_Abstract|mixed
+     */
+    protected $viewRenderer;
+
+    /**
+     * @var \Zend_Controller_Action_Helper_AjaxContextTestController|mixed
+     */
+    protected $controller;
+
     /**
      * Runs the test methods of this class.
      *

--- a/tests/Zend/Controller/Action/Helper/AutoCompleteTest.php
+++ b/tests/Zend/Controller/Action/Helper/AutoCompleteTest.php
@@ -54,9 +54,33 @@ require_once 'Zend/Layout.php';
  * @group      Zend_Controller_Action
  * @group      Zend_Controller_Action_Helper
  */
-#[AllowDynamicProperties]
 class Zend_Controller_Action_Helper_AutoCompleteTest extends TestCase
 {
+    /**
+     * @var \Zend_Controller_Request_Http|mixed
+     */
+    protected $request;
+
+    /**
+     * @var \Zend_Controller_Response_Cli|mixed
+     */
+    protected $response;
+
+    /**
+     * @var \Zend_Controller_Front|mixed
+     */
+    protected $front;
+
+    /**
+     * @var \Zend_Controller_Action_Helper_Abstract|mixed
+     */
+    protected $viewRenderer;
+
+    /**
+     * @var \Zend_Layout|mixed
+     */
+    protected $layout;
+
     /**
      * Runs the test methods of this class.
      *

--- a/tests/Zend/Controller/Action/Helper/CacheTest.php
+++ b/tests/Zend/Controller/Action/Helper/CacheTest.php
@@ -20,9 +20,16 @@ require_once 'Zend/Cache/Backend.php';
 /**
  * Test class for Zend_Controller_Action_Helper_Cache
  */
-#[AllowDynamicProperties]
 class Zend_Controller_Action_Helper_CacheTest extends TestCase
 {
+    /**
+     * @var \Zend_Controller_Front|mixed
+     */
+    protected $front;
+    /**
+     * @var \Zend_Controller_Request_Http|mixed
+     */
+    protected $request;
     protected $_requestUriOld;
 
     /**

--- a/tests/Zend/Controller/Action/Helper/ContextSwitchTest.php
+++ b/tests/Zend/Controller/Action/Helper/ContextSwitchTest.php
@@ -56,9 +56,48 @@ require_once 'Zend/View/Interface.php';
  * @group      Zend_Controller_Action
  * @group      Zend_Controller_Action_Helper
  */
-#[AllowDynamicProperties]
 class Zend_Controller_Action_Helper_ContextSwitchTest extends TestCase
 {
+    /**
+     * @var \Zend_Controller_Front|mixed
+     */
+    protected $front;
+
+    /**
+     * @var \Zend_Layout|mixed
+     */
+    protected $layout;
+
+    /**
+     * @var \Zend_Controller_Action_Helper_ContextSwitch|mixed
+     */
+    protected $helper;
+
+    /**
+     * @var \Zend_Controller_Request_Http|mixed
+     */
+    protected $request;
+
+    /**
+     * @var \Zend_Controller_Response_Cli|mixed
+     */
+    protected $response;
+
+    /**
+     * @var \Zend_View|mixed
+     */
+    protected $view;
+
+    /**
+     * @var \Zend_Controller_Action_Helper_Abstract|mixed
+     */
+    protected $viewRenderer;
+
+    /**
+     * @var \Zend_Controller_Action_Helper_ContextSwitchTestController|mixed
+     */
+    protected $controller;
+
     /**
      * Runs the test methods of this class.
      *

--- a/tests/Zend/Controller/Action/Helper/JsonTest.php
+++ b/tests/Zend/Controller/Action/Helper/JsonTest.php
@@ -51,9 +51,21 @@ require_once 'Zend/Layout.php';
  * @group      Zend_Controller_Action
  * @group      Zend_Controller_Action_Helper
  */
-#[AllowDynamicProperties]
 class Zend_Controller_Action_Helper_JsonTest extends TestCase
 {
+    /**
+     * @var \Zend_Controller_Response_Http|mixed
+     */
+    protected $response;
+
+    /**
+     * @var \Zend_Controller_Action_Helper_ViewRenderer|mixed
+     */
+    protected $viewRenderer;
+    /**
+     * @var \Zend_Controller_Action_Helper_Json|mixed
+     */
+    protected $helper;
     /**
      * Runs the test methods of this class.
      *

--- a/tests/Zend/Controller/Action/Helper/RedirectorTest.php
+++ b/tests/Zend/Controller/Action/Helper/RedirectorTest.php
@@ -49,9 +49,18 @@ require_once 'Zend/Controller/Response/Http.php';
  * @group      Zend_Controller_Action
  * @group      Zend_Controller_Action_Helper
  */
-#[AllowDynamicProperties]
 class Zend_Controller_Action_Helper_RedirectorTest extends TestCase
 {
+    /**
+     * @var \Zend_Controller_Router_Interface|mixed
+     */
+    protected $router;
+
+    /**
+     * @var array<string, mixed>|mixed
+     */
+    protected $_server;
+
     /**
      * @var Zend_Controller_Action_Helper_Redirector
      */

--- a/tests/Zend/Controller/Action/Helper/UrlTest.php
+++ b/tests/Zend/Controller/Action/Helper/UrlTest.php
@@ -47,9 +47,18 @@ require_once 'Zend/Controller/Request/Http.php';
  * @group      Zend_Controller_Action
  * @group      Zend_Controller_Action_Helper
  */
-#[AllowDynamicProperties]
 class Zend_Controller_Action_Helper_UrlTest extends TestCase
 {
+    /**
+     * @var \Zend_Controller_Front|mixed
+     */
+    protected $front;
+
+    /**
+     * @var \Zend_Controller_Action_Helper_Url|mixed
+     */
+    protected $helper;
+
     /**
      * Runs the test methods of this class.
      *

--- a/tests/Zend/Controller/ActionTest.php
+++ b/tests/Zend/Controller/ActionTest.php
@@ -46,9 +46,13 @@ require_once 'Zend/Controller/Response/Cli.php';
  * @group      Zend_Controller
  * @group      Zend_Controller_Action
  */
-#[AllowDynamicProperties]
 class Zend_Controller_ActionTest extends TestCase
 {
+    /**
+     * @var \Zend_Controller_ActionTest_TestController|mixed
+     */
+    protected $_controller;
+
     /**
      * Runs the test methods of this class.
      *

--- a/tests/Zend/Controller/Dispatcher/StandardTest.php
+++ b/tests/Zend/Controller/Dispatcher/StandardTest.php
@@ -48,6 +48,8 @@ require_once 'Zend/Controller/Response/Cli.php';
  */
 class Zend_Controller_Dispatcher_StandardTest extends TestCase
 {
+    protected $error;
+
     protected $_dispatcher;
 
     /**

--- a/tests/Zend/Controller/Request/HttpTestCaseTest.php
+++ b/tests/Zend/Controller/Request/HttpTestCaseTest.php
@@ -44,9 +44,13 @@ require_once 'Zend/Controller/Request/HttpTestCase.php';
  * @group      Zend_Controller
  * @group      Zend_Controller_Request
  */
-#[AllowDynamicProperties]
 class Zend_Controller_Request_HttpTestCaseTest extends TestCase
 {
+    /**
+     * @var \Zend_Controller_Request_HttpTestCase|mixed
+     */
+    protected $request;
+
     /**
      * Runs the test methods of this class.
      *

--- a/tests/Zend/Controller/Response/HttpTestCaseTest.php
+++ b/tests/Zend/Controller/Response/HttpTestCaseTest.php
@@ -44,9 +44,13 @@ require_once 'Zend/Controller/Response/HttpTestCase.php';
  * @group      Zend_Controller
  * @group      Zend_Controller_Response
  */
-#[AllowDynamicProperties]
 class Zend_Controller_Response_HttpTestCaseTest extends TestCase
 {
+    /**
+     * @var \Zend_Controller_Response_HttpTestCase|mixed
+     */
+    protected $response;
+
     /**
      * Runs the test methods of this class.
      *

--- a/tests/Zend/Crypt/Rsa/RsaTest.php
+++ b/tests/Zend/Crypt/Rsa/RsaTest.php
@@ -34,9 +34,23 @@ require_once 'Zend/Crypt/Rsa.php';
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  * @group      Zend_Crypt
  */
-#[AllowDynamicProperties]
 class Zend_Crypt_RsaTest extends TestCase
 {
+    /**
+     * @var string|mixed
+     */
+    protected $_testPemStringPublic;
+
+    /**
+     * @var string|mixed
+     */
+    protected $_testCertificateString;
+
+    /**
+     * @var string|mixed
+     */
+    protected $_testCertificatePath;
+
     protected $_testPemString = null;
 
     protected $_testPemPath = null;

--- a/tests/Zend/CurrencyTest.php
+++ b/tests/Zend/CurrencyTest.php
@@ -38,9 +38,13 @@ require_once 'Zend/Currency.php';
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  * @group      Zend_Currency
  */
-#[AllowDynamicProperties]
 class Zend_CurrencyTest extends TestCase
 {
+    /**
+     * @var \Zend_Cache_Core|mixed
+     */
+    protected $_cache;
+
     protected function setUp(): void
     {
         require_once 'Zend/Cache.php';

--- a/tests/Zend/Date/DateObjectTest.php
+++ b/tests/Zend/Date/DateObjectTest.php
@@ -36,9 +36,18 @@ require_once 'Zend/Date.php';
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  * @group      Zend_Date
  */
-#[AllowDynamicProperties]
 class Zend_Date_DateObjectTest extends TestCase
 {
+    /**
+     * @var string|mixed
+     */
+    protected $originalTimezone;
+
+    /**
+     * @var \Zend_Cache_Core|mixed
+     */
+    protected $_cache;
+
     protected function setUp(): void
     {
         $this->originalTimezone = date_default_timezone_get();

--- a/tests/Zend/DateTest.php
+++ b/tests/Zend/DateTest.php
@@ -56,9 +56,13 @@ require_once 'Zend/TimeSync.php';
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  * @group      Zend_Date
  */
-#[AllowDynamicProperties]
 class Zend_DateTest extends TestCase
 {
+    /**
+     * @var string|mixed
+     */
+    protected $originalTimezone;
+
     private $_cache = null;
     private $_orig = [];
 

--- a/tests/Zend/Dojo/BuildLayerTest.php
+++ b/tests/Zend/Dojo/BuildLayerTest.php
@@ -44,6 +44,11 @@ require_once 'Zend/Json.php';
  */
 class Zend_Dojo_BuildLayerTest extends TestCase
 {
+    /**
+     * @var \Zend_View|mixed
+     */
+    protected $view;
+
     public static function main()
     {
         $suite = new TestSuite(__CLASS__);

--- a/tests/Zend/Dojo/Form/Decorator/AccordionContainerTest.php
+++ b/tests/Zend/Dojo/Form/Decorator/AccordionContainerTest.php
@@ -58,6 +58,18 @@ require_once 'Zend/Dojo/View/Helper/Dojo.php';
  */
 class Zend_Dojo_Form_Decorator_AccordionContainerTest extends TestCase
 {
+    protected $view;
+
+    /**
+     * @var \Zend_Dojo_Form_Decorator_AccordionContainer|mixed
+     */
+    protected $decorator;
+
+    /**
+     * @var \Zend_Dojo_Form
+     */
+    protected $element;
+
     /**
      * Runs the test methods of this class.
      *

--- a/tests/Zend/Dojo/Form/Decorator/AccordionPaneTest.php
+++ b/tests/Zend/Dojo/Form/Decorator/AccordionPaneTest.php
@@ -58,6 +58,15 @@ require_once 'Zend/Dojo/View/Helper/Dojo.php';
  */
 class Zend_Dojo_Form_Decorator_AccordionPaneTest extends TestCase
 {
+    protected $view;
+
+    /**
+     * @var \Zend_Dojo_Form_Decorator_AccordionPane|mixed
+     */
+    protected $decorator;
+
+    protected $element;
+
     /**
      * Runs the test methods of this class.
      *

--- a/tests/Zend/Dojo/Form/Decorator/BorderContainerTest.php
+++ b/tests/Zend/Dojo/Form/Decorator/BorderContainerTest.php
@@ -59,6 +59,18 @@ require_once 'Zend/Dojo/View/Helper/Dojo.php';
 class Zend_Dojo_Form_Decorator_BorderContainerTest extends TestCase
 {
     /**
+     * @var \Zend_View
+     */
+    protected $view;
+
+    /**
+     * @var \Zend_Dojo_Form_Decorator_BorderContainer|mixed
+     */
+    protected $decorator;
+
+    protected $element;
+
+    /**
      * Runs the test methods of this class.
      *
      * @return void

--- a/tests/Zend/Dojo/Form/Decorator/DijitContainerTest.php
+++ b/tests/Zend/Dojo/Form/Decorator/DijitContainerTest.php
@@ -62,6 +62,23 @@ require_once 'Zend/Dojo/View/Helper/Dojo.php';
 class Zend_Dojo_Form_Decorator_DijitContainerTest extends TestCase
 {
     /**
+     * @var mixed[]|string[]|mixed
+     */
+    protected $errors;
+
+    protected $view;
+
+    /**
+     * @var \Zend_Dojo_Form_Decorator_ContentPane|mixed
+     */
+    protected $decorator;
+
+    /**
+     * @var \Zend_Dojo_Form
+     */
+    protected $element;
+
+    /**
      * Runs the test methods of this class.
      *
      * @return void

--- a/tests/Zend/Dojo/Form/Decorator/DijitElementTest.php
+++ b/tests/Zend/Dojo/Form/Decorator/DijitElementTest.php
@@ -59,6 +59,26 @@ require_once 'Zend/Dojo/View/Helper/Dojo.php';
 class Zend_Dojo_Form_Decorator_DijitElementTest extends TestCase
 {
     /**
+     * @var mixed[]|string[]|mixed
+     */
+    protected $errors;
+
+    /**
+     * @var \Zend_View
+     */
+    protected $view;
+
+    /**
+     * @var \Zend_Dojo_Form_Decorator_DijitElement|mixed
+     */
+    protected $decorator;
+
+    /**
+     * @var \Zend_Dojo_Form_Element_TextBox
+     */
+    protected $element;
+
+    /**
      * Runs the test methods of this class.
      *
      * @return void

--- a/tests/Zend/Dojo/Form/Decorator/DijitFormTest.php
+++ b/tests/Zend/Dojo/Form/Decorator/DijitFormTest.php
@@ -59,6 +59,21 @@ require_once 'Zend/Dojo/View/Helper/Dojo.php';
 class Zend_Dojo_Form_Decorator_DijitFormTest extends TestCase
 {
     /**
+     * @var \Zend_View
+     */
+    protected $view;
+
+    /**
+     * @var \Zend_Dojo_Form_Decorator_DijitForm|mixed
+     */
+    protected $decorator;
+
+    /**
+     * @var \Zend_Dojo_Form
+     */
+    protected $element;
+
+    /**
      * Runs the test methods of this class.
      *
      * @return void

--- a/tests/Zend/Dojo/Form/Decorator/SplitContainerTest.php
+++ b/tests/Zend/Dojo/Form/Decorator/SplitContainerTest.php
@@ -59,6 +59,20 @@ require_once 'Zend/Dojo/View/Helper/Dojo.php';
 class Zend_Dojo_Form_Decorator_SplitContainerTest extends TestCase
 {
     /**
+     * @var \Zend_View
+     */
+    protected $view;
+
+    /**
+     * @var \Zend_Dojo_Form_Decorator_SplitContainer|mixed
+     */
+    protected $decorator;
+
+    /**
+     * @var \Zend_Dojo_Form
+     */
+    protected $element;
+    /**
      * Runs the test methods of this class.
      *
      * @return void

--- a/tests/Zend/Dojo/Form/Decorator/StackContainerTest.php
+++ b/tests/Zend/Dojo/Form/Decorator/StackContainerTest.php
@@ -59,6 +59,21 @@ require_once 'Zend/Dojo/View/Helper/Dojo.php';
 class Zend_Dojo_Form_Decorator_StackContainerTest extends TestCase
 {
     /**
+     * @var \Zend_View
+     */
+    protected $view;
+
+    /**
+     * @var \Zend_Dojo_Form_Decorator_StackContainer|mixed
+     */
+    protected $decorator;
+
+    /**
+     * @var \Zend_Dojo_Form
+     */
+    protected $element;
+
+    /**
      * Runs the test methods of this class.
      *
      * @return void

--- a/tests/Zend/Dojo/Form/Decorator/TabContainerTest.php
+++ b/tests/Zend/Dojo/Form/Decorator/TabContainerTest.php
@@ -59,6 +59,21 @@ require_once 'Zend/Dojo/View/Helper/Dojo.php';
 class Zend_Dojo_Form_Decorator_TabContainerTest extends TestCase
 {
     /**
+     * @var \Zend_View
+     */
+    protected $view;
+
+    /**
+     * @var \Zend_Dojo_Form_Decorator_TabContainer|mixed
+     */
+    protected $decorator;
+
+    /**
+     * @var \Zend_Dojo_Form
+     */
+    protected $element;
+
+    /**
      * Runs the test methods of this class.
      *
      * @return void

--- a/tests/Zend/Dojo/Form/Element/ButtonTest.php
+++ b/tests/Zend/Dojo/Form/Element/ButtonTest.php
@@ -59,6 +59,16 @@ require_once 'Zend/Dojo/View/Helper/Dojo.php';
 class Zend_Dojo_Form_Element_ButtonTest extends TestCase
 {
     /**
+     * @var \Zend_View
+     */
+    protected $view;
+
+    /**
+     * @var \Zend_Dojo_Form_Element_Button
+     */
+    protected $element;
+
+    /**
      * Runs the test methods of this class.
      *
      * @return void

--- a/tests/Zend/Dojo/Form/Element/CheckBoxTest.php
+++ b/tests/Zend/Dojo/Form/Element/CheckBoxTest.php
@@ -56,6 +56,16 @@ require_once 'Zend/Dojo/View/Helper/Dojo.php';
 class Zend_Dojo_Form_Element_CheckBoxTest extends TestCase
 {
     /**
+     * @var \Zend_View
+     */
+    protected $view;
+
+    /**
+     * @var \Zend_Dojo_Form_Element_CheckBox
+     */
+    protected $element;
+
+    /**
      * Runs the test methods of this class.
      *
      * @return void

--- a/tests/Zend/Dojo/Form/Element/ComboBoxTest.php
+++ b/tests/Zend/Dojo/Form/Element/ComboBoxTest.php
@@ -56,6 +56,16 @@ require_once 'Zend/Dojo/View/Helper/Dojo.php';
 class Zend_Dojo_Form_Element_ComboBoxTest extends TestCase
 {
     /**
+     * @var \Zend_View
+     */
+    protected $view;
+
+    /**
+     * @var \Zend_Dojo_Form_Element_ComboBox
+     */
+    protected $element;
+
+    /**
      * Runs the test methods of this class.
      *
      * @return void

--- a/tests/Zend/Dojo/Form/Element/CurrencyTextBoxTest.php
+++ b/tests/Zend/Dojo/Form/Element/CurrencyTextBoxTest.php
@@ -56,6 +56,15 @@ require_once 'Zend/Dojo/View/Helper/Dojo.php';
 class Zend_Dojo_Form_Element_CurrencyTextBoxTest extends TestCase
 {
     /**
+     * @var \Zend_View
+     */
+    protected $view;
+
+    /**
+     * @var Zend_Dojo_Form_Element_CurrencyTextBox
+     */
+    protected $element;
+    /**
      * Runs the test methods of this class.
      *
      * @return void

--- a/tests/Zend/Dojo/Form/Element/DateTextBoxTest.php
+++ b/tests/Zend/Dojo/Form/Element/DateTextBoxTest.php
@@ -56,6 +56,16 @@ require_once 'Zend/Dojo/View/Helper/Dojo.php';
 class Zend_Dojo_Form_Element_DateTextBoxTest extends TestCase
 {
     /**
+     * @var \Zend_View
+     */
+    protected $view;
+
+    /**
+     * @var \Zend_Dojo_Form_Element_DateTextBox
+     */
+    protected $element;
+
+    /**
      * Runs the test methods of this class.
      *
      * @return void

--- a/tests/Zend/Dojo/Form/Element/DijitTest.php
+++ b/tests/Zend/Dojo/Form/Element/DijitTest.php
@@ -56,6 +56,16 @@ require_once 'Zend/Dojo/View/Helper/Dojo.php';
 class Zend_Dojo_Form_Element_DijitTest extends TestCase
 {
     /**
+     * @var \Zend_View
+     */
+    protected $view;
+
+    /**
+     * @var \Zend_Dojo_Form_Element_TextBox
+     */
+    protected $element;
+
+    /**
      * Runs the test methods of this class.
      *
      * @return void

--- a/tests/Zend/Dojo/Form/Element/EditorTest.php
+++ b/tests/Zend/Dojo/Form/Element/EditorTest.php
@@ -56,6 +56,16 @@ require_once 'Zend/Dojo/View/Helper/Dojo.php';
 class Zend_Dojo_Form_Element_EditorTest extends TestCase
 {
     /**
+     * @var \Zend_View
+     */
+    protected $view;
+
+    /**
+     * @var \Zend_Dojo_Form_Element_TextBox
+     */
+    protected $element;
+
+    /**
      * Runs the test methods of this class.
      *
      * @return void

--- a/tests/Zend/Dojo/Form/Element/FilteringSelectTest.php
+++ b/tests/Zend/Dojo/Form/Element/FilteringSelectTest.php
@@ -56,6 +56,16 @@ require_once 'Zend/Dojo/View/Helper/Dojo.php';
 class Zend_Dojo_Form_Element_FilteringSelectTest extends TestCase
 {
     /**
+     * @var \Zend_View
+     */
+    protected $view;
+
+    /**
+     * @var \Zend_Dojo_Form_Element_FilteringSelect
+     */
+    protected $element;
+
+    /**
      * Runs the test methods of this class.
      *
      * @return void

--- a/tests/Zend/Dojo/Form/Element/HorizontalSliderTest.php
+++ b/tests/Zend/Dojo/Form/Element/HorizontalSliderTest.php
@@ -56,6 +56,16 @@ require_once 'Zend/Dojo/View/Helper/Dojo.php';
 class Zend_Dojo_Form_Element_HorizontalSliderTest extends TestCase
 {
     /**
+     * @var \Zend_View
+     */
+    protected $view;
+
+    /**
+     * @var \Zend_Dojo_Form_Element_HorizontalSlider
+     */
+    protected $element;
+
+    /**
      * Runs the test methods of this class.
      *
      * @return void

--- a/tests/Zend/Dojo/Form/Element/NumberSpinnerTest.php
+++ b/tests/Zend/Dojo/Form/Element/NumberSpinnerTest.php
@@ -56,6 +56,16 @@ require_once 'Zend/Dojo/View/Helper/Dojo.php';
 class Zend_Dojo_Form_Element_NumberSpinnerTest extends TestCase
 {
     /**
+     * @var \Zend_View
+     */
+    protected $view;
+
+    /**
+     * @var \Zend_Dojo_Form_Element_NumberSpinner
+     */
+    protected $element;
+
+    /**
      * Runs the test methods of this class.
      *
      * @return void

--- a/tests/Zend/Dojo/Form/Element/NumberTextBoxTest.php
+++ b/tests/Zend/Dojo/Form/Element/NumberTextBoxTest.php
@@ -55,6 +55,16 @@ require_once 'Zend/Dojo/View/Helper/Dojo.php';
 class Zend_Dojo_Form_Element_NumberTextBoxTest extends TestCase
 {
     /**
+     * @var \Zend_View
+     */
+    protected $view;
+
+    /**
+     * @var \Zend_Dojo_Form_Element_NumberTextBox
+     */
+    protected $element;
+
+    /**
      * Runs the test methods of this class.
      *
      * @return void

--- a/tests/Zend/Dojo/Form/Element/PasswordTextBoxTest.php
+++ b/tests/Zend/Dojo/Form/Element/PasswordTextBoxTest.php
@@ -56,6 +56,16 @@ require_once 'Zend/Dojo/View/Helper/Dojo.php';
 class Zend_Dojo_Form_Element_PasswordTextBoxTest extends TestCase
 {
     /**
+     * @var \Zend_View
+     */
+    protected $view;
+
+    /**
+     * @var \Zend_Dojo_Form_Element_PasswordTextBox
+     */
+    protected $element;
+
+    /**
      * Runs the test methods of this class.
      *
      * @return void

--- a/tests/Zend/Dojo/Form/Element/RadioButtonTest.php
+++ b/tests/Zend/Dojo/Form/Element/RadioButtonTest.php
@@ -56,6 +56,16 @@ require_once 'Zend/Dojo/View/Helper/Dojo.php';
 class Zend_Dojo_Form_Element_RadioButtonTest extends TestCase
 {
     /**
+     * @var \Zend_View
+     */
+    protected $view;
+
+    /**
+     * @var \Zend_Dojo_Form_Element_RadioButton
+     */
+    protected $element;
+
+    /**
      * Runs the test methods of this class.
      *
      * @return void

--- a/tests/Zend/Dojo/Form/Element/SimpleTextareaTest.php
+++ b/tests/Zend/Dojo/Form/Element/SimpleTextareaTest.php
@@ -59,6 +59,16 @@ require_once 'Zend/Dojo/View/Helper/Dojo.php';
 class Zend_Dojo_Form_Element_SimpleTextareaTest extends TestCase
 {
     /**
+     * @var \Zend_View
+     */
+    protected $view;
+
+    /**
+     * @var \Zend_Dojo_Form_Element_SimpleTextarea
+     */
+    protected $element;
+
+    /**
      * Runs the test methods of this class.
      *
      * @return void

--- a/tests/Zend/Dojo/Form/Element/SubmitButtonTest.php
+++ b/tests/Zend/Dojo/Form/Element/SubmitButtonTest.php
@@ -59,6 +59,16 @@ require_once 'Zend/Dojo/View/Helper/Dojo.php';
 class Zend_Dojo_Form_Element_SubmitButtonTest extends TestCase
 {
     /**
+     * @var \Zend_View
+     */
+    protected $view;
+
+    /**
+     * @var \Zend_Dojo_Form_Element_SubmitButton
+     */
+    protected $element;
+
+    /**
      * Runs the test methods of this class.
      *
      * @return void

--- a/tests/Zend/Dojo/Form/Element/TextBoxTest.php
+++ b/tests/Zend/Dojo/Form/Element/TextBoxTest.php
@@ -56,6 +56,16 @@ require_once 'Zend/Dojo/View/Helper/Dojo.php';
 class Zend_Dojo_Form_Element_TextBoxTest extends TestCase
 {
     /**
+     * @var \Zend_View
+     */
+    protected $view;
+
+    /**
+     * @var \Zend_Dojo_Form_Element_TextBox
+     */
+    protected $element;
+
+    /**
      * Runs the test methods of this class.
      *
      * @return void

--- a/tests/Zend/Dojo/Form/Element/TextareaTest.php
+++ b/tests/Zend/Dojo/Form/Element/TextareaTest.php
@@ -56,6 +56,16 @@ require_once 'Zend/Dojo/View/Helper/Dojo.php';
 class Zend_Dojo_Form_Element_TextareaTest extends TestCase
 {
     /**
+     * @var \Zend_View
+     */
+    protected $view;
+
+    /**
+     * @var \Zend_Dojo_Form_Element_Textarea
+     */
+    protected $element;
+
+    /**
      * Runs the test methods of this class.
      *
      * @return void

--- a/tests/Zend/Dojo/Form/Element/TimeTextBoxTest.php
+++ b/tests/Zend/Dojo/Form/Element/TimeTextBoxTest.php
@@ -56,6 +56,16 @@ require_once 'Zend/Dojo/View/Helper/Dojo.php';
 class Zend_Dojo_Form_Element_TimeTextBoxTest extends TestCase
 {
     /**
+     * @var \Zend_View
+     */
+    protected $view;
+
+    /**
+     * @var \Zend_Dojo_Form_Element_TimeTextBox
+     */
+    protected $element;
+
+    /**
      * Runs the test methods of this class.
      *
      * @return void

--- a/tests/Zend/Dojo/Form/Element/ValidationTextBoxTest.php
+++ b/tests/Zend/Dojo/Form/Element/ValidationTextBoxTest.php
@@ -56,6 +56,16 @@ require_once 'Zend/Dojo/View/Helper/Dojo.php';
 class Zend_Dojo_Form_Element_ValidationTextBoxTest extends TestCase
 {
     /**
+     * @var \Zend_View
+     */
+    protected $view;
+
+    /**
+     * @var \Zend_Dojo_Form_Element_ValidationTextBox
+     */
+    protected $element;
+
+    /**
      * Runs the test methods of this class.
      *
      * @return void

--- a/tests/Zend/Dojo/Form/Element/VerticalSliderTest.php
+++ b/tests/Zend/Dojo/Form/Element/VerticalSliderTest.php
@@ -56,6 +56,16 @@ require_once 'Zend/Dojo/View/Helper/Dojo.php';
 class Zend_Dojo_Form_Element_VerticalSliderTest extends TestCase
 {
     /**
+     * @var \Zend_View
+     */
+    protected $view;
+
+    /**
+     * @var \Zend_Dojo_Form_Element_VerticalSlider
+     */
+    protected $element;
+
+    /**
      * Runs the test methods of this class.
      *
      * @return void

--- a/tests/Zend/Dojo/Form/FormTest.php
+++ b/tests/Zend/Dojo/Form/FormTest.php
@@ -50,6 +50,11 @@ require_once 'Zend/View.php';
 class Zend_Dojo_Form_FormTest extends TestCase
 {
     /**
+     * @var \Zend_Dojo_Form|mixed
+     */
+    protected $form;
+
+    /**
      * Runs the test methods of this class.
      *
      * @return void

--- a/tests/Zend/Dojo/Form/SubFormTest.php
+++ b/tests/Zend/Dojo/Form/SubFormTest.php
@@ -50,6 +50,11 @@ require_once 'Zend/View.php';
 class Zend_Dojo_Form_SubFormTest extends TestCase
 {
     /**
+     * @var \Zend_Dojo_Form_SubForm|mixed
+     */
+    protected $form;
+
+    /**
      * Runs the test methods of this class.
      *
      * @return void

--- a/tests/Zend/Dojo/View/Helper/AccordionContainerTest.php
+++ b/tests/Zend/Dojo/View/Helper/AccordionContainerTest.php
@@ -56,6 +56,16 @@ require_once 'Zend/Dojo/View/Helper/Dojo.php';
 class Zend_Dojo_View_Helper_AccordionContainerTest extends TestCase
 {
     /**
+     * @var \Zend_View
+     */
+    protected $view;
+
+    /**
+     * @var \Zend_Dojo_View_Helper_AccordionContainer|mixed
+     */
+    protected $helper;
+
+    /**
      * Runs the test methods of this class.
      *
      * @return void

--- a/tests/Zend/Dojo/View/Helper/AccordionPaneTest.php
+++ b/tests/Zend/Dojo/View/Helper/AccordionPaneTest.php
@@ -56,6 +56,16 @@ require_once 'Zend/Dojo/View/Helper/Dojo.php';
 class Zend_Dojo_View_Helper_AccordionPaneTest extends TestCase
 {
     /**
+     * @var \Zend_View
+     */
+    protected $view;
+
+    /**
+     * @var \Zend_Dojo_View_Helper_AccordionPane|mixed
+     */
+    protected $helper;
+
+    /**
      * Runs the test methods of this class.
      *
      * @return void

--- a/tests/Zend/Dojo/View/Helper/BorderContainerTest.php
+++ b/tests/Zend/Dojo/View/Helper/BorderContainerTest.php
@@ -56,6 +56,16 @@ require_once 'Zend/Dojo/View/Helper/Dojo.php';
 class Zend_Dojo_View_Helper_BorderContainerTest extends TestCase
 {
     /**
+     * @var \Zend_View
+     */
+    protected $view;
+
+    /**
+     * @var \Zend_Dojo_View_Helper_BorderContainer|mixed
+     */
+    protected $helper;
+
+    /**
      * Runs the test methods of this class.
      *
      * @return void

--- a/tests/Zend/Dojo/View/Helper/ButtonTest.php
+++ b/tests/Zend/Dojo/View/Helper/ButtonTest.php
@@ -56,6 +56,15 @@ require_once 'Zend/Dojo/View/Helper/Dojo.php';
 class Zend_Dojo_View_Helper_ButtonTest extends TestCase
 {
     /**
+     * @var \Zend_View
+     */
+    protected $view;
+
+    /**
+     * @var \Zend_Dojo_View_Helper_Button|mixed
+     */
+    protected $helper;
+    /**
      * Runs the test methods of this class.
      *
      * @return void

--- a/tests/Zend/Dojo/View/Helper/CheckBoxTest.php
+++ b/tests/Zend/Dojo/View/Helper/CheckBoxTest.php
@@ -56,6 +56,16 @@ require_once 'Zend/Dojo/View/Helper/Dojo.php';
 class Zend_Dojo_View_Helper_CheckBoxTest extends TestCase
 {
     /**
+     * @var \Zend_View
+     */
+    protected $view;
+
+    /**
+     * @var \Zend_Dojo_View_Helper_CheckBox|mixed
+     */
+    protected $helper;
+
+    /**
      * Runs the test methods of this class.
      *
      * @return void

--- a/tests/Zend/Dojo/View/Helper/ComboBoxTest.php
+++ b/tests/Zend/Dojo/View/Helper/ComboBoxTest.php
@@ -56,6 +56,16 @@ require_once 'Zend/Dojo/View/Helper/Dojo.php';
 class Zend_Dojo_View_Helper_ComboBoxTest extends TestCase
 {
     /**
+     * @var \Zend_View
+     */
+    protected $view;
+
+    /**
+     * @var \Zend_Dojo_View_Helper_ComboBox|mixed
+     */
+    protected $helper;
+
+    /**
      * Runs the test methods of this class.
      *
      * @return void

--- a/tests/Zend/Dojo/View/Helper/ContentPaneTest.php
+++ b/tests/Zend/Dojo/View/Helper/ContentPaneTest.php
@@ -56,6 +56,16 @@ require_once 'Zend/Dojo/View/Helper/Dojo.php';
 class Zend_Dojo_View_Helper_ContentPaneTest extends TestCase
 {
     /**
+     * @var \Zend_View
+     */
+    protected $view;
+
+    /**
+     * @var \Zend_Dojo_View_Helper_ContentPane|mixed
+     */
+    protected $helper;
+
+    /**
      * Runs the test methods of this class.
      *
      * @return void

--- a/tests/Zend/Dojo/View/Helper/CurrencyTextBoxTest.php
+++ b/tests/Zend/Dojo/View/Helper/CurrencyTextBoxTest.php
@@ -56,6 +56,16 @@ require_once 'Zend/Dojo/View/Helper/Dojo.php';
 class Zend_Dojo_View_Helper_CurrencyTextBoxTest extends TestCase
 {
     /**
+     * @var \Zend_View
+     */
+    protected $view;
+
+    /**
+     * @var \Zend_Dojo_View_Helper_CurrencyTextBox|mixed
+     */
+    protected $helper;
+
+    /**
      * Runs the test methods of this class.
      *
      * @return void

--- a/tests/Zend/Dojo/View/Helper/CustomDijitTest.php
+++ b/tests/Zend/Dojo/View/Helper/CustomDijitTest.php
@@ -56,6 +56,11 @@ require_once 'Zend/Dojo/View/Helper/Dojo.php';
 class Zend_Dojo_View_Helper_CustomDijitTest extends TestCase
 {
     /**
+     * @var \Zend_View
+     */
+    protected $view;
+
+    /**
      * Runs the test methods of this class.
      *
      * @return void

--- a/tests/Zend/Dojo/View/Helper/DateTextBoxTest.php
+++ b/tests/Zend/Dojo/View/Helper/DateTextBoxTest.php
@@ -56,6 +56,16 @@ require_once 'Zend/Dojo/View/Helper/Dojo.php';
 class Zend_Dojo_View_Helper_DateTextBoxTest extends TestCase
 {
     /**
+     * @var \Zend_View
+     */
+    protected $view;
+
+    /**
+     * @var \Zend_Dojo_View_Helper_DateTextBox|mixed
+     */
+    protected $helper;
+
+    /**
      * Runs the test methods of this class.
      *
      * @return void

--- a/tests/Zend/Dojo/View/Helper/DojoTest.php
+++ b/tests/Zend/Dojo/View/Helper/DojoTest.php
@@ -55,6 +55,11 @@ require_once 'Zend/View.php';
 class Zend_Dojo_View_Helper_DojoTest extends TestCase
 {
     /**
+     * @var \Zend_View
+     */
+    protected $view;
+
+    /**
      * @var Zend_Dojo_View_Helper_Dojo_Container
      */
     protected $helper;

--- a/tests/Zend/Dojo/View/Helper/EditorTest.php
+++ b/tests/Zend/Dojo/View/Helper/EditorTest.php
@@ -56,6 +56,16 @@ require_once 'Zend/Dojo/View/Helper/Dojo.php';
 class Zend_Dojo_View_Helper_EditorTest extends TestCase
 {
     /**
+     * @var \Zend_View
+     */
+    protected $view;
+
+    /**
+     * @var \Zend_Dojo_View_Helper_Editor|mixed
+     */
+    protected $helper;
+
+    /**
      * Runs the test methods of this class.
      *
      * @return void

--- a/tests/Zend/Dojo/View/Helper/FilteringSelectTest.php
+++ b/tests/Zend/Dojo/View/Helper/FilteringSelectTest.php
@@ -56,6 +56,16 @@ require_once 'Zend/Dojo/View/Helper/Dojo.php';
 class Zend_Dojo_View_Helper_FilteringSelectTest extends TestCase
 {
     /**
+     * @var \Zend_View
+     */
+    protected $view;
+
+    /**
+     * @var \Zend_Dojo_View_Helper_FilteringSelect|mixed
+     */
+    protected $helper;
+
+    /**
      * Runs the test methods of this class.
      *
      * @return void

--- a/tests/Zend/Dojo/View/Helper/FormTest.php
+++ b/tests/Zend/Dojo/View/Helper/FormTest.php
@@ -56,6 +56,16 @@ require_once 'Zend/Dojo/View/Helper/Dojo.php';
 class Zend_Dojo_View_Helper_FormTest extends TestCase
 {
     /**
+     * @var \Zend_View
+     */
+    protected $view;
+
+    /**
+     * @var \Zend_Dojo_View_Helper_Form|mixed
+     */
+    protected $helper;
+
+    /**
      * Runs the test methods of this class.
      *
      * @return void

--- a/tests/Zend/Dojo/View/Helper/HorizontalSliderTest.php
+++ b/tests/Zend/Dojo/View/Helper/HorizontalSliderTest.php
@@ -62,6 +62,16 @@ require_once 'Zend/Dojo/View/Helper/Dojo.php';
 class Zend_Dojo_View_Helper_HorizontalSliderTest extends TestCase
 {
     /**
+     * @var \Zend_View
+     */
+    protected $view;
+
+    /**
+     * @var \Zend_Dojo_View_Helper_HorizontalSlider|mixed
+     */
+    protected $helper;
+
+    /**
      * Runs the test methods of this class.
      *
      * @return void

--- a/tests/Zend/Dojo/View/Helper/NumberSpinnerTest.php
+++ b/tests/Zend/Dojo/View/Helper/NumberSpinnerTest.php
@@ -56,6 +56,16 @@ require_once 'Zend/Dojo/View/Helper/Dojo.php';
 class Zend_Dojo_View_Helper_NumberSpinnerTest extends TestCase
 {
     /**
+     * @var \Zend_View
+     */
+    protected $view;
+
+    /**
+     * @var \Zend_Dojo_View_Helper_NumberSpinner|mixed
+     */
+    protected $helper;
+
+    /**
      * Runs the test methods of this class.
      *
      * @return void

--- a/tests/Zend/Dojo/View/Helper/NumberTextBoxTest.php
+++ b/tests/Zend/Dojo/View/Helper/NumberTextBoxTest.php
@@ -56,6 +56,16 @@ require_once 'Zend/Dojo/View/Helper/Dojo.php';
 class Zend_Dojo_View_Helper_NumberTextBoxTest extends TestCase
 {
     /**
+     * @var \Zend_View
+     */
+    protected $view;
+
+    /**
+     * @var \Zend_Dojo_View_Helper_NumberTextBox|mixed
+     */
+    protected $helper;
+
+    /**
      * Runs the test methods of this class.
      *
      * @return void

--- a/tests/Zend/Dojo/View/Helper/PasswordTextBoxTest.php
+++ b/tests/Zend/Dojo/View/Helper/PasswordTextBoxTest.php
@@ -56,6 +56,16 @@ require_once 'Zend/Dojo/View/Helper/Dojo.php';
 class Zend_Dojo_View_Helper_PasswordTextBoxTest extends TestCase
 {
     /**
+     * @var \Zend_View
+     */
+    protected $view;
+
+    /**
+     * @var \Zend_Dojo_View_Helper_PasswordTextBox|mixed
+     */
+    protected $helper;
+
+    /**
      * Runs the test methods of this class.
      *
      * @return void

--- a/tests/Zend/Dojo/View/Helper/RadioButtonTest.php
+++ b/tests/Zend/Dojo/View/Helper/RadioButtonTest.php
@@ -56,6 +56,16 @@ require_once 'Zend/Dojo/View/Helper/Dojo.php';
 class Zend_Dojo_View_Helper_RadioButtonTest extends TestCase
 {
     /**
+     * @var \Zend_View
+     */
+    protected $view;
+
+    /**
+     * @var \Zend_Dojo_View_Helper_RadioButton|mixed
+     */
+    protected $helper;
+
+    /**
      * Runs the test methods of this class.
      *
      * @return void

--- a/tests/Zend/Dojo/View/Helper/SimpleTextareaTest.php
+++ b/tests/Zend/Dojo/View/Helper/SimpleTextareaTest.php
@@ -59,6 +59,16 @@ require_once 'Zend/Dojo/View/Helper/Dojo.php';
 class Zend_Dojo_View_Helper_SimpleTextareaTest extends TestCase
 {
     /**
+     * @var \Zend_View
+     */
+    protected $view;
+
+    /**
+     * @var \Zend_Dojo_View_Helper_SimpleTextarea|mixed
+     */
+    protected $helper;
+
+    /**
      * Runs the test methods of this class.
      *
      * @return void

--- a/tests/Zend/Dojo/View/Helper/SplitContainerTest.php
+++ b/tests/Zend/Dojo/View/Helper/SplitContainerTest.php
@@ -56,6 +56,16 @@ require_once 'Zend/Dojo/View/Helper/Dojo.php';
 class Zend_Dojo_View_Helper_SplitContainerTest extends TestCase
 {
     /**
+     * @var \Zend_View
+     */
+    protected $view;
+
+    /**
+     * @var \Zend_Dojo_View_Helper_SplitContainer|mixed
+     */
+    protected $helper;
+
+    /**
      * Runs the test methods of this class.
      *
      * @return void

--- a/tests/Zend/Dojo/View/Helper/StackContainerTest.php
+++ b/tests/Zend/Dojo/View/Helper/StackContainerTest.php
@@ -55,6 +55,13 @@ require_once 'Zend/Dojo/View/Helper/Dojo.php';
  */
 class Zend_Dojo_View_Helper_StackContainerTest extends TestCase
 {
+    protected $view;
+
+    /**
+     * @var \Zend_Dojo_View_Helper_StackContainer|mixed
+     */
+    protected $helper;
+
     /**
      * Runs the test methods of this class.
      *

--- a/tests/Zend/Dojo/View/Helper/SubmitButtonTest.php
+++ b/tests/Zend/Dojo/View/Helper/SubmitButtonTest.php
@@ -55,6 +55,13 @@ require_once 'Zend/Dojo/View/Helper/Dojo.php';
  */
 class Zend_Dojo_View_Helper_SubmitButtonTest extends TestCase
 {
+    protected $view;
+
+    /**
+     * @var \Zend_Dojo_View_Helper_SubmitButton|mixed
+     */
+    protected $helper;
+
     /**
      * Runs the test methods of this class.
      *

--- a/tests/Zend/Dojo/View/Helper/TabContainerTest.php
+++ b/tests/Zend/Dojo/View/Helper/TabContainerTest.php
@@ -56,6 +56,16 @@ require_once 'Zend/Dojo/View/Helper/Dojo.php';
 class Zend_Dojo_View_Helper_TabContainerTest extends TestCase
 {
     /**
+     * @var \Zend_View
+     */
+    protected $view;
+
+    /**
+     * @var \Zend_Dojo_View_Helper_TabContainer|mixed
+     */
+    protected $helper;
+
+    /**
      * Runs the test methods of this class.
      *
      * @return void

--- a/tests/Zend/Dojo/View/Helper/TextBoxTest.php
+++ b/tests/Zend/Dojo/View/Helper/TextBoxTest.php
@@ -56,6 +56,16 @@ require_once 'Zend/Dojo/View/Helper/Dojo.php';
 class Zend_Dojo_View_Helper_TextBoxTest extends TestCase
 {
     /**
+     * @var \Zend_View
+     */
+    protected $view;
+
+    /**
+     * @var \Zend_Dojo_View_Helper_TextBox|mixed
+     */
+    protected $helper;
+
+    /**
      * Runs the test methods of this class.
      *
      * @return void

--- a/tests/Zend/Dojo/View/Helper/TextareaTest.php
+++ b/tests/Zend/Dojo/View/Helper/TextareaTest.php
@@ -56,6 +56,16 @@ require_once 'Zend/Dojo/View/Helper/Dojo.php';
 class Zend_Dojo_View_Helper_TextareaTest extends TestCase
 {
     /**
+     * @var \Zend_View
+     */
+    protected $view;
+
+    /**
+     * @var \Zend_Dojo_View_Helper_Textarea|mixed
+     */
+    protected $helper;
+
+    /**
      * Runs the test methods of this class.
      *
      * @return void

--- a/tests/Zend/Dojo/View/Helper/TimeTextBoxTest.php
+++ b/tests/Zend/Dojo/View/Helper/TimeTextBoxTest.php
@@ -56,6 +56,16 @@ require_once 'Zend/Dojo/View/Helper/Dojo.php';
 class Zend_Dojo_View_Helper_TimeTextBoxTest extends TestCase
 {
     /**
+     * @var \Zend_View
+     */
+    protected $view;
+
+    /**
+     * @var \Zend_Dojo_View_Helper_TimeTextBox|mixed
+     */
+    protected $helper;
+
+    /**
      * Runs the test methods of this class.
      *
      * @return void

--- a/tests/Zend/Dojo/View/Helper/ValidationTextBoxTest.php
+++ b/tests/Zend/Dojo/View/Helper/ValidationTextBoxTest.php
@@ -56,6 +56,16 @@ require_once 'Zend/Dojo/View/Helper/Dojo.php';
 class Zend_Dojo_View_Helper_ValidationTextBoxTest extends TestCase
 {
     /**
+     * @var \Zend_View
+     */
+    protected $view;
+
+    /**
+     * @var \Zend_Dojo_View_Helper_ValidationTextBox|mixed
+     */
+    protected $helper;
+
+    /**
      * Runs the test methods of this class.
      *
      * @return void

--- a/tests/Zend/Dojo/View/Helper/VerticalSliderTest.php
+++ b/tests/Zend/Dojo/View/Helper/VerticalSliderTest.php
@@ -56,6 +56,16 @@ require_once 'Zend/Dojo/View/Helper/Dojo.php';
 class Zend_Dojo_View_Helper_VerticalSliderTest extends TestCase
 {
     /**
+     * @var \Zend_View
+     */
+    protected $view;
+
+    /**
+     * @var \Zend_Dojo_View_Helper_VerticalSlider|mixed
+     */
+    protected $helper;
+
+    /**
      * Runs the test methods of this class.
      *
      * @return void

--- a/tests/Zend/Dom/QueryTest.php
+++ b/tests/Zend/Dom/QueryTest.php
@@ -43,9 +43,21 @@ require_once 'Zend/Dom/Query.php';
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  * @group      Zend_Dom
  */
-#[AllowDynamicProperties]
 class Zend_Dom_QueryTest extends TestCase
 {
+    /**
+     * @var \Zend_Dom_Query|mixed
+     */
+    protected $query;
+
+    /**
+     * @var string
+     */
+    protected $error;
+
+    /**
+     * @var string
+     */
     public $html;
 
     /**

--- a/tests/Zend/EventManager/EventManagerTest.php
+++ b/tests/Zend/EventManager/EventManagerTest.php
@@ -44,9 +44,38 @@ require_once 'Zend/Stdlib/CallbackHandler.php';
  * @copyright  Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
-#[AllowDynamicProperties]
 class Zend_EventManager_EventManagerTest extends TestCase
 {
+    /**
+     * @var string
+     */
+    protected $message;
+
+    /**
+     * @var string|mixed
+     */
+    protected $default;
+
+    /**
+     * @var \Zend_EventManager_EventManager|mixed
+     */
+    protected $events;
+
+    /**
+     * @var string|class-string<\FOO>|mixed
+     */
+    protected $foo;
+
+    /**
+     * @var string|mixed
+     */
+    protected $bar;
+
+    /**
+     * @var \stdClass|mixed
+     */
+    protected $test;
+
     public static function main()
     {
         $suite = new TestSuite(__CLASS__);

--- a/tests/Zend/EventManager/FilterChainTest.php
+++ b/tests/Zend/EventManager/FilterChainTest.php
@@ -40,9 +40,18 @@ require_once 'Zend/Stdlib/CallbackHandler.php';
  * @copyright  Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
-#[AllowDynamicProperties]
 class Zend_EventManager_FilterChainTest extends TestCase
 {
+    /**
+     * @var string
+     */
+    protected $message;
+
+    /**
+     * @var \Zend_EventManager_FilterChain|mixed
+     */
+    protected $filterchain;
+
     public static function main()
     {
         $suite = new TestSuite(__CLASS__);

--- a/tests/Zend/EventManager/GlobalEventManagerTest.php
+++ b/tests/Zend/EventManager/GlobalEventManagerTest.php
@@ -39,9 +39,13 @@ require_once 'Zend/EventManager/EventManager.php';
  * @copyright  Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
-#[AllowDynamicProperties]
 class Zend_EventManager_GlobalEventManagerTest extends TestCase
 {
+    /**
+     * @var \stdClass|mixed
+     */
+    protected $test;
+
     public static function main()
     {
         $suite = new TestSuite(__CLASS__);

--- a/tests/Zend/EventManager/StaticEventManagerTest.php
+++ b/tests/Zend/EventManager/StaticEventManagerTest.php
@@ -39,9 +39,13 @@ require_once 'Zend/EventManager/StaticEventManager.php';
  * @copyright  Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
-#[AllowDynamicProperties]
 class Zend_EventManager_StaticEventManagerTest extends TestCase
 {
+    /**
+     * @var \stdClass|mixed
+     */
+    protected $test;
+
     public static function main()
     {
         $suite = new TestSuite(__CLASS__);

--- a/tests/Zend/EventManager/StaticIntegrationTest.php
+++ b/tests/Zend/EventManager/StaticIntegrationTest.php
@@ -41,9 +41,18 @@ require_once 'Zend/EventManager/TestAsset/StaticEventsMock.php';
  * @copyright  Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
-#[AllowDynamicProperties]
 class Zend_EventManager_StaticIntegrationTest extends TestCase
 {
+    /**
+     * @var \stdClass|mixed
+     */
+    protected $counter;
+
+    /**
+     * @var \stdClass|mixed
+     */
+    protected $test;
+
     public static function main()
     {
         $suite = new TestSuite(__CLASS__);

--- a/tests/Zend/Feed/Pubsubhubbub/SubscriberHttpTest.php
+++ b/tests/Zend/Feed/Pubsubhubbub/SubscriberHttpTest.php
@@ -46,6 +46,8 @@ require_once 'Zend/Uri/Http.php';
  */
 class Zend_Feed_Pubsubhubbub_SubscriberHttpTest extends TestCase
 {
+    protected $_storage;
+
     protected $_subscriber = null;
 
     protected $_baseuri;

--- a/tests/Zend/Feed/Reader/Integration/PodcastRss2Test.php
+++ b/tests/Zend/Feed/Reader/Integration/PodcastRss2Test.php
@@ -36,6 +36,11 @@ require_once 'Zend/Feed/Reader.php';
  */
 class Zend_Feed_Reader_Integration_PodcastRss2Test extends TestCase
 {
+    /**
+     * @var mixed[]|void|mixed
+     */
+    protected $_options;
+
     protected $_feedSamplePath = null;
 
     protected function setUp(): void

--- a/tests/Zend/Filter/InflectorTest.php
+++ b/tests/Zend/Filter/InflectorTest.php
@@ -52,9 +52,23 @@ require_once 'Zend/Config.php';
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  * @group      Zend_Filter
  */
-#[AllowDynamicProperties]
 class Zend_Filter_InflectorTest extends TestCase
 {
+    /**
+     * @var \Zend_Filter_Inflector|mixed
+     */
+    protected $inflector;
+
+    /**
+     * @var \Zend_Loader_PluginLoader_Interface|mixed
+     */
+    protected $loader;
+
+    /**
+     * @var string|mixed
+     */
+    protected $_context;
+
     /**
      * Runs the test methods of this class.
      *

--- a/tests/Zend/Filter/PregReplaceTest.php
+++ b/tests/Zend/Filter/PregReplaceTest.php
@@ -47,9 +47,13 @@ require_once 'Zend/Filter/PregReplace.php';
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  * @group      Zend_Filter
  */
-#[AllowDynamicProperties]
 class Zend_Filter_PregReplaceTest extends TestCase
 {
+    /**
+     * @var \Zend_Filter_PregReplace|mixed
+     */
+    protected $filter;
+
     /**
      * Runs the test methods of this class.
      *

--- a/tests/Zend/FilterTest.php
+++ b/tests/Zend/FilterTest.php
@@ -37,9 +37,18 @@ require_once 'Zend/Filter.php';
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  * @group      Zend_Filter
  */
-#[AllowDynamicProperties]
 class Zend_FilterTest extends TestCase
 {
+    /**
+     * @var null|bool
+     */
+    protected $error;
+
+    /**
+     * @var bool
+     */
+    protected $_errorOccurred;
+
     /**
      * Zend_Filter object
      *

--- a/tests/Zend/Form/Decorator/PrepareElementsTest.php
+++ b/tests/Zend/Form/Decorator/PrepareElementsTest.php
@@ -48,6 +48,16 @@ require_once 'Zend/Form/SubForm.php';
 class Zend_Form_Decorator_PrepareElementsTest extends TestCase
 {
     /**
+     * @var \Zend_Form|mixed
+     */
+    protected $form;
+
+    /**
+     * @var \Zend_Form_Decorator_Abstract|bool
+     */
+    protected $decorator;
+
+    /**
      * Runs the test methods of this class.
      *
      * @return void

--- a/tests/Zend/Form/DisplayGroupTest.php
+++ b/tests/Zend/Form/DisplayGroupTest.php
@@ -51,9 +51,23 @@ require_once 'Zend/View.php';
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  * @group      Zend_Form
  */
-#[AllowDynamicProperties]
 class Zend_Form_DisplayGroupTest extends TestCase
 {
+    /**
+     * @var string
+     */
+    protected $error;
+
+    /**
+     * @var \Zend_Loader_PluginLoader|mixed
+     */
+    protected $loader;
+
+    /**
+     * @var \Zend_Form_DisplayGroup|mixed
+     */
+    protected $group;
+
     public static function main()
     {
         $suite = new TestSuite('Zend_Form_DisplayGroupTest');

--- a/tests/Zend/Gdata/Analytics/AccountQueryTest.php
+++ b/tests/Zend/Gdata/Analytics/AccountQueryTest.php
@@ -37,6 +37,11 @@ require_once 'Zend/Gdata/Analytics.php';
 class Zend_GData_Analytics_AccountQueryTest extends TestCase
 {
     /**
+     * @var string|mixed
+     */
+    protected $queryBase;
+
+    /**
      * @var Zend_GData_Analytics_AccountQuery
      */
     public $accountQuery;

--- a/tests/Zend/Gdata/App/AuthorTest.php
+++ b/tests/Zend/Gdata/App/AuthorTest.php
@@ -37,6 +37,16 @@ require_once 'Zend/Gdata/App.php';
  */
 class Zend_Gdata_App_AuthorTest extends TestCase
 {
+    /**
+     * @var string|bool|mixed
+     */
+    protected $authorText;
+
+    /**
+     * @var \Zend_Gdata_App_Extension_Author|mixed
+     */
+    protected $author;
+
     protected function setUp(): void
     {
         $this->authorText = file_get_contents(

--- a/tests/Zend/Gdata/App/CaptchaRequiredExceptionTest.php
+++ b/tests/Zend/Gdata/App/CaptchaRequiredExceptionTest.php
@@ -36,6 +36,11 @@ use PHPUnit\Framework\TestCase;
  */
 class Zend_Gdata_App_CaptchaRequiredExceptionTest extends TestCase
 {
+    /**
+     * @var \Zend_Gdata_App_CaptchaRequiredException|mixed
+     */
+    protected $exampleException;
+
     protected function setUp(): void
     {
         $this->exampleException = new Zend_Gdata_App_CaptchaRequiredException('testtoken', 'Captcha?ctoken=testtoken');

--- a/tests/Zend/Gdata/App/CategoryTest.php
+++ b/tests/Zend/Gdata/App/CategoryTest.php
@@ -37,6 +37,16 @@ require_once 'Zend/Gdata/App.php';
  */
 class Zend_Gdata_App_CategoryTest extends TestCase
 {
+    /**
+     * @var string|bool|mixed
+     */
+    protected $categoryText;
+
+    /**
+     * @var \Zend_Gdata_App_Extension_Category|mixed
+     */
+    protected $category;
+
     protected function setUp(): void
     {
         $this->categoryText = file_get_contents(

--- a/tests/Zend/Gdata/App/ContentTest.php
+++ b/tests/Zend/Gdata/App/ContentTest.php
@@ -37,6 +37,21 @@ require_once 'Zend/Gdata/App.php';
  */
 class Zend_Gdata_App_ContentTest extends TestCase
 {
+    /**
+     * @var string|bool|mixed
+     */
+    protected $contentText;
+
+    /**
+     * @var string|bool|mixed
+     */
+    protected $contentText2;
+
+    /**
+     * @var \Zend_Gdata_App_Extension_Content|mixed
+     */
+    protected $content;
+
     protected function setUp(): void
     {
         $this->contentText = file_get_contents(

--- a/tests/Zend/Gdata/App/ControlTest.php
+++ b/tests/Zend/Gdata/App/ControlTest.php
@@ -38,6 +38,16 @@ require_once 'Zend/Gdata/App.php';
  */
 class Zend_Gdata_App_ControlTest extends TestCase
 {
+    /**
+     * @var string|bool|mixed
+     */
+    protected $controlText;
+
+    /**
+     * @var \Zend_Gdata_App_Extension_Control|mixed
+     */
+    protected $control;
+
     protected function setUp(): void
     {
         $this->controlText = file_get_contents(

--- a/tests/Zend/Gdata/App/EntryTest.php
+++ b/tests/Zend/Gdata/App/EntryTest.php
@@ -39,6 +39,30 @@ require_once 'Zend/Gdata/HttpClient.php';
  */
 class Zend_Gdata_App_EntryTest extends TestCase
 {
+    protected $enryText;
+
+    protected $httpEntrySample;
+
+    /**
+     * @var \Zend_Gdata_App_Entry|mixed
+     */
+    protected $enry;
+
+    /**
+     * @var \Test_Zend_Gdata_MockHttpClient|mixed
+     */
+    protected $adapter;
+
+    /**
+     * @var \Zend_Gdata_HttpClient|mixed
+     */
+    protected $client;
+
+    /**
+     * @var \Zend_Gdata_App|mixed
+     */
+    protected $service;
+
     protected function setUp(): void
     {
         $this->enryText = $this->loadResponse(

--- a/tests/Zend/Gdata/App/FeedTest.php
+++ b/tests/Zend/Gdata/App/FeedTest.php
@@ -38,6 +38,16 @@ require_once 'Zend/Gdata/App.php';
  */
 class Zend_Gdata_App_FeedTest extends TestCase
 {
+    /**
+     * @var string|bool|mixed
+     */
+    protected $feedText;
+
+    /**
+     * @var \Zend_Gdata_App_Feed|mixed
+     */
+    protected $feed;
+
     protected function setUp(): void
     {
         $this->feedText = file_get_contents(

--- a/tests/Zend/Gdata/App/GeneratorTest.php
+++ b/tests/Zend/Gdata/App/GeneratorTest.php
@@ -38,6 +38,16 @@ require_once 'Zend/Gdata/App.php';
  */
 class Zend_Gdata_App_GeneratorTest extends TestCase
 {
+    /**
+     * @var string|bool|mixed
+     */
+    protected $generatorText;
+
+    /**
+     * @var \Zend_Gdata_App_Extension_Generator|mixed
+     */
+    protected $generator;
+
     protected function setUp(): void
     {
         $this->generatorText = file_get_contents(

--- a/tests/Zend/Gdata/App/HttpExceptionTest.php
+++ b/tests/Zend/Gdata/App/HttpExceptionTest.php
@@ -39,6 +39,21 @@ require_once 'Zend/Gdata/ClientLogin.php';
  */
 class Zend_Gdata_App_HttpExceptionTest extends TestCase
 {
+    /**
+     * @var mixed
+     */
+    protected $sprKey;
+
+    /**
+     * @var mixed
+     */
+    protected $wksId;
+
+    /**
+     * @var \Zend_Gdata_Spreadsheets|mixed
+     */
+    protected $gdata;
+
     protected function setUp(): void
     {
         $user = constant('TESTS_ZEND_GDATA_CLIENTLOGIN_EMAIL');

--- a/tests/Zend/Gdata/AppTest.php
+++ b/tests/Zend/Gdata/AppTest.php
@@ -38,6 +38,46 @@ require_once 'Zend/Gdata/TestUtility/MockHttpClient.php';
  */
 class Zend_Gdata_AppTest extends TestCase
 {
+    /**
+     * @var string
+     */
+    protected $fileName;
+
+    /**
+     * @var string|mixed
+     */
+    protected $expectedEtag;
+
+    /**
+     * @var int|mixed
+     */
+    protected $expectedMajorProtocolVersion;
+
+    /**
+     * @var int|mixed
+     */
+    protected $expectedMinorProtocolVersion;
+
+    protected $httpEntrySample;
+    protected $httpEntrySampleWithoutVersion;
+    protected $httpFeedSample;
+    protected $httpFeedSampleWithoutVersion;
+
+    /**
+     * @var \Test_Zend_Gdata_MockHttpClient|mixed
+     */
+    protected $adapter;
+
+    /**
+     * @var \Zend_Gdata_HttpClient|mixed
+     */
+    protected $client;
+
+    /**
+     * @var \Zend_Gdata_App|mixed
+     */
+    protected $service;
+
     protected function setUp(): void
     {
         $this->fileName = 'Zend/Gdata/App/_files/FeedSample1.xml';

--- a/tests/Zend/Gdata/AttendeeStatusTest.php
+++ b/tests/Zend/Gdata/AttendeeStatusTest.php
@@ -36,6 +36,16 @@ require_once 'Zend/Gdata.php';
  */
 class Zend_Gdata_AttendeeStatusTest extends TestCase
 {
+    /**
+     * @var string|bool|mixed
+     */
+    protected $attendeeStatusText;
+
+    /**
+     * @var \Zend_Gdata_Extension_AttendeeStatus|mixed
+     */
+    protected $attendeeStatus;
+
     protected function setUp(): void
     {
         $this->attendeeStatusText = file_get_contents(

--- a/tests/Zend/Gdata/AttendeeTypeTest.php
+++ b/tests/Zend/Gdata/AttendeeTypeTest.php
@@ -36,6 +36,16 @@ require_once 'Zend/Gdata.php';
  */
 class Zend_Gdata_AttendeeTypeTest extends TestCase
 {
+    /**
+     * @var string|bool|mixed
+     */
+    protected $attendeeTypeText;
+
+    /**
+     * @var \Zend_Gdata_Extension_AttendeeType|mixed
+     */
+    protected $attendeeType;
+
     protected function setUp(): void
     {
         $this->attendeeTypeText = file_get_contents(

--- a/tests/Zend/Gdata/Books/CollectionEntryTest.php
+++ b/tests/Zend/Gdata/Books/CollectionEntryTest.php
@@ -37,6 +37,11 @@ require_once 'Zend/Gdata/Books/CollectionEntry.php';
  */
 class Zend_Gdata_Books_CollectionEntryTest extends TestCase
 {
+    /**
+     * @var \Zend_Gdata_Books_CollectionEntry
+     */
+    protected $gdata;
+
     protected function setUp(): void
     {
         $this->gdata = new Zend_Gdata_Books_CollectionEntry();

--- a/tests/Zend/Gdata/Books/CollectionFeedTest.php
+++ b/tests/Zend/Gdata/Books/CollectionFeedTest.php
@@ -37,6 +37,11 @@ require_once 'Zend/Gdata/Books/CollectionFeed.php';
  */
 class Zend_Gdata_Books_CollectionFeedTest extends TestCase
 {
+    /**
+     * @var \Zend_Gdata_Books_CollectionFeed
+     */
+    protected $gdata;
+
     protected function setUp(): void
     {
         $this->gdata = new Zend_Gdata_Books_CollectionFeed();

--- a/tests/Zend/Gdata/Books/VolumeEntryTest.php
+++ b/tests/Zend/Gdata/Books/VolumeEntryTest.php
@@ -37,6 +37,16 @@ require_once 'Zend/Gdata/Books.php';
  */
 class Zend_Gdata_Books_VolumeEntryTest extends TestCase
 {
+    /**
+     * @var string|bool|mixed
+     */
+    protected $entryText;
+
+    /**
+     * @var \Zend_Gdata_Books_VolumeEntry|mixed
+     */
+    protected $entry;
+
     protected function setUp(): void
     {
         $this->entryText = file_get_contents(

--- a/tests/Zend/Gdata/Books/VolumeFeedTest.php
+++ b/tests/Zend/Gdata/Books/VolumeFeedTest.php
@@ -37,6 +37,16 @@ require_once 'Zend/Gdata/Books.php';
  */
 class Zend_Gdata_Books_VolumeFeedTest extends TestCase
 {
+    /**
+     * @var string|bool|mixed
+     */
+    protected $feedText;
+
+    /**
+     * @var \Zend_Gdata_Books_VolumeFeed|mixed
+     */
+    protected $feed;
+
     protected function setUp(): void
     {
         $this->feedText = file_get_contents(

--- a/tests/Zend/Gdata/BooksOnlineTest.php
+++ b/tests/Zend/Gdata/BooksOnlineTest.php
@@ -38,6 +38,11 @@ require_once 'Zend/Gdata/ClientLogin.php';
  */
 class Zend_Gdata_BooksOnlineTest extends TestCase
 {
+    /**
+     * @var \Zend_Gdata_Books|mixed
+     */
+    protected $gdata;
+
     protected function setUp(): void
     {
         $user = constant('TESTS_ZEND_GDATA_CLIENTLOGIN_EMAIL');

--- a/tests/Zend/Gdata/BooksTest.php
+++ b/tests/Zend/Gdata/BooksTest.php
@@ -37,6 +37,11 @@ require_once 'Zend/Http/Client.php';
  */
 class Zend_Gdata_BooksTest extends TestCase
 {
+    /**
+     * @var \Zend_Gdata_Books
+     */
+    protected $gdata;
+
     protected function setUp(): void
     {
         $this->gdata = new Zend_Gdata_Books(new Zend_Http_Client());

--- a/tests/Zend/Gdata/Calendar/AccessLevelTest.php
+++ b/tests/Zend/Gdata/Calendar/AccessLevelTest.php
@@ -37,6 +37,16 @@ require_once 'Zend/Gdata/Calendar.php';
  */
 class Zend_Gdata_Calendar_AccessLevelTest extends TestCase
 {
+    /**
+     * @var string|bool|mixed
+     */
+    protected $accessLevelText;
+
+    /**
+     * @var \Zend_Gdata_Calendar_Extension_AccessLevel|mixed
+     */
+    protected $accessLevel;
+
     protected function setUp(): void
     {
         $this->accessLevelText = file_get_contents(

--- a/tests/Zend/Gdata/Calendar/ColorTest.php
+++ b/tests/Zend/Gdata/Calendar/ColorTest.php
@@ -37,6 +37,16 @@ require_once 'Zend/Gdata/Calendar.php';
  */
 class Zend_Gdata_Calendar_ColorTest extends TestCase
 {
+    /**
+     * @var string|bool|mixed
+     */
+    protected $colorText;
+
+    /**
+     * @var \Zend_Gdata_Calendar_Extension_Color|mixed
+     */
+    protected $color;
+
     protected function setUp(): void
     {
         $this->colorText = file_get_contents(

--- a/tests/Zend/Gdata/Calendar/EventEntryTest.php
+++ b/tests/Zend/Gdata/Calendar/EventEntryTest.php
@@ -38,6 +38,16 @@ require_once 'Zend/Gdata/Calendar.php';
  */
 class Zend_Gdata_Calendar_EventEntryTest extends TestCase
 {
+    /**
+     * @var string|bool|mixed
+     */
+    protected $entryText;
+
+    /**
+     * @var \Zend_Gdata_Calendar_EventEntry|mixed
+     */
+    protected $entry;
+
     protected function setUp(): void
     {
         $this->entryText = file_get_contents(

--- a/tests/Zend/Gdata/Calendar/EventQueryExceptionTest.php
+++ b/tests/Zend/Gdata/Calendar/EventQueryExceptionTest.php
@@ -38,6 +38,11 @@ require_once 'Zend/Http/Client.php';
  */
 class Zend_Gdata_Calendar_EventQueryExceptionTest extends TestCase
 {
+    /**
+     * @var \Zend_Gdata_Calendar_EventQuery|mixed
+     */
+    protected $query;
+
     public const GOOGLE_DEVELOPER_CALENDAR = 'developer-calendar@google.com';
 
     protected function setUp(): void

--- a/tests/Zend/Gdata/Calendar/EventQueryTest.php
+++ b/tests/Zend/Gdata/Calendar/EventQueryTest.php
@@ -38,6 +38,10 @@ require_once 'Zend/Http/Client.php';
  */
 class Zend_Gdata_Calendar_EventQueryTest extends TestCase
 {
+    /**
+     * @var \Zend_Gdata_Calendar_EventQuery|mixed
+     */
+    protected $query;
     public const GOOGLE_DEVELOPER_CALENDAR = 'developer-calendar@google.com';
     public const ZEND_CONFERENCE_EVENT = 'bn2h4o4mc3a03ci4t48j3m56pg';
     public const ZEND_CONFERENCE_EVENT_COMMENT = 'i9q87onko1uphfs7i21elnnb4g';

--- a/tests/Zend/Gdata/Calendar/HiddenTest.php
+++ b/tests/Zend/Gdata/Calendar/HiddenTest.php
@@ -37,6 +37,16 @@ require_once 'Zend/Gdata/Calendar.php';
  */
 class Zend_Gdata_Calendar_HiddenTest extends TestCase
 {
+    /**
+     * @var string|bool|mixed
+     */
+    protected $hiddenText;
+
+    /**
+     * @var \Zend_Gdata_Calendar_Extension_Hidden|mixed
+     */
+    protected $hidden;
+
     protected function setUp(): void
     {
         $this->hiddenText = file_get_contents(

--- a/tests/Zend/Gdata/Calendar/LinkTest.php
+++ b/tests/Zend/Gdata/Calendar/LinkTest.php
@@ -38,6 +38,16 @@ require_once 'Zend/Gdata/Calendar.php';
  */
 class Zend_Gdata_Calendar_LinkTest extends TestCase
 {
+    /**
+     * @var string|bool|mixed
+     */
+    protected $linkText;
+
+    /**
+     * @var \Zend_Gdata_Calendar_Extension_Link|mixed
+     */
+    protected $link;
+
     protected function setUp(): void
     {
         $this->linkText = file_get_contents(

--- a/tests/Zend/Gdata/Calendar/QuickAddTest.php
+++ b/tests/Zend/Gdata/Calendar/QuickAddTest.php
@@ -37,6 +37,16 @@ require_once 'Zend/Gdata/Calendar.php';
  */
 class Zend_Gdata_Calendar_QuickAddTest extends TestCase
 {
+    /**
+     * @var string|bool|mixed
+     */
+    protected $quickAddText;
+
+    /**
+     * @var \Zend_Gdata_Calendar_Extension_QuickAdd|mixed
+     */
+    protected $quickAdd;
+
     protected function setUp(): void
     {
         $this->quickAddText = file_get_contents(

--- a/tests/Zend/Gdata/Calendar/SelectedTest.php
+++ b/tests/Zend/Gdata/Calendar/SelectedTest.php
@@ -37,6 +37,16 @@ require_once 'Zend/Gdata/Calendar.php';
  */
 class Zend_Gdata_Calendar_SelectedTest extends TestCase
 {
+    /**
+     * @var string|bool|mixed
+     */
+    protected $selectedText;
+
+    /**
+     * @var \Zend_Gdata_Calendar_Extension_Selected|mixed
+     */
+    protected $selected;
+
     protected function setUp(): void
     {
         $this->selectedText = file_get_contents(

--- a/tests/Zend/Gdata/Calendar/SendEventNotificationsTest.php
+++ b/tests/Zend/Gdata/Calendar/SendEventNotificationsTest.php
@@ -37,6 +37,16 @@ require_once 'Zend/Gdata/Calendar.php';
  */
 class Zend_Gdata_Calendar_SendEventNotificationsTest extends TestCase
 {
+    /**
+     * @var string|bool|mixed
+     */
+    protected $sendEventNotificationsText;
+
+    /**
+     * @var \Zend_Gdata_Calendar_Extension_SendEventNotifications|mixed
+     */
+    protected $sendEventNotifications;
+
     protected function setUp(): void
     {
         $this->sendEventNotificationsText = file_get_contents(

--- a/tests/Zend/Gdata/Calendar/TimezoneTest.php
+++ b/tests/Zend/Gdata/Calendar/TimezoneTest.php
@@ -37,6 +37,16 @@ require_once 'Zend/Gdata/Calendar.php';
  */
 class Zend_Gdata_Calendar_TimezoneTest extends TestCase
 {
+    /**
+     * @var string|bool|mixed
+     */
+    protected $timezoneText;
+
+    /**
+     * @var \Zend_Gdata_Calendar_Extension_Timezone|mixed
+     */
+    protected $timezone;
+
     protected function setUp(): void
     {
         $this->timezoneText = file_get_contents(

--- a/tests/Zend/Gdata/Calendar/WebContentTest.php
+++ b/tests/Zend/Gdata/Calendar/WebContentTest.php
@@ -37,6 +37,16 @@ require_once 'Zend/Gdata/Calendar.php';
  */
 class Zend_Gdata_Calendar_WebContentTest extends TestCase
 {
+    /**
+     * @var string|bool|mixed
+     */
+    protected $webContentText;
+
+    /**
+     * @var \Zend_Gdata_Calendar_Extension_WebContent|mixed
+     */
+    protected $webContent;
+
     protected function setUp(): void
     {
         $this->webContentText = file_get_contents(

--- a/tests/Zend/Gdata/CalendarOnlineTest.php
+++ b/tests/Zend/Gdata/CalendarOnlineTest.php
@@ -39,6 +39,11 @@ require_once 'Zend/Http/Client.php';
  */
 class Zend_Gdata_CalendarOnlineTest extends TestCase
 {
+    /**
+     * @var \Zend_Gdata_Calendar|mixed
+     */
+    protected $gdata;
+
     public const GOOGLE_DEVELOPER_CALENDAR = 'developer-calendar@google.com';
     public const ZEND_CONFERENCE_EVENT = 'bn2h4o4mc3a03ci4t48j3m56pg';
 

--- a/tests/Zend/Gdata/CalendarTest.php
+++ b/tests/Zend/Gdata/CalendarTest.php
@@ -39,6 +39,15 @@ require_once 'Zend/Http/Client/Adapter/Test.php';
  */
 class Zend_Gdata_CalendarTest extends TestCase
 {
+    /**
+     * @var string|bool|mixed
+     */
+    protected $eventFeedText;
+    /**
+     * @var \Zend_Gdata_Calendar_EventFeed|mixed
+     */
+    protected $eventFeed;
+
     protected function setUp(): void
     {
         $this->eventFeedText = file_get_contents(

--- a/tests/Zend/Gdata/CommentsTest.php
+++ b/tests/Zend/Gdata/CommentsTest.php
@@ -36,6 +36,15 @@ require_once 'Zend/Gdata.php';
  */
 class Zend_Gdata_CommentsTest extends TestCase
 {
+    /**
+     * @var string|bool|mixed
+     */
+    protected $commentsText;
+    /**
+     * @var \Zend_Gdata_Extension_Comments|mixed
+     */
+    protected $comments;
+
     protected function setUp(): void
     {
         $this->commentsText = file_get_contents(

--- a/tests/Zend/Gdata/Docs/DocumentListEntryTest.php
+++ b/tests/Zend/Gdata/Docs/DocumentListEntryTest.php
@@ -38,6 +38,16 @@ require_once 'Zend/Gdata/Docs/DocumentListEntry.php';
  */
 class Zend_Gdata_Docs_DocumentListEntryTest extends TestCase
 {
+    /**
+     * @var \Zend_Gdata_Docs_DocumentListEntry|mixed
+     */
+    protected $doc;
+
+    /**
+     * @var \Zend_Gdata_Docs|mixed
+     */
+    protected $docsClient;
+
     protected function setUp(): void
     {
         $this->doc = new Zend_Gdata_Docs_DocumentListEntry(

--- a/tests/Zend/Gdata/Docs/DocumentListFeedTest.php
+++ b/tests/Zend/Gdata/Docs/DocumentListFeedTest.php
@@ -37,6 +37,11 @@ require_once 'Zend/Http/Client.php';
  */
 class Zend_Gdata_Docs_DocumentListFeedTest extends TestCase
 {
+    /**
+     * @var \Zend_Gdata_Docs_DocumentListFeed|mixed
+     */
+    protected $docFeed;
+
     protected function setUp(): void
     {
         $this->docFeed = new Zend_Gdata_Docs_DocumentListFeed(

--- a/tests/Zend/Gdata/Docs/QueryTest.php
+++ b/tests/Zend/Gdata/Docs/QueryTest.php
@@ -38,6 +38,11 @@ require_once 'Zend/Http/Client.php';
  */
 class Zend_Gdata_Docs_QueryTest extends TestCase
 {
+    /**
+     * @var \Zend_Gdata_Docs_Query|mixed
+     */
+    protected $docQuery;
+
     protected function setUp(): void
     {
         $this->docQuery = new Zend_Gdata_Docs_Query();

--- a/tests/Zend/Gdata/DocsOnlineTest.php
+++ b/tests/Zend/Gdata/DocsOnlineTest.php
@@ -38,6 +38,15 @@ require_once 'Zend/Gdata/ClientLogin.php';
  */
 class Zend_Gdata_DocsOnlineTest extends TestCase
 {
+    /**
+     * @var mixed
+     */
+    protected $docTitle;
+    /**
+     * @var \Zend_Gdata_Docs|mixed
+     */
+    protected $gdata;
+
     protected function setUp(): void
     {
         $user = constant('TESTS_ZEND_GDATA_CLIENTLOGIN_EMAIL');

--- a/tests/Zend/Gdata/DocsTest.php
+++ b/tests/Zend/Gdata/DocsTest.php
@@ -38,6 +38,19 @@ require_once 'Zend/Gdata/TestUtility/MockHttpClient.php';
  */
 class Zend_Gdata_DocsTest extends TestCase
 {
+    /**
+     * @var \Test_Zend_Gdata_MockHttpClient|mixed
+     */
+    protected $adapter;
+    /**
+     * @var \Zend_Gdata_HttpClient|mixed
+     */
+    protected $client;
+    /**
+     * @var \Zend_Gdata_Docs|mixed
+     */
+    protected $gdata;
+
     protected function setUp(): void
     {
         $this->adapter = new Test_Zend_Gdata_MockHttpClient();

--- a/tests/Zend/Gdata/EntryLinkTest.php
+++ b/tests/Zend/Gdata/EntryLinkTest.php
@@ -36,6 +36,15 @@ require_once 'Zend/Gdata.php';
  */
 class Zend_Gdata_EntryLinkTest extends TestCase
 {
+    /**
+     * @var string|bool|mixed
+     */
+    protected $entryLinkText;
+    /**
+     * @var \Zend_Gdata_Extension_EntryLink|mixed
+     */
+    protected $entryLink;
+
     protected function setUp(): void
     {
         $this->entryLinkText = file_get_contents(

--- a/tests/Zend/Gdata/EntryTest.php
+++ b/tests/Zend/Gdata/EntryTest.php
@@ -35,6 +35,46 @@ require_once 'Zend/Gdata/Entry.php';
  */
 class Zend_Gdata_EntryTest extends TestCase
 {
+    /**
+     * @var \Zend_Gdata_Entry|mixed
+     */
+    protected $entry;
+
+    /**
+     * @var string|bool|mixed
+     */
+    protected $entryText;
+
+    /**
+     * @var string|mixed
+     */
+    protected $etagLocalName;
+
+    /**
+     * @var string|mixed
+     */
+    protected $expectedEtag;
+
+    /**
+     * @var string|mixed
+     */
+    protected $expectedMismatchExceptionMessage;
+
+    /**
+     * @var string|mixed
+     */
+    protected $gdNamespace;
+
+    /**
+     * @var string|mixed
+     */
+    protected $openSearchNamespacev1;
+
+    /**
+     * @var string|mixed
+     */
+    protected $openSearchNamespacev2;
+
     protected function setUp(): void
     {
         $this->entry = new Zend_Gdata_Entry();

--- a/tests/Zend/Gdata/EventStatusTest.php
+++ b/tests/Zend/Gdata/EventStatusTest.php
@@ -36,6 +36,16 @@ require_once 'Zend/Gdata.php';
  */
 class Zend_Gdata_EventStatusTest extends TestCase
 {
+    /**
+     * @var string|bool|mixed
+     */
+    protected $eventStatusText;
+
+    /**
+     * @var \Zend_Gdata_Extension_EventStatus|mixed
+     */
+    protected $eventStatus;
+
     protected function setUp(): void
     {
         $this->eventStatusText = file_get_contents(

--- a/tests/Zend/Gdata/ExtendedPropertyTest.php
+++ b/tests/Zend/Gdata/ExtendedPropertyTest.php
@@ -36,6 +36,16 @@ require_once 'Zend/Gdata.php';
  */
 class Zend_Gdata_ExtendedPropertyTest extends TestCase
 {
+    /**
+     * @var string|bool|mixed
+     */
+    protected $extendedPropertyText;
+
+    /**
+     * @var \Zend_Gdata_Extension_ExtendedProperty|mixed
+     */
+    protected $extendedProperty;
+
     protected function setUp(): void
     {
         $this->extendedPropertyText = file_get_contents(

--- a/tests/Zend/Gdata/FeedLinkTest.php
+++ b/tests/Zend/Gdata/FeedLinkTest.php
@@ -36,6 +36,15 @@ require_once 'Zend/Gdata.php';
  */
 class Zend_Gdata_FeedLinkTest extends TestCase
 {
+    /**
+     * @var string|bool|mixed
+     */
+    protected $feedLinkText;
+
+    /**
+     * @var \Zend_Gdata_Extension_FeedLink|mixed
+     */
+    protected $feedLink;
     protected function setUp(): void
     {
         $this->feedLinkText = file_get_contents(

--- a/tests/Zend/Gdata/FeedTest.php
+++ b/tests/Zend/Gdata/FeedTest.php
@@ -37,6 +37,51 @@ require_once 'Zend/Gdata/App/Util.php';
  */
 class Zend_Gdata_FeedTest extends TestCase
 {
+    /**
+     * @var string|mixed
+     */
+    protected $etagLocalName;
+
+    /**
+     * @var string|mixed
+     */
+    protected $expectedEtag;
+
+    /**
+     * @var string|mixed
+     */
+    protected $expectedMismatchExceptionMessage;
+
+    /**
+     * @var \Zend_Gdata_Feed|mixed
+     */
+    protected $feed;
+
+    /**
+     * @var string|bool|mixed
+     */
+    protected $feedTextV1;
+
+    /**
+     * @var string|bool|mixed
+     */
+    protected $feedTextV2;
+
+    /**
+     * @var string|mixed
+     */
+    protected $gdNamespace;
+
+    /**
+     * @var string|mixed
+     */
+    protected $openSearchNamespacev1;
+
+    /**
+     * @var string|mixed
+     */
+    protected $openSearchNamespacev2;
+
     protected function setUp(): void
     {
         $this->etagLocalName = 'etag';

--- a/tests/Zend/Gdata/Gapps/EmailListEntryTest.php
+++ b/tests/Zend/Gdata/Gapps/EmailListEntryTest.php
@@ -37,6 +37,16 @@ require_once 'Zend/Gdata/Gapps.php';
  */
 class Zend_Gdata_Gapps_EmailListEntryTest extends TestCase
 {
+    /**
+     * @var string|bool|mixed
+     */
+    protected $entryText;
+
+    /**
+     * @var \Zend_Gdata_Gapps_EmailListEntry|mixed
+     */
+    protected $entry;
+
     protected function setUp(): void
     {
         $this->entryText = file_get_contents(

--- a/tests/Zend/Gdata/Gapps/EmailListFeedTest.php
+++ b/tests/Zend/Gdata/Gapps/EmailListFeedTest.php
@@ -37,6 +37,11 @@ require_once 'Zend/Gdata/Gapps/EmailListFeed.php';
  */
 class Zend_Gdata_Gapps_EmailListFeedTest extends TestCase
 {
+    /**
+     * @var \Zend_Gdata_Gapps_EmailListFeed|mixed
+     */
+    protected $emptyEmailListFeed;
+
     protected $emailListFeed = null;
 
     /**

--- a/tests/Zend/Gdata/Gapps/EmailListQueryTest.php
+++ b/tests/Zend/Gdata/Gapps/EmailListQueryTest.php
@@ -37,6 +37,11 @@ require_once 'Zend/Gdata/Gapps/EmailListQuery.php';
  */
 class Zend_Gdata_Gapps_EmailListQueryTest extends TestCase
 {
+    /**
+     * @var \Zend_Gdata_Gapps_EmailListQuery|mixed
+     */
+    protected $query;
+
     protected function setUp(): void
     {
         $this->query = new Zend_Gdata_Gapps_EmailListQuery();

--- a/tests/Zend/Gdata/Gapps/EmailListRecipientEntryTest.php
+++ b/tests/Zend/Gdata/Gapps/EmailListRecipientEntryTest.php
@@ -37,6 +37,16 @@ require_once 'Zend/Gdata/Gapps.php';
  */
 class Zend_Gdata_Gapps_EmailListRecipientEntryTest extends TestCase
 {
+    /**
+     * @var string|bool|mixed
+     */
+    protected $entryText;
+
+    /**
+     * @var \Zend_Gdata_Gapps_EmailListRecipientEntry|mixed
+     */
+    protected $entry;
+
     protected function setUp(): void
     {
         $this->entryText = file_get_contents(

--- a/tests/Zend/Gdata/Gapps/EmailListRecipientFeedTest.php
+++ b/tests/Zend/Gdata/Gapps/EmailListRecipientFeedTest.php
@@ -37,6 +37,11 @@ require_once 'Zend/Gdata/Gapps/EmailListRecipientFeed.php';
  */
 class Zend_Gdata_Gapps_EmailListRecipientFeedTest extends TestCase
 {
+    /**
+     * @var \Zend_Gdata_Gapps_EmailListRecipientFeed|mixed
+     */
+    protected $emptyEmailListRecipientFeed;
+
     protected $emailListRecipientFeed = null;
 
     /**

--- a/tests/Zend/Gdata/Gapps/EmailListRecipientQueryTest.php
+++ b/tests/Zend/Gdata/Gapps/EmailListRecipientQueryTest.php
@@ -37,6 +37,11 @@ require_once 'Zend/Gdata/Gapps/EmailListRecipientQuery.php';
  */
 class Zend_Gdata_Gapps_EmailListRecipientQueryTest extends TestCase
 {
+    /**
+     * @var \Zend_Gdata_Gapps_EmailListRecipientQuery|mixed
+     */
+    protected $query;
+
     protected function setUp(): void
     {
         $this->query = new Zend_Gdata_Gapps_EmailListRecipientQuery();

--- a/tests/Zend/Gdata/Gapps/EmailListTest.php
+++ b/tests/Zend/Gdata/Gapps/EmailListTest.php
@@ -37,6 +37,16 @@ require_once 'Zend/Gdata.php';
  */
 class Zend_Gdata_Gapps_EmailListTest extends TestCase
 {
+    /**
+     * @var string|bool|mixed
+     */
+    protected $emailListText;
+
+    /**
+     * @var \Zend_Gdata_Gapps_Extension_EmailList|mixed
+     */
+    protected $emailList;
+
     protected function setUp(): void
     {
         $this->emailListText = file_get_contents(

--- a/tests/Zend/Gdata/Gapps/ErrorTest.php
+++ b/tests/Zend/Gdata/Gapps/ErrorTest.php
@@ -37,6 +37,11 @@ require_once 'Zend/Gdata/Gapps.php';
  */
 class Zend_Gdata_Gapps_ErrorTest extends TestCase
 {
+    /**
+     * @var \Zend_Gdata_Gapps_Error|mixed
+     */
+    protected $error;
+
     protected function setUp(): void
     {
         $this->error = new Zend_Gdata_Gapps_Error();

--- a/tests/Zend/Gdata/Gapps/GroupEntryTest.php
+++ b/tests/Zend/Gdata/Gapps/GroupEntryTest.php
@@ -37,6 +37,16 @@ require_once 'Zend/Gdata/Gapps.php';
  */
 class Zend_Gdata_Gapps_GroupEntryTest extends TestCase
 {
+    /**
+     * @var string|bool|mixed
+     */
+    protected $entryText;
+
+    /**
+     * @var \Zend_Gdata_Gapps_GroupEntry|mixed
+     */
+    protected $entry;
+
     protected function setUp(): void
     {
         $this->entryText = file_get_contents(

--- a/tests/Zend/Gdata/Gapps/GroupFeedTest.php
+++ b/tests/Zend/Gdata/Gapps/GroupFeedTest.php
@@ -37,6 +37,11 @@ require_once 'Zend/Gdata/Gapps/GroupFeed.php';
  */
 class Zend_Gdata_Gapps_GroupFeedTest extends TestCase
 {
+    /**
+     * @var \Zend_Gdata_Gapps_GroupFeed|mixed
+     */
+    protected $emptyGroupFeed;
+
     protected $groupFeed = null;
 
     /**

--- a/tests/Zend/Gdata/Gapps/GroupQueryTest.php
+++ b/tests/Zend/Gdata/Gapps/GroupQueryTest.php
@@ -37,6 +37,11 @@ require_once 'Zend/Gdata/Gapps/GroupQuery.php';
  */
 class Zend_Gdata_Gapps_GroupQueryTest extends TestCase
 {
+    /**
+     * @var \Zend_Gdata_Gapps_GroupQuery|mixed
+     */
+    protected $query;
+
     protected function setUp(): void
     {
         $this->query = new Zend_Gdata_Gapps_GroupQuery();

--- a/tests/Zend/Gdata/Gapps/LoginTest.php
+++ b/tests/Zend/Gdata/Gapps/LoginTest.php
@@ -37,6 +37,16 @@ require_once 'Zend/Gdata.php';
  */
 class Zend_Gdata_Gapps_LoginTest extends TestCase
 {
+    /**
+     * @var string|bool|mixed
+     */
+    protected $loginText;
+
+    /**
+     * @var \Zend_Gdata_Gapps_Extension_Login|mixed
+     */
+    protected $login;
+
     protected function setUp(): void
     {
         $this->loginText = file_get_contents(

--- a/tests/Zend/Gdata/Gapps/MemberEntryTest.php
+++ b/tests/Zend/Gdata/Gapps/MemberEntryTest.php
@@ -37,6 +37,16 @@ require_once 'Zend/Gdata/Gapps.php';
  */
 class Zend_Gdata_Gapps_MemberEntryTest extends TestCase
 {
+    /**
+     * @var string|bool|mixed
+     */
+    protected $entryText;
+
+    /**
+     * @var \Zend_Gdata_Gapps_MemberEntry|mixed
+     */
+    protected $entry;
+
     protected function setUp(): void
     {
         $this->entryText = file_get_contents(

--- a/tests/Zend/Gdata/Gapps/MemberFeedTest.php
+++ b/tests/Zend/Gdata/Gapps/MemberFeedTest.php
@@ -37,6 +37,11 @@ require_once 'Zend/Gdata/Gapps/MemberFeed.php';
  */
 class Zend_Gdata_Gapps_MemberFeedTest extends TestCase
 {
+    /**
+     * @var \Zend_Gdata_Gapps_MemberFeed|mixed
+     */
+    protected $emptyMemberFeed;
+
     protected $memberFeed = null;
 
     /**

--- a/tests/Zend/Gdata/Gapps/MemberQueryTest.php
+++ b/tests/Zend/Gdata/Gapps/MemberQueryTest.php
@@ -37,6 +37,11 @@ require_once 'Zend/Gdata/Gapps/MemberQuery.php';
  */
 class Zend_Gdata_Gapps_MemberQueryTest extends TestCase
 {
+    /**
+     * @var \Zend_Gdata_Gapps_MemberQuery|mixed
+     */
+    protected $query;
+
     protected function setUp(): void
     {
         $this->query = new Zend_Gdata_Gapps_MemberQuery();

--- a/tests/Zend/Gdata/Gapps/NameTest.php
+++ b/tests/Zend/Gdata/Gapps/NameTest.php
@@ -37,6 +37,16 @@ require_once 'Zend/Gdata.php';
  */
 class Zend_Gdata_Gapps_NameTest extends TestCase
 {
+    /**
+     * @var string|bool|mixed
+     */
+    protected $theNameText;
+
+    /**
+     * @var \Zend_Gdata_Gapps_Extension_Name|mixed
+     */
+    protected $theName;
+
     protected function setUp(): void
     {
         $this->theNameText = file_get_contents(

--- a/tests/Zend/Gdata/Gapps/NicknameEntryTest.php
+++ b/tests/Zend/Gdata/Gapps/NicknameEntryTest.php
@@ -37,6 +37,16 @@ require_once 'Zend/Gdata/Gapps.php';
  */
 class Zend_Gdata_Gapps_NicknameEntryTest extends TestCase
 {
+    /**
+     * @var string|bool|mixed
+     */
+    protected $entryText;
+
+    /**
+     * @var \Zend_Gdata_Gapps_NicknameEntry|mixed
+     */
+    protected $entry;
+
     protected function setUp(): void
     {
         $this->entryText = file_get_contents(

--- a/tests/Zend/Gdata/Gapps/NicknameFeedTest.php
+++ b/tests/Zend/Gdata/Gapps/NicknameFeedTest.php
@@ -37,6 +37,11 @@ require_once 'Zend/Gdata/Gapps/NicknameFeed.php';
  */
 class Zend_Gdata_Gapps_NicknameFeedTest extends TestCase
 {
+    /**
+     * @var \Zend_Gdata_Gapps_NicknameFeed|mixed
+     */
+    protected $emptyNicknameFeed;
+
     protected $nicknameFeed = null;
 
     /**

--- a/tests/Zend/Gdata/Gapps/NicknameQueryTest.php
+++ b/tests/Zend/Gdata/Gapps/NicknameQueryTest.php
@@ -37,6 +37,11 @@ require_once 'Zend/Gdata/Gapps/NicknameQuery.php';
  */
 class Zend_Gdata_Gapps_NicknameQueryTest extends TestCase
 {
+    /**
+     * @var \Zend_Gdata_Gapps_NicknameQuery|mixed
+     */
+    protected $query;
+
     protected function setUp(): void
     {
         $this->query = new Zend_Gdata_Gapps_NicknameQuery();

--- a/tests/Zend/Gdata/Gapps/NicknameTest.php
+++ b/tests/Zend/Gdata/Gapps/NicknameTest.php
@@ -37,6 +37,16 @@ require_once 'Zend/Gdata.php';
  */
 class Zend_Gdata_Gapps_NicknameTest extends TestCase
 {
+    /**
+     * @var string|bool|mixed
+     */
+    protected $nicknameText;
+
+    /**
+     * @var \Zend_Gdata_Gapps_Extension_Nickname|mixed
+     */
+    protected $nickname;
+
     protected function setUp(): void
     {
         $this->nicknameText = file_get_contents(

--- a/tests/Zend/Gdata/Gapps/OwnerEntryTest.php
+++ b/tests/Zend/Gdata/Gapps/OwnerEntryTest.php
@@ -37,6 +37,16 @@ require_once 'Zend/Gdata/Gapps.php';
  */
 class Zend_Gdata_Gapps_OwnerEntryTest extends TestCase
 {
+    /**
+     * @var string|bool|mixed
+     */
+    protected $entryText;
+
+    /**
+     * @var \Zend_Gdata_Gapps_OwnerEntry|mixed
+     */
+    protected $entry;
+
     protected function setUp(): void
     {
         $this->entryText = file_get_contents(

--- a/tests/Zend/Gdata/Gapps/OwnerFeedTest.php
+++ b/tests/Zend/Gdata/Gapps/OwnerFeedTest.php
@@ -37,6 +37,11 @@ require_once 'Zend/Gdata/Gapps/OwnerFeed.php';
  */
 class Zend_Gdata_Gapps_OwnerFeedTest extends TestCase
 {
+    /**
+     * @var \Zend_Gdata_Gapps_OwnerFeed|mixed
+     */
+    protected $emptyOwnerFeed;
+
     protected $ownerFeed = null;
 
     /**

--- a/tests/Zend/Gdata/Gapps/OwnerQueryTest.php
+++ b/tests/Zend/Gdata/Gapps/OwnerQueryTest.php
@@ -37,6 +37,11 @@ require_once 'Zend/Gdata/Gapps/OwnerQuery.php';
  */
 class Zend_Gdata_Gapps_OwnerQueryTest extends TestCase
 {
+    /**
+     * @var \Zend_Gdata_Gapps_OwnerQuery|mixed
+     */
+    protected $query;
+
     protected function setUp(): void
     {
         $this->query = new Zend_Gdata_Gapps_OwnerQuery();

--- a/tests/Zend/Gdata/Gapps/PropertyTest.php
+++ b/tests/Zend/Gdata/Gapps/PropertyTest.php
@@ -37,6 +37,16 @@ require_once 'Zend/Gdata.php';
  */
 class Zend_Gdata_Gapps_PropertyTest extends TestCase
 {
+    /**
+     * @var string|bool|mixed
+     */
+    protected $thePropertyText;
+
+    /**
+     * @var \Zend_Gdata_Gapps_Extension_Property|mixed
+     */
+    protected $theProperty;
+
     protected function setUp(): void
     {
         $this->thePropertyText = file_get_contents(

--- a/tests/Zend/Gdata/Gapps/QuotaTest.php
+++ b/tests/Zend/Gdata/Gapps/QuotaTest.php
@@ -37,6 +37,16 @@ require_once 'Zend/Gdata.php';
  */
 class Zend_Gdata_Gapps_QuotaTest extends TestCase
 {
+    /**
+     * @var string|bool|mixed
+     */
+    protected $quotaText;
+
+    /**
+     * @var \Zend_Gdata_Gapps_Extension_Quota|mixed
+     */
+    protected $quota;
+
     protected function setUp(): void
     {
         $this->quotaText = file_get_contents(

--- a/tests/Zend/Gdata/Gapps/ServiceExceptionTest.php
+++ b/tests/Zend/Gdata/Gapps/ServiceExceptionTest.php
@@ -38,6 +38,11 @@ require_once 'Zend/Gdata/Gapps.php';
  */
 class Zend_Gdata_Gapps_ServiceExceptionTest extends TestCase
 {
+    /**
+     * @var string|bool|mixed
+     */
+    protected $xmlSample;
+
     protected $fixture;
     protected $data;
 

--- a/tests/Zend/Gdata/Gapps/UserEntryTest.php
+++ b/tests/Zend/Gdata/Gapps/UserEntryTest.php
@@ -37,6 +37,16 @@ require_once 'Zend/Gdata/Gapps.php';
  */
 class Zend_Gdata_Gapps_UserEntryTest extends TestCase
 {
+    /**
+     * @var string|bool|mixed
+     */
+    protected $entryText;
+
+    /**
+     * @var \Zend_Gdata_Gapps_UserEntry|mixed
+     */
+    protected $entry;
+
     protected function setUp(): void
     {
         $this->entryText = file_get_contents(

--- a/tests/Zend/Gdata/Gapps/UserFeedTest.php
+++ b/tests/Zend/Gdata/Gapps/UserFeedTest.php
@@ -37,6 +37,11 @@ require_once 'Zend/Gdata/Gapps/UserFeed.php';
  */
 class Zend_Gdata_Gapps_UserFeedTest extends TestCase
 {
+    /**
+     * @var \Zend_Gdata_Gapps_UserFeed|mixed
+     */
+    protected $emptyUserFeed;
+
     protected $userFeed = null;
 
     /**

--- a/tests/Zend/Gdata/Gapps/UserQueryTest.php
+++ b/tests/Zend/Gdata/Gapps/UserQueryTest.php
@@ -37,6 +37,11 @@ require_once 'Zend/Gdata/Gapps/UserQuery.php';
  */
 class Zend_Gdata_Gapps_UserQueryTest extends TestCase
 {
+    /**
+     * @var \Zend_Gdata_Gapps_UserQuery|mixed
+     */
+    protected $query;
+
     protected function setUp(): void
     {
         $this->query = new Zend_Gdata_Gapps_UserQuery();

--- a/tests/Zend/Gdata/GappsOnlineTest.php
+++ b/tests/Zend/Gdata/GappsOnlineTest.php
@@ -40,6 +40,23 @@ require_once 'Zend/Http/Client.php';
  */
 class Zend_Gdata_GappsOnlineTest extends TestCase
 {
+    /**
+     * @var string|mixed
+     */
+    protected $id;
+    /**
+     * @var mixed
+     */
+    protected $domain;
+    /**
+     * @var \Zend_Gdata_Gapps|mixed
+     */
+    protected $gdata;
+    /**
+     * @var mixed[]|mixed
+     */
+    protected $autoDeletePool;
+
     public const GIVEN_NAME = 'Zend_Gdata';
     public const FAMILY_NAME = 'Automated Test Account';
     public const PASSWORD = '4ohtladfl;';

--- a/tests/Zend/Gdata/GappsTest.php
+++ b/tests/Zend/Gdata/GappsTest.php
@@ -39,6 +39,11 @@ require_once 'Zend/Http/Client.php';
  */
 class Zend_Gdata_GappsTest extends TestCase
 {
+    /**
+     * @var \Zend_Gdata_Gapps|mixed
+     */
+    protected $gdata;
+
     public const TEST_DOMAIN = 'nowhere.invalid';
 
     protected function setUp(): void

--- a/tests/Zend/Gdata/GdataOnlineTest.php
+++ b/tests/Zend/Gdata/GdataOnlineTest.php
@@ -40,6 +40,11 @@ require_once 'Zend/Gdata/App/InvalidArgumentException.php';
  */
 class Zend_Gdata_GdataOnlineTest extends TestCase
 {
+    /**
+     * @var \Zend_Gdata|mixed
+     */
+    protected $gdata;
+
     private $blog = null; // blog ID from config
 
     protected function setUp(): void

--- a/tests/Zend/Gdata/MediaMimeStreamTest.php
+++ b/tests/Zend/Gdata/MediaMimeStreamTest.php
@@ -35,6 +35,31 @@ require_once 'Zend/Gdata/MediaMimeStream.php';
  */
 class Zend_Gdata_MediaMimeStreamTest extends TestCase
 {
+    /**
+     * @var string|mixed
+     */
+    protected $locationOfFakeBinary;
+
+    /**
+     * @var string|mixed
+     */
+    protected $smallXMLString;
+
+    /**
+     * @var string|mixed
+     */
+    protected $testMediaType;
+
+    /**
+     * @var \Zend_Gdata_MediaMimeStream|mixed
+     */
+    protected $mediaMimeStream;
+
+    /**
+     * @var int|mixed
+     */
+    protected $exceptedLenOfMimeMessage;
+
     protected function setUp(): void
     {
         $this->locationOfFakeBinary =

--- a/tests/Zend/Gdata/OpenSearchItemsPerPageTest.php
+++ b/tests/Zend/Gdata/OpenSearchItemsPerPageTest.php
@@ -37,6 +37,16 @@ require_once 'Zend/Gdata.php';
  */
 class Zend_Gdata_OpenSearchItemsPerPageTest extends TestCase
 {
+    /**
+     * @var string|bool|mixed
+     */
+    protected $openSearchItemsPerPageText;
+
+    /**
+     * @var \Zend_Gdata_Extension_OpenSearchItemsPerPage|mixed
+     */
+    protected $openSearchItemsPerPage;
+
     protected function setUp(): void
     {
         $this->openSearchItemsPerPageText = file_get_contents(

--- a/tests/Zend/Gdata/OpenSearchStartIndexTest.php
+++ b/tests/Zend/Gdata/OpenSearchStartIndexTest.php
@@ -37,6 +37,16 @@ require_once 'Zend/Gdata.php';
  */
 class Zend_Gdata_OpenSearchStartIndexTest extends TestCase
 {
+    /**
+     * @var string|bool|mixed
+     */
+    protected $openSearchStartIndexText;
+
+    /**
+     * @var \Zend_Gdata_Extension_OpenSearchStartIndex|mixed
+     */
+    protected $openSearchStartIndex;
+
     protected function setUp(): void
     {
         $this->openSearchStartIndexText = file_get_contents(

--- a/tests/Zend/Gdata/OpenSearchTotalResultsTest.php
+++ b/tests/Zend/Gdata/OpenSearchTotalResultsTest.php
@@ -37,6 +37,16 @@ require_once 'Zend/Gdata.php';
  */
 class Zend_Gdata_OpenSearchTotalResultsTest extends TestCase
 {
+    /**
+     * @var string|bool|mixed
+     */
+    protected $openSearchTotalResultsText;
+
+    /**
+     * @var \Zend_Gdata_Extension_OpenSearchTotalResults|mixed
+     */
+
+     protected $openSearchTotalResults;
     protected function setUp(): void
     {
         $this->openSearchTotalResultsText = file_get_contents(

--- a/tests/Zend/Gdata/OriginalEventTest.php
+++ b/tests/Zend/Gdata/OriginalEventTest.php
@@ -36,6 +36,16 @@ require_once 'Zend/Gdata.php';
  */
 class Zend_Gdata_OriginalEventTest extends TestCase
 {
+    /**
+     * @var string|bool|mixed
+     */
+    protected $originalEventText;
+
+    /**
+     * @var \Zend_Gdata_Extension_OriginalEvent|mixed
+     */
+    protected $originalEvent;
+
     protected function setUp(): void
     {
         $this->originalEventText = file_get_contents(

--- a/tests/Zend/Gdata/RecurrenceExceptionTest.php
+++ b/tests/Zend/Gdata/RecurrenceExceptionTest.php
@@ -36,6 +36,16 @@ require_once 'Zend/Gdata.php';
  */
 class Zend_Gdata_RecurrenceExceptionTest extends TestCase
 {
+    /**
+     * @var string|bool|mixed
+     */
+    protected $recurrenceExceptionText;
+
+    /**
+     * @var \Zend_Gdata_Extension_RecurrenceException|mixed
+     */
+    protected $recurrenceException;
+
     protected function setUp(): void
     {
         $this->recurrenceExceptionText = file_get_contents(

--- a/tests/Zend/Gdata/RecurrenceTest.php
+++ b/tests/Zend/Gdata/RecurrenceTest.php
@@ -36,6 +36,16 @@ require_once 'Zend/Gdata.php';
  */
 class Zend_Gdata_RecurrenceTest extends TestCase
 {
+    /**
+     * @var string|bool|mixed
+     */
+    protected $recurrenceText;
+
+    /**
+     * @var \Zend_Gdata_Extension_Recurrence|mixed
+     */
+    protected $recurrence;
+
     protected function setUp(): void
     {
         $this->recurrenceText = file_get_contents(

--- a/tests/Zend/Gdata/ReminderTest.php
+++ b/tests/Zend/Gdata/ReminderTest.php
@@ -36,6 +36,16 @@ require_once 'Zend/Gdata.php';
  */
 class Zend_Gdata_ReminderTest extends TestCase
 {
+    /**
+     * @var string|bool|mixed
+     */
+    protected $reminderText;
+
+    /**
+     * @var \Zend_Gdata_Extension_Reminder|mixed
+     */
+    protected $reminder;
+
     protected function setUp(): void
     {
         $this->reminderText = file_get_contents(

--- a/tests/Zend/Gdata/Spreadsheets/CellEntryTest.php
+++ b/tests/Zend/Gdata/Spreadsheets/CellEntryTest.php
@@ -37,6 +37,11 @@ require_once 'Zend/Http/Client.php';
  */
 class Zend_Gdata_Spreadsheets_CellEntryTest extends TestCase
 {
+    /**
+     * @var \Zend_Gdata_Spreadsheets_CellEntry|mixed
+     */
+    protected $cellEntry;
+
     protected function setUp(): void
     {
         $this->cellEntry = new Zend_Gdata_Spreadsheets_CellEntry();

--- a/tests/Zend/Gdata/Spreadsheets/CellFeedTest.php
+++ b/tests/Zend/Gdata/Spreadsheets/CellFeedTest.php
@@ -37,6 +37,11 @@ require_once 'Zend/Http/Client.php';
  */
 class Zend_Gdata_Spreadsheets_CellFeedTest extends TestCase
 {
+    /**
+     * @var \Zend_Gdata_Spreadsheets_CellFeed|mixed
+     */
+    protected $cellFeed;
+
     protected function setUp(): void
     {
         $this->cellFeed = new Zend_Gdata_Spreadsheets_CellFeed(

--- a/tests/Zend/Gdata/Spreadsheets/CellQueryTest.php
+++ b/tests/Zend/Gdata/Spreadsheets/CellQueryTest.php
@@ -37,6 +37,11 @@ require_once 'Zend/Http/Client.php';
  */
 class Zend_Gdata_Spreadsheets_CellQueryTest extends TestCase
 {
+    /**
+     * @var \Zend_Gdata_Spreadsheets_CellQuery|mixed
+     */
+    protected $docQuery;
+
     protected function setUp(): void
     {
         $this->docQuery = new Zend_Gdata_Spreadsheets_CellQuery();

--- a/tests/Zend/Gdata/Spreadsheets/CellTest.php
+++ b/tests/Zend/Gdata/Spreadsheets/CellTest.php
@@ -37,6 +37,11 @@ require_once 'Zend/Http/Client.php';
  */
 class Zend_Gdata_Spreadsheets_CellTest extends TestCase
 {
+    /**
+     * @var \Zend_Gdata_Spreadsheets_Extension_Cell|mixed
+     */
+    protected $cell;
+
     protected function setUp(): void
     {
         $this->cell = new Zend_Gdata_Spreadsheets_Extension_Cell();

--- a/tests/Zend/Gdata/Spreadsheets/ColCountTest.php
+++ b/tests/Zend/Gdata/Spreadsheets/ColCountTest.php
@@ -37,6 +37,11 @@ require_once 'Zend/Http/Client.php';
  */
 class Zend_Gdata_Spreadsheets_ColCountTest extends TestCase
 {
+    /**
+     * @var \Zend_Gdata_Spreadsheets_Extension_ColCount|mixed
+     */
+    protected $colCount;
+
     protected function setUp(): void
     {
         $this->colCount = new Zend_Gdata_Spreadsheets_Extension_ColCount();

--- a/tests/Zend/Gdata/Spreadsheets/CustomTest.php
+++ b/tests/Zend/Gdata/Spreadsheets/CustomTest.php
@@ -37,6 +37,11 @@ require_once 'Zend/Http/Client.php';
  */
 class Zend_Gdata_Spreadsheets_CustomTest extends TestCase
 {
+    /**
+     * @var \Zend_Gdata_Spreadsheets_Extension_Custom|mixed
+     */
+    protected $custom;
+
     protected function setUp(): void
     {
         $this->custom = new Zend_Gdata_Spreadsheets_Extension_Custom();

--- a/tests/Zend/Gdata/Spreadsheets/DocumentQueryTest.php
+++ b/tests/Zend/Gdata/Spreadsheets/DocumentQueryTest.php
@@ -37,6 +37,11 @@ require_once 'Zend/Http/Client.php';
  */
 class Zend_Gdata_Spreadsheets_DocumentQueryTest extends TestCase
 {
+    /**
+     * @var \Zend_Gdata_Spreadsheets_DocumentQuery|mixed
+     */
+    protected $docQuery;
+
     protected function setUp(): void
     {
         $this->docQuery = new Zend_Gdata_Spreadsheets_DocumentQuery();

--- a/tests/Zend/Gdata/Spreadsheets/ListEntryTest.php
+++ b/tests/Zend/Gdata/Spreadsheets/ListEntryTest.php
@@ -37,6 +37,16 @@ require_once 'Zend/Http/Client.php';
  */
 class Zend_Gdata_Spreadsheets_ListEntryTest extends TestCase
 {
+    /**
+     * @var \Zend_Gdata_Spreadsheets_ListEntry|mixed
+     */
+    protected $listEntry;
+
+    /**
+     * @var mixed[]|\Zend_Gdata_Spreadsheets_Extension_Custom[]|mixed
+     */
+    protected $rowData;
+
     protected function setUp(): void
     {
         $this->listEntry = new Zend_Gdata_Spreadsheets_ListEntry();

--- a/tests/Zend/Gdata/Spreadsheets/ListFeedTest.php
+++ b/tests/Zend/Gdata/Spreadsheets/ListFeedTest.php
@@ -37,6 +37,11 @@ require_once 'Zend/Http/Client.php';
  */
 class Zend_Gdata_Spreadsheets_ListFeedTest extends TestCase
 {
+    /**
+     * @var \Zend_Gdata_Spreadsheets_ListFeed|mixed
+     */
+    protected $listFeed;
+
     protected function setUp(): void
     {
         $this->listFeed = new Zend_Gdata_Spreadsheets_ListFeed(

--- a/tests/Zend/Gdata/Spreadsheets/ListQueryTest.php
+++ b/tests/Zend/Gdata/Spreadsheets/ListQueryTest.php
@@ -37,6 +37,11 @@ require_once 'Zend/Http/Client.php';
  */
 class Zend_Gdata_Spreadsheets_ListQueryTest extends TestCase
 {
+    /**
+     * @var \Zend_Gdata_Spreadsheets_ListQuery|mixed
+     */
+    protected $docQuery;
+
     protected function setUp(): void
     {
         $this->docQuery = new Zend_Gdata_Spreadsheets_ListQuery();

--- a/tests/Zend/Gdata/Spreadsheets/RowCountTest.php
+++ b/tests/Zend/Gdata/Spreadsheets/RowCountTest.php
@@ -37,6 +37,11 @@ require_once 'Zend/Http/Client.php';
  */
 class Zend_Gdata_Spreadsheets_RowCountTest extends TestCase
 {
+    /**
+     * @var \Zend_Gdata_Spreadsheets_Extension_RowCount|mixed
+     */
+    protected $rowCount;
+
     protected function setUp(): void
     {
         $this->rowCount = new Zend_Gdata_Spreadsheets_Extension_RowCount();

--- a/tests/Zend/Gdata/Spreadsheets/SpreadsheetFeedTest.php
+++ b/tests/Zend/Gdata/Spreadsheets/SpreadsheetFeedTest.php
@@ -37,6 +37,11 @@ require_once 'Zend/Http/Client.php';
  */
 class Zend_Gdata_Spreadsheets_SpreadsheetFeedTest extends TestCase
 {
+    /**
+     * @var \Zend_Gdata_Spreadsheets_SpreadsheetFeed|mixed
+     */
+    protected $sprFeed;
+
     protected function setUp(): void
     {
         $this->sprFeed = new Zend_Gdata_Spreadsheets_SpreadsheetFeed(

--- a/tests/Zend/Gdata/Spreadsheets/WorksheetEntryTest.php
+++ b/tests/Zend/Gdata/Spreadsheets/WorksheetEntryTest.php
@@ -37,6 +37,11 @@ require_once 'Zend/Http/Client.php';
  */
 class Zend_Gdata_Spreadsheets_WorksheetEntryTest extends TestCase
 {
+    /**
+     * @var \Zend_Gdata_Spreadsheets_WorksheetEntry|mixed
+     */
+    protected $wksEntry;
+
     protected function setUp(): void
     {
         $this->wksEntry = new Zend_Gdata_Spreadsheets_WorksheetEntry();

--- a/tests/Zend/Gdata/Spreadsheets/WorksheetFeedTest.php
+++ b/tests/Zend/Gdata/Spreadsheets/WorksheetFeedTest.php
@@ -37,6 +37,11 @@ require_once 'Zend/Http/Client.php';
  */
 class Zend_Gdata_Spreadsheets_WorksheetFeedTest extends TestCase
 {
+    /**
+     * @var \Zend_Gdata_Spreadsheets_WorksheetFeed|mixed
+     */
+    protected $wksFeed;
+
     protected function setUp(): void
     {
         $this->wksFeed = new Zend_Gdata_Spreadsheets_WorksheetFeed(

--- a/tests/Zend/Gdata/SpreadsheetsOnlineTest.php
+++ b/tests/Zend/Gdata/SpreadsheetsOnlineTest.php
@@ -38,6 +38,21 @@ require_once 'Zend/Gdata/ClientLogin.php';
  */
 class Zend_Gdata_SpreadsheetsOnlineTest extends TestCase
 {
+    /**
+     * @var mixed
+     */
+    protected $sprKey;
+
+    /**
+     * @var mixed
+     */
+    protected $wksId;
+
+    /**
+     * @var \Zend_Gdata_Spreadsheets|mixed
+     */
+    protected $gdata;
+
     protected function setUp(): void
     {
         $user = constant('TESTS_ZEND_GDATA_CLIENTLOGIN_EMAIL');

--- a/tests/Zend/Gdata/SpreadsheetsTest.php
+++ b/tests/Zend/Gdata/SpreadsheetsTest.php
@@ -37,6 +37,11 @@ require_once 'Zend/Http/Client.php';
  */
 class Zend_Gdata_SpreadsheetsTest extends TestCase
 {
+    /**
+     * @var \Zend_Gdata_Spreadsheets
+     */
+    protected $gdata;
+
     protected function setUp(): void
     {
         $this->gdata = new Zend_Gdata_Spreadsheets(new Zend_Http_Client());

--- a/tests/Zend/Gdata/TestUtility/MockHttpClient.php
+++ b/tests/Zend/Gdata/TestUtility/MockHttpClient.php
@@ -31,7 +31,7 @@ require_once 'Zend/Http/Client/Adapter/Test.php';
  */
 class Test_Zend_Gdata_MockHttpClient_Request
 {
-    public $methd;
+    public $method;
     public $uri;
     public $http_ver;
     public $headers;

--- a/tests/Zend/Gdata/TransparencyTest.php
+++ b/tests/Zend/Gdata/TransparencyTest.php
@@ -36,6 +36,16 @@ require_once 'Zend/Gdata.php';
  */
 class Zend_Gdata_TransparencyTest extends TestCase
 {
+    /**
+     * @var string|bool|mixed
+     */
+    protected $transparencyText;
+
+    /**
+     * @var \Zend_Gdata_Extension_Transparency|mixed
+     */
+    protected $transparency;
+
     protected function setUp(): void
     {
         $this->transparencyText = file_get_contents(

--- a/tests/Zend/Gdata/VisibilityTest.php
+++ b/tests/Zend/Gdata/VisibilityTest.php
@@ -36,6 +36,16 @@ require_once 'Zend/Gdata.php';
  */
 class Zend_Gdata_VisibilityTest extends TestCase
 {
+    /**
+     * @var string|bool|mixed
+     */
+    protected $visibilityText;
+
+    /**
+     * @var \Zend_Gdata_Extension_Visibility|mixed
+     */
+    protected $visibility;
+
     protected function setUp(): void
     {
         $this->visibilityText = file_get_contents(

--- a/tests/Zend/Gdata/WhenTest.php
+++ b/tests/Zend/Gdata/WhenTest.php
@@ -36,6 +36,16 @@ require_once 'Zend/Gdata.php';
  */
 class Zend_Gdata_WhenTest extends TestCase
 {
+    /**
+     * @var string|bool|mixed
+     */
+    protected $whenText;
+
+    /**
+     * @var \Zend_Gdata_Extension_When|mixed
+     */
+    protected $when;
+
     protected function setUp(): void
     {
         $this->whenText = file_get_contents(

--- a/tests/Zend/Gdata/WhereTest.php
+++ b/tests/Zend/Gdata/WhereTest.php
@@ -36,6 +36,16 @@ require_once 'Zend/Gdata.php';
  */
 class Zend_Gdata_WhereTest extends TestCase
 {
+    /**
+     * @var string|bool|mixed
+     */
+    protected $whereText;
+
+    /**
+     * @var \Zend_Gdata_Extension_Where|mixed
+     */
+    protected $where;
+
     protected function setUp(): void
     {
         $this->whereText = file_get_contents(

--- a/tests/Zend/Gdata/WhoTest.php
+++ b/tests/Zend/Gdata/WhoTest.php
@@ -36,6 +36,16 @@ require_once 'Zend/Gdata.php';
  */
 class Zend_Gdata_WhoTest extends TestCase
 {
+    /**
+     * @var string|bool|mixed
+     */
+    protected $whoText;
+
+    /**
+     * @var \Zend_Gdata_Extension_Who|mixed
+     */
+    protected $who;
+
     protected function setUp(): void
     {
         $this->whoText = file_get_contents(

--- a/tests/Zend/Http/Client/ClientTest.php
+++ b/tests/Zend/Http/Client/ClientTest.php
@@ -34,9 +34,13 @@ require_once 'Zend/Http/Client.php';
  * @group      Zend_Http
  * @group      Zend_Http_Client
  */
-#[AllowDynamicProperties]
 class Zend_Http_Client_ClientTest extends TestCase
 {
+    /**
+     * @var \Zend_Http_Client|mixed
+     */
+    protected $client;
+
     /**
      * Set up the test case
      *

--- a/tests/Zend/Http/UserAgent/Features/Adapter/DeviceAtlasTest.php
+++ b/tests/Zend/Http/UserAgent/Features/Adapter/DeviceAtlasTest.php
@@ -33,6 +33,11 @@ require_once 'Zend/Http/UserAgent/Features/Adapter/DeviceAtlas.php';
  */
 class Zend_Http_UserAgent_Features_Adapter_DeviceAtlasTest extends TestCase
 {
+    /**
+     * @var array<string, mixed>
+     */
+    protected $config;
+
     protected function setUp(): void
     {
         if (!constant('TESTS_ZEND_HTTP_USERAGENT_DEVICEATLAS_LIB_DIR')

--- a/tests/Zend/Http/UserAgent/Features/Adapter/TeraWurflTest.php
+++ b/tests/Zend/Http/UserAgent/Features/Adapter/TeraWurflTest.php
@@ -37,6 +37,11 @@ require_once 'Zend/Http/UserAgent/Features/Adapter/TeraWurfl.php';
  */
 class Zend_Http_UserAgent_Features_Adapter_TeraWurflTest extends TestCase
 {
+    /**
+     * @var array<string, mixed>
+     */
+    protected $config;
+
     protected function setUp(): void
     {
         if (!constant('TESTS_ZEND_HTTP_USERAGENT_TERAWURFL_LIB_DIR')) {

--- a/tests/Zend/Http/UserAgentTest.php
+++ b/tests/Zend/Http/UserAgentTest.php
@@ -45,6 +45,17 @@ require_once dirname(__FILE__) . '/TestAsset/PopulatedStorage.php';
 #[AllowDynamicProperties]
 class Zend_Http_UserAgentTest extends TestCase
 {
+    /**
+     * @var mixed[]|array<string, string>|mixed|array<string, mixed>
+     */
+
+     protected $server;
+
+     /**
+     * @var array<string, array<string, string>>|mixed|array<string, string>|array<string, array<string, class-string<\Zend_Http_TestAsset_TestPluginLoader>>>|array<string, array<string, array<string, class-string<\Zend_Http_TestAsset_DesktopDevice>>>>|array<string, array<string, array<string, string>>>|array<string, array<string, array<string, class-string<\Zend_Http_TestAsset_InvalidDevice>>>>|array<string, mixed>
+     */
+    protected $config;
+
     protected function setUp(): void
     {
         Zend_Session::$_unitTestEnabled = true;

--- a/tests/Zend/Json/Server/CacheTest.php
+++ b/tests/Zend/Json/Server/CacheTest.php
@@ -44,9 +44,18 @@ require_once 'Zend/Json/Server.php';
  * @group      Zend_Json
  * @group      Zend_Json_Server
  */
-#[AllowDynamicProperties]
 class Zend_Json_Server_CacheTest extends TestCase
 {
+    /**
+     * @var \Zend_Json_Server|mixed
+     */
+    protected $server;
+
+    /**
+     * @var string|bool|mixed
+     */
+    protected $cacheFile;
+
     /**
      * Runs the test methods of this class.
      *

--- a/tests/Zend/Json/Server/ErrorTest.php
+++ b/tests/Zend/Json/Server/ErrorTest.php
@@ -44,9 +44,13 @@ require_once 'Zend/Json.php';
  * @group      Zend_Json
  * @group      Zend_Json_Server
  */
-#[AllowDynamicProperties]
 class Zend_Json_Server_ErrorTest extends TestCase
 {
+    /**
+     * @var \Zend_Json_Server_Error|mixed
+     */
+    protected $error;
+
     /**
      * Runs the test methods of this class.
      *

--- a/tests/Zend/Json/Server/RequestTest.php
+++ b/tests/Zend/Json/Server/RequestTest.php
@@ -42,9 +42,13 @@ require_once 'Zend/Json.php';
  * @group      Zend_Json
  * @group      Zend_Json_Server
  */
-#[AllowDynamicProperties]
 class Zend_Json_Server_RequestTest extends TestCase
 {
+    /**
+     * @var \Zend_Json_Server_Request|mixed
+     */
+    protected $request;
+
     /**
      * Runs the test methods of this class.
      *

--- a/tests/Zend/Json/Server/ResponseTest.php
+++ b/tests/Zend/Json/Server/ResponseTest.php
@@ -45,9 +45,13 @@ require_once 'Zend/Json.php';
  * @group      Zend_Json
  * @group      Zend_Json_Server
  */
-#[AllowDynamicProperties]
 class Zend_Json_Server_ResponseTest extends TestCase
 {
+    /**
+     * @var \Zend_Json_Server_Response|mixed
+     */
+    protected $response;
+
     /**
      * Runs the test methods of this class.
      *

--- a/tests/Zend/Json/Server/Smd/ServiceTest.php
+++ b/tests/Zend/Json/Server/Smd/ServiceTest.php
@@ -45,9 +45,13 @@ require_once 'Zend/Json.php';
  * @group      Zend_Json
  * @group      Zend_Json_Server
  */
-#[AllowDynamicProperties]
 class Zend_Json_Server_Smd_ServiceTest extends TestCase
 {
+    /**
+     * @var \Zend_Json_Server_Smd_Service|mixed
+     */
+    protected $service;
+
     /**
      * Runs the test methods of this class.
      *

--- a/tests/Zend/Json/Server/SmdTest.php
+++ b/tests/Zend/Json/Server/SmdTest.php
@@ -45,9 +45,13 @@ require_once 'Zend/Json.php';
  * @group      Zend_Json
  * @group      Zend_Json_Server
  */
-#[AllowDynamicProperties]
 class Zend_Json_Server_SmdTest extends TestCase
 {
+    /**
+     * @var \Zend_Json_Server_Smd|mixed
+     */
+    protected $smd;
+
     /**
      * Runs the test methods of this class.
      *

--- a/tests/Zend/Json/ServerTest.php
+++ b/tests/Zend/Json/ServerTest.php
@@ -47,9 +47,13 @@ require_once 'Zend/Server/Exception.php';
  * @group      Zend_Json
  * @group      Zend_Json_Server
  */
-#[AllowDynamicProperties]
 class Zend_Json_ServerTest extends TestCase
 {
+    /**
+     * @var \Zend_Json_Server|mixed
+     */
+    protected $server;
+
     /**
      * Runs the test methods of this class.
      *

--- a/tests/Zend/Loader/Autoloader/ResourceTest.php
+++ b/tests/Zend/Loader/Autoloader/ResourceTest.php
@@ -55,9 +55,33 @@ require_once 'Zend/Config.php';
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  * @group      Zend_Loader
  */
-#[AllowDynamicProperties]
 class Zend_Loader_Autoloader_ResourceTest extends TestCase
 {
+    /**
+     * @var mixed[]|mixed
+     */
+    protected $loaders;
+
+    /**
+     * @var string|bool|mixed
+     */
+    protected $includePath;
+
+    /**
+     * @var \Zend_Loader_Autoloader
+     */
+    protected $autoloader;
+
+    /**
+     * @var null
+     */
+    protected $error;
+
+    /**
+     * @var \Zend_Loader_Autoloader_Resource|mixed
+     */
+    protected $loader;
+
     public static function main()
     {
         $suite = new TestSuite(__CLASS__);

--- a/tests/Zend/Loader/AutoloaderFactoryTest.php
+++ b/tests/Zend/Loader/AutoloaderFactoryTest.php
@@ -43,9 +43,18 @@ require_once 'Zend/Loader/StandardAutoloader.php';
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  * @group      Loader
  */
-#[AllowDynamicProperties]
 class Zend_Loader_AutoloaderFactoryTest extends TestCase
 {
+    /**
+     * @var mixed[]|mixed
+     */
+    protected $loaders;
+
+    /**
+     * @var string|bool|mixed
+     */
+    protected $includePath;
+
     public static function main()
     {
         $suite = new TestSuite(__CLASS__);

--- a/tests/Zend/Loader/AutoloaderMultiVersionTest.php
+++ b/tests/Zend/Loader/AutoloaderMultiVersionTest.php
@@ -42,9 +42,48 @@ require_once 'Zend/Loader/Autoloader.php';
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  * @group      Zend_Loader
  */
-#[AllowDynamicProperties]
 class Zend_Loader_AutoloaderMultiVersionTest extends TestCase
 {
+    /**
+     * @var mixed[]|mixed
+     */
+    protected $loaders;
+
+    /**
+     * @var string|bool|mixed
+     */
+    protected $includePath;
+
+    /**
+     * @var mixed
+     */
+    protected $path;
+
+    /**
+     * @var mixed
+     */
+    protected $latest;
+
+    /**
+     * @var mixed
+     */
+    protected $latestMajor;
+
+    /**
+     * @var mixed
+     */
+    protected $latestMinor;
+
+    /**
+     * @var mixed
+     */
+    protected $specific;
+
+    /**
+     * @var \Zend_Loader_Autoloader|mixed
+     */
+    protected $autoloader;
+
     public static function main()
     {
         $suite = new TestSuite(__CLASS__);

--- a/tests/Zend/Loader/AutoloaderTest.php
+++ b/tests/Zend/Loader/AutoloaderTest.php
@@ -47,9 +47,28 @@ require_once 'Zend/Loader/Autoloader/Interface.php';
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  * @group      Zend_Loader
  */
-#[AllowDynamicProperties]
 class Zend_Loader_AutoloaderTest extends TestCase
 {
+    /**
+     * @var mixed[]|mixed
+     */
+    protected $loaders;
+
+    /**
+     * @var string|bool|mixed
+     */
+    protected $includePath;
+
+    /**
+     * @var \Zend_Loader_Autoloader|mixed
+     */
+    protected $autoloader;
+
+    /**
+     * @var null|mixed
+     */
+    protected $error;
+
     public static function main()
     {
         $suite = new TestSuite(__CLASS__);

--- a/tests/Zend/Loader/ClassMapAutoloaderTest.php
+++ b/tests/Zend/Loader/ClassMapAutoloaderTest.php
@@ -39,9 +39,18 @@ require_once 'Zend/Loader/ClassMapAutoloader.php';
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  * @group      Loader
  */
-#[AllowDynamicProperties]
 class Zend_Loader_ClassMapAutoloaderTest extends TestCase
 {
+    /**
+     * @var mixed[]|mixed
+     */
+    protected $loaders;
+
+    /**
+     * @var string|bool|mixed
+     */
+    protected $includePath;
+
     /**
      * @var Zend_Loader_ClassMapAutoloader
      */

--- a/tests/Zend/Loader/PluginLoaderTest.php
+++ b/tests/Zend/Loader/PluginLoaderTest.php
@@ -42,9 +42,18 @@ require_once 'Zend/Loader/PluginLoader.php';
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  * @group      Zend_Loader
  */
-#[AllowDynamicProperties]
 class Zend_Loader_PluginLoaderTest extends TestCase
 {
+    /**
+     * @var string|bool|mixed
+     */
+    protected $libPath;
+
+    /**
+     * @var null|mixed|string
+     */
+    protected $key;
+
     protected $_includeCache;
 
     /**

--- a/tests/Zend/Loader/StandardAutoloaderTest.php
+++ b/tests/Zend/Loader/StandardAutoloaderTest.php
@@ -38,9 +38,18 @@ require_once 'Zend/Loader/TestAsset/StandardAutoloader.php';
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  * @group      Loader
  */
-#[AllowDynamicProperties]
 class Zend_Loader_StandardAutoloaderTest extends TestCase
 {
+    /**
+     * @var mixed[]|mixed
+     */
+    protected $loaders;
+
+    /**
+     * @var string|bool|mixed
+     */
+    protected $includePath;
+
     protected function setUp(): void
     {
         // Store original autoloaders

--- a/tests/Zend/LoaderTest.php
+++ b/tests/Zend/LoaderTest.php
@@ -48,9 +48,28 @@ require_once 'Zend/Loader/Autoloader.php';
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  * @group      Zend_Loader
  */
-#[AllowDynamicProperties]
 class Zend_LoaderTest extends TestCase
 {
+    /**
+     * @var mixed[]|mixed
+     */
+    protected $loaders;
+
+    /**
+     * @var string|bool|mixed
+     */
+    protected $includePath;
+
+    /**
+     * @var null|mixed
+     */
+    protected $error;
+
+    /**
+     * @var null|mixed|bool
+     */
+    protected $errorHandler;
+
     /**
      * Runs the test methods of this class.
      *

--- a/tests/Zend/Log/Filter/ChainingTest.php
+++ b/tests/Zend/Log/Filter/ChainingTest.php
@@ -43,9 +43,18 @@ require_once 'Zend/Log/Writer/Stream.php';
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  * @group      Zend_Log
  */
-#[AllowDynamicProperties]
 class Zend_Log_Filter_ChainingTest extends TestCase
 {
+    /**
+     * @var resource|bool|mixed
+     */
+    protected $log;
+
+    /**
+     * @var \Zend_Log|mixed
+     */
+    protected $logger;
+
     public static function main()
     {
         $suite = new TestSuite(__CLASS__);

--- a/tests/Zend/Log/Filter/SuppressTest.php
+++ b/tests/Zend/Log/Filter/SuppressTest.php
@@ -43,9 +43,13 @@ require_once 'Zend/Log/Filter/Suppress.php';
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  * @group      Zend_Log
  */
-#[AllowDynamicProperties]
 class Zend_Log_Filter_SuppressTest extends TestCase
 {
+    /**
+     * @var \Zend_Log_Filter_Suppress|mixed
+     */
+    protected $filter;
+
     public static function main()
     {
         $suite = new TestSuite(__CLASS__);

--- a/tests/Zend/Log/LogTest.php
+++ b/tests/Zend/Log/LogTest.php
@@ -49,9 +49,28 @@ require_once 'Zend/Log/FactoryInterface.php';
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  * @group      Zend_Log
  */
-#[AllowDynamicProperties]
 class Zend_Log_LogTest extends TestCase
 {
+    /**
+     * @var resource|bool|mixed
+     */
+    protected $log;
+
+    /**
+     * @var \Zend_Log_Writer_Stream|mixed
+     */
+    protected $writer;
+
+    /**
+     * @var \Zend_Log_Writer_Mock|mixed
+     */
+    protected $errWriter;
+
+    /**
+     * @var bool|mixed
+     */
+    protected $expectingLogging;
+
     public static function main()
     {
         $suite = new TestSuite(__CLASS__);

--- a/tests/Zend/Log/Writer/DbTest.php
+++ b/tests/Zend/Log/Writer/DbTest.php
@@ -41,9 +41,23 @@ require_once 'Zend/Log/Writer/Db.php';
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  * @group      Zend_Log
  */
-#[AllowDynamicProperties]
 class Zend_Log_Writer_DbTest extends TestCase
 {
+    /**
+     * @var string|mixed
+     */
+    protected $tableName;
+
+    /**
+     * @var \Zend_Log_Writer_DbTest_MockDbAdapter|mixed
+     */
+    protected $db;
+
+    /**
+     * @var \Zend_Log_Writer_Db|mixed
+     */
+    protected $writer;
+
     public static function main()
     {
         $suite = new TestSuite(__CLASS__);

--- a/tests/Zend/Mail/FileTransportTest.php
+++ b/tests/Zend/Mail/FileTransportTest.php
@@ -41,9 +41,12 @@ require_once 'Zend/Mail/Transport/File.php';
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  * @group      Zend_Mail
  */
-#[AllowDynamicProperties]
 class Zend_Mail_FileTransportTest extends TestCase
 {
+    /**
+     * @var bool|mixed
+     */
+    protected $createdTmpDir;
     protected $_params;
     protected $_transport;
     protected $_tmpdir;

--- a/tests/Zend/Mail/MboxMessageOldTest.php
+++ b/tests/Zend/Mail/MboxMessageOldTest.php
@@ -96,7 +96,7 @@ class Zend_Mail_MboxMessageOldTest extends TestCase
 
     protected function tearDown(): void
     {
-        unlink($this->_mboxFile);
+        unlink((string) $this->_mboxFile);
     }
 
     public function testFetchHeader()

--- a/tests/Zend/Mail/MboxTest.php
+++ b/tests/Zend/Mail/MboxTest.php
@@ -79,7 +79,7 @@ class Zend_Mail_MboxTest extends TestCase
 
     protected function tearDown(): void
     {
-        unlink($this->_mboxFile);
+        unlink((string) $this->_mboxFile);
     }
     /** @doesNotPerformAssertions */
     public function testLoadOk()

--- a/tests/Zend/Measure/TemperatureTest.php
+++ b/tests/Zend/Measure/TemperatureTest.php
@@ -49,6 +49,11 @@ require_once 'Zend/Registry.php';
  */
 class Zend_Measure_TemperatureTest extends TestCase
 {
+    /**
+     * @var string|bool|mixed
+     */
+    protected $_locale;
+
     public static function main()
     {
         $suite = new TestSuite(__CLASS__);

--- a/tests/Zend/Mobile/Push/AbstractTest.php
+++ b/tests/Zend/Mobile/Push/AbstractTest.php
@@ -36,9 +36,13 @@ require_once 'Zend/Mobile/Push/Message/Abstract.php';
  * @group      Zend_Mobile_Push
  * @group      Zend_Mobile_Push_Abstract
  */
-
 class Zend_Mobile_Push_AbstractTest extends TestCase
 {
+    /**
+     * @var \Zend_Mobile_Push_AbstractProxy|mixed
+     */
+    protected $adapter;
+
     protected function setUp(): void
     {
         $this->adapter = new Zend_Mobile_Push_AbstractProxy();

--- a/tests/Zend/Mobile/Push/ApnsTest.php
+++ b/tests/Zend/Mobile/Push/ApnsTest.php
@@ -38,6 +38,16 @@ require_once 'Zend/Mobile/Push/Test/ApnsProxy.php';
  */
 class Zend_Mobile_Push_ApnsTest extends TestCase
 {
+    /**
+     * @var \Zend_Mobile_Push_Test_ApnsProxy|mixed
+     */
+    protected $apns;
+
+    /**
+     * @var \Zend_Mobile_Push_Message_Apns|mixed
+     */
+    protected $message;
+
     protected function setUp(): void
     {
         $this->apns = new Zend_Mobile_Push_Test_ApnsProxy();

--- a/tests/Zend/Mobile/Push/GcmTest.php
+++ b/tests/Zend/Mobile/Push/GcmTest.php
@@ -39,6 +39,26 @@ require_once 'Zend/Http/Client/Adapter/Test.php';
  */
 class Zend_Mobile_Push_gcmTest extends TestCase
 {
+    /**
+     * @var \Zend_Http_Client_Adapter_Test|mixed
+     */
+    protected $adapter;
+
+    /**
+     * @var \Zend_Http_Client|mixed
+     */
+    protected $client;
+
+    /**
+     * @var \Zend_Mobile_Push_Gcm|mixed
+     */
+    protected $gcm;
+
+    /**
+     * @var \Zend_Mobile_Push_Message_Gcm|mixed
+     */
+    protected $message;
+
     protected function _createJSONResponse($id, $success, $failure, $ids, $results)
     {
         return json_encode([

--- a/tests/Zend/Mobile/Push/Message/AbstractTest.php
+++ b/tests/Zend/Mobile/Push/Message/AbstractTest.php
@@ -35,6 +35,11 @@ require_once 'Zend/Mobile/Push/Message/Abstract.php';
  */
 class Zend_Mobile_Push_Message_AbstractTest extends TestCase
 {
+    /**
+     * @var \Zend_Mobile_Push_Message_AbstractProxy|mixed
+     */
+    protected $msg;
+
     protected function setUp(): void
     {
         $this->msg = new Zend_Mobile_Push_Message_AbstractProxy();

--- a/tests/Zend/Mobile/Push/Message/ApnsTest.php
+++ b/tests/Zend/Mobile/Push/Message/ApnsTest.php
@@ -37,6 +37,11 @@ require_once 'Zend/Mobile/Push/Message/Apns.php';
  */
 class Zend_Mobile_Push_Message_ApnsTest extends TestCase
 {
+    /**
+     * @var \Zend_Mobile_Push_Message_Apns|mixed
+     */
+    protected $message;
+
     protected function setUp(): void
     {
         $this->message = new Zend_Mobile_Push_Message_Apns();

--- a/tests/Zend/Mobile/Push/MpnsTest.php
+++ b/tests/Zend/Mobile/Push/MpnsTest.php
@@ -42,6 +42,21 @@ require_once 'Zend/Http/Client/Adapter/Test.php';
  */
 class Zend_Mobile_Push_MpnsTest extends TestCase
 {
+    /**
+     * @var \Zend_Http_Client_Adapter_Test|mixed
+     */
+    protected $adapter;
+
+    /**
+     * @var \Zend_Http_Client|mixed
+     */
+    protected $client;
+
+    /**
+     * @var \Zend_Mobile_Push_Mpns|mixed
+     */
+    protected $mpns;
+
     protected function setUp(): void
     {
         $this->adapter = new Zend_Http_Client_Adapter_Test();

--- a/tests/Zend/Oauth/ClientTest.php
+++ b/tests/Zend/Oauth/ClientTest.php
@@ -45,6 +45,11 @@ class Test_Oauth_Client extends Zend_Oauth_Client
  */
 class Zend_Oauth_ClientTest extends TestCase
 {
+    /**
+     * @var \Zend_Oauth_Client|mixed
+     */
+    protected $client;
+
     protected function setUp(): void
     {
         $this->client = new Zend_Oauth_Client([]);

--- a/tests/Zend/Oauth/ConfigTest.php
+++ b/tests/Zend/Oauth/ConfigTest.php
@@ -36,6 +36,11 @@ require_once 'Zend/Oauth/Config.php';
  */
 class Zend_Oauth_ConfigTest extends TestCase
 {
+    /**
+     * @var \Zend_Oauth_Config|mixed
+     */
+    protected $config;
+
     protected function setUp(): void
     {
         $this->config = new Zend_Oauth_Config();

--- a/tests/Zend/Oauth/Oauth/Http/AccessTokenTest.php
+++ b/tests/Zend/Oauth/Oauth/Http/AccessTokenTest.php
@@ -36,6 +36,11 @@ require_once 'Zend/Oauth/Http/AccessToken.php';
  */
 class Zend_Oauth_Http_AccessTokenTest extends TestCase
 {
+    /**
+     * @var \Test_Http_Utility_39745|mixed
+     */
+    protected $stubHttpUtility;
+
     protected $stubConsumer = null;
 
     protected function setUp(): void

--- a/tests/Zend/Oauth/Oauth/Http/RequestTokenTest.php
+++ b/tests/Zend/Oauth/Oauth/Http/RequestTokenTest.php
@@ -36,6 +36,16 @@ require_once 'Zend/Oauth/Http/RequestToken.php';
  */
 class Zend_Oauth_Http_RequestTokenTest extends TestCase
 {
+    /**
+     * @var \Test_Consumer_32874b|mixed
+     */
+    protected $stubConsumer2;
+
+    /**
+     * @var \Test_Http_Utility_32874|mixed
+     */
+    protected $stubHttpUtility;
+
     protected $stubConsumer = null;
 
     protected function setUp(): void

--- a/tests/Zend/OpenId/Provider/User/SessionTest.php
+++ b/tests/Zend/OpenId/Provider/User/SessionTest.php
@@ -39,6 +39,16 @@ require_once 'Zend/OpenId/Provider/User/Session.php';
  */
 class Zend_OpenId_Provider_User_SessionTest extends TestCase
 {
+    /**
+     * @var \Zend_OpenId_Provider_User_Session|mixed
+     */
+    protected $_user1;
+
+    /**
+     * @var \Zend_OpenId_Provider_User_Session|mixed
+     */
+    protected $_user2;
+
     public const USER1 = "test_user1";
     public const USER2 = "test_user2";
 

--- a/tests/Zend/Queue/Custom/DbForUpdate.php
+++ b/tests/Zend/Queue/Custom/DbForUpdate.php
@@ -40,6 +40,8 @@ require_once 'Zend/Queue/Adapter/Db.php';
  */
 class Custom_DbForUpdate extends Zend_Queue_Adapter_Db
 {
+    protected $_msg_table;
+
     /**
      * Return the first element in the queue
      *

--- a/tests/Zend/Queue/QueueTest.php
+++ b/tests/Zend/Queue/QueueTest.php
@@ -50,6 +50,16 @@ require_once 'Zend/Queue/Adapter/Array.php';
  */
 class Zend_Queue_QueueTest extends TestCase
 {
+    /**
+     * @var array<string, mixed[]>|array<string, string>|mixed|array<string, mixed>
+     */
+    protected $config;
+
+    /**
+     * @var \Zend_Queue|mixed
+     */
+    protected $queue;
+
     protected function setUp(): void
     {
         // Test Zend_Config

--- a/tests/Zend/Service/AkismetTest.php
+++ b/tests/Zend/Service/AkismetTest.php
@@ -44,6 +44,21 @@ require_once 'Zend/Http/Client/Adapter/Test.php';
  */
 class Zend_Service_AkismetTest extends TestCase
 {
+    /**
+     * @var \Zend_Service_Akismet|mixed
+     */
+    protected $akismet;
+
+    /**
+     * @var \Zend_Http_Client_Adapter_Test|mixed
+     */
+    protected $adapter;
+
+    /**
+     * @var array<string, string>|mixed
+     */
+    protected $comment;
+
     protected function setUp(): void
     {
         $this->akismet = new Zend_Service_Akismet('somebogusapikey', 'http://framework.zend.com/wiki/');

--- a/tests/Zend/Service/Amazon/Authentication/V1Test.php
+++ b/tests/Zend/Service/Amazon/Authentication/V1Test.php
@@ -37,6 +37,11 @@ require_once 'Zend/Service/Amazon/Authentication/V1.php';
 class Zend_Service_Amazon_Authentication_V1Test extends TestCase
 {
     /**
+     * @var \Zend_Service_Amazon_Authentication_V1|null|mixed
+     */
+    protected $Zend_Service_Amazon_Authentication_V1;
+
+    /**
      * @var Zend_Service_Amazon_Authentication_V2
      */
     private $Zend_Service_Amazon_Authentication_V2;

--- a/tests/Zend/Service/Amazon/Ec2/AvailabilityzonesTest.php
+++ b/tests/Zend/Service/Amazon/Ec2/AvailabilityzonesTest.php
@@ -42,6 +42,11 @@ require_once 'Zend/Service/Amazon/Ec2/Availabilityzones.php';
 class Zend_Service_Amazon_Ec2_AvailabilityzonesTest extends TestCase
 {
     /**
+     * @var \Zend_Http_Client_Adapter_Test|mixed
+     */
+    protected $adapter;
+
+    /**
      * @var Zend_Service_Amazon_Ec2_Availabilityzones
      */
     private $Zend_Service_Amazon_Ec2_Availabilityzones;

--- a/tests/Zend/Service/Amazon/Ec2/CloudWatchTest.php
+++ b/tests/Zend/Service/Amazon/Ec2/CloudWatchTest.php
@@ -42,6 +42,11 @@ require_once 'Zend/Http/Client/Adapter/Test.php';
 class Zend_Service_Amazon_Ec2_CloudWatchTest extends TestCase
 {
     /**
+     * @var \Zend_Http_Client_Adapter_Test|mixed
+     */
+    protected $adapter;
+
+    /**
      * @var Zend_Service_Amazon_Ec2_CloudWatch
      */
     private $Zend_Service_Amazon_Ec2_CloudWatch;

--- a/tests/Zend/Service/Amazon/Ec2/EbsTest.php
+++ b/tests/Zend/Service/Amazon/Ec2/EbsTest.php
@@ -42,6 +42,11 @@ require_once 'Zend/Service/Amazon/Ec2/Ebs.php';
 class Zend_Service_Amazon_Ec2_EbsTest extends TestCase
 {
     /**
+     * @var \Zend_Http_Client_Adapter_Test|mixed
+     */
+    protected $adapter;
+
+    /**
      * @var Zend_Service_Amazon_Ec2_Ebs
      */
     private $Zend_Service_Amazon_Ec2_Ebs;

--- a/tests/Zend/Service/Amazon/Ec2/ElasticipTest.php
+++ b/tests/Zend/Service/Amazon/Ec2/ElasticipTest.php
@@ -42,6 +42,11 @@ require_once 'Zend/Service/Amazon/Ec2/Elasticip.php';
 class Zend_Service_Amazon_Ec2_ElasticipTest extends TestCase
 {
     /**
+     * @var \Zend_Http_Client_Adapter_Test|mixed
+     */
+    protected $adapter;
+
+    /**
      * @var Zend_Service_Amazon_Ec2_Elasticip
      */
     private $Zend_Service_Amazon_Ec2_Elasticip;

--- a/tests/Zend/Service/Amazon/Ec2/ImageTest.php
+++ b/tests/Zend/Service/Amazon/Ec2/ImageTest.php
@@ -43,6 +43,11 @@ require_once 'Zend/Service/Amazon/Ec2/Image.php';
 class Zend_Service_Amazon_Ec2_ImageTest extends TestCase
 {
     /**
+     * @var \Zend_Http_Client_Adapter_Test|mixed
+     */
+    protected $adapter;
+
+    /**
      * @var Zend_Service_Amazon_Ec2_Image
      */
     private $Zend_Service_Amazon_Ec2_Image;

--- a/tests/Zend/Service/Amazon/Ec2/InstanceReservedTest.php
+++ b/tests/Zend/Service/Amazon/Ec2/InstanceReservedTest.php
@@ -44,6 +44,11 @@ require_once 'Zend/Http/Client/Adapter/Test.php';
 class InstanceReservedTest extends TestCase
 {
     /**
+     * @var \Zend_Http_Client_Adapter_Test|mixed
+     */
+    protected $adapter;
+
+    /**
      * @var Zend_Service_Amazon_Ec2_Instance_Reserved
      */
     private $Zend_Service_Amazon_Ec2_Instance_Reserved;

--- a/tests/Zend/Service/Amazon/Ec2/InstanceTest.php
+++ b/tests/Zend/Service/Amazon/Ec2/InstanceTest.php
@@ -43,6 +43,11 @@ require_once 'Zend/Service/Amazon/Ec2/Instance.php';
 class Zend_Service_Amazon_Ec2_InstanceTest extends TestCase
 {
     /**
+     * @var \Zend_Http_Client_Adapter_Test|mixed
+     */
+    protected $adapter;
+
+    /**
      * @var Zend_Service_Amazon_Ec2_Instance
      */
     private $Zend_Service_Amazon_Ec2_Instance;

--- a/tests/Zend/Service/Amazon/Ec2/InstanceWindowsTest.php
+++ b/tests/Zend/Service/Amazon/Ec2/InstanceWindowsTest.php
@@ -44,6 +44,11 @@ require_once 'Zend/Http/Client/Adapter/Test.php';
 class InstanceWindowsTest extends TestCase
 {
     /**
+     * @var \Zend_Http_Client_Adapter_Test|mixed
+     */
+    protected $adapter;
+
+    /**
      * @var Zend_Service_Amazon_Ec2_Instance_Windows
      */
     private $Zend_Service_Amazon_Ec2_Instance_Windows;

--- a/tests/Zend/Service/Amazon/Ec2/KeypairTest.php
+++ b/tests/Zend/Service/Amazon/Ec2/KeypairTest.php
@@ -42,6 +42,11 @@ require_once 'Zend/Service/Amazon/Ec2/Keypair.php';
 class Zend_Service_Amazon_Ec2_KeypairTest extends TestCase
 {
     /**
+     * @var \Zend_Http_Client_Adapter_Test|mixed
+     */
+    protected $adapter;
+
+    /**
      * @var Zend_Service_Amazon_Ec2_Keypair
      */
     private $Zend_Service_Amazon_Ec2_Keypair;

--- a/tests/Zend/Service/Amazon/Ec2/RegionTest.php
+++ b/tests/Zend/Service/Amazon/Ec2/RegionTest.php
@@ -42,6 +42,16 @@ require_once 'Zend/Service/Amazon/Ec2/Region.php';
 class Zend_Service_Amazon_Ec2_RegionTest extends TestCase
 {
     /**
+     * @var \Zend_Http_Client_Adapter_Test|mixed
+     */
+    protected $adapter;
+
+    /**
+     * @var null
+     */
+    protected $Zend_Service_Amazon_Ec2_Availabilityzones;
+
+    /**
      * @var Zend_Service_Amazon_Ec2_Availabilityzones
      */
     private $Zend_Service_Amazon_Ec2_Region;

--- a/tests/Zend/Service/Amazon/Ec2/SecuritygroupsTest.php
+++ b/tests/Zend/Service/Amazon/Ec2/SecuritygroupsTest.php
@@ -42,6 +42,11 @@ require_once 'Zend/Service/Amazon/Ec2/Securitygroups.php';
 class Zend_Service_Amazon_Ec2_SecuritygroupsTest extends TestCase
 {
     /**
+     * @var \Zend_Http_Client_Adapter_Test|mixed
+     */
+    protected $adapter;
+
+    /**
      * @var Zend_Service_Amazon_Ec2_Securitygroups
      */
     private $Zend_Service_Amazon_Ec2_Securitygroups;

--- a/tests/Zend/Service/Amazon/S3/OnlineTest.php
+++ b/tests/Zend/Service/Amazon/S3/OnlineTest.php
@@ -47,6 +47,21 @@ require_once 'Zend/Http/Client/Adapter/Socket.php';
 class Zend_Service_Amazon_S3_OnlineTest extends TestCase
 {
     /**
+     * @var string|mixed
+     */
+    protected $_nosuchbucket;
+
+    /**
+     * @var mixed
+     */
+    protected $_bucket;
+
+    /**
+     * @var string|mixed
+     */
+    protected $_bucketEu;
+
+    /**
      * Reference to Amazon service consumer object
      *
      * @var Zend_Service_Amazon_S3

--- a/tests/Zend/Service/Amazon/S3/StreamTest.php
+++ b/tests/Zend/Service/Amazon/S3/StreamTest.php
@@ -46,6 +46,36 @@ require_once 'Zend/Http/Client/Adapter/Socket.php';
 class Zend_Service_Amazon_S3_StreamTest extends TestCase
 {
     /**
+     * @var \Zend_Service_Amazon_S3|mixed
+     */
+    protected $_amazon;
+
+    /**
+     * @var string
+     */
+    protected $_nosuchbucket;
+
+    /**
+     * @var \Zend_Http_Client_Adapter_Socket|mixed
+     */
+    protected $_httpClientAdapterSocket;
+
+    /**
+     * @var mixed
+     */
+    protected $_bucket;
+
+    /**
+     * @var string|mixed
+     */
+    protected $_bucketName;
+
+    /**
+     * @var string|mixed
+     */
+    protected $_fileName;
+
+    /**
      * Sets up this test case
      *
      * @return void

--- a/tests/Zend/Service/Amazon/Sqs/OnlineTest.php
+++ b/tests/Zend/Service/Amazon/Sqs/OnlineTest.php
@@ -39,6 +39,11 @@ require_once 'Zend/Http/Client/Adapter/Socket.php';
 class Zend_Service_Amazon_Sqs_OnlineTest extends TestCase
 {
     /**
+     * @var mixed
+     */
+    protected $_queue_name;
+
+    /**
      * Reference to Amazon service consumer object
      *
      * @var Zend_Service_Amazon_Sqs

--- a/tests/Zend/Service/Rackspace/Servers/OnlineTest.php
+++ b/tests/Zend/Service/Rackspace/Servers/OnlineTest.php
@@ -36,6 +36,11 @@ require_once 'Zend/Http/Client/Adapter/Socket.php';
 class Zend_Service_Rackspace_Servers_OnlineTest extends TestCase
 {
     /**
+     * @var string
+     */
+    protected $filename;
+
+    /**
      * Reference to Rackspace Servers object
      *
      * @var Zend_Service_Rackspace_Servers

--- a/tests/Zend/Service/StrikeIron/BaseTest.php
+++ b/tests/Zend/Service/StrikeIron/BaseTest.php
@@ -39,6 +39,16 @@ require_once 'Zend/Service/StrikeIron/BaseTest.php';
  */
 class Zend_Service_StrikeIron_BaseTest extends TestCase
 {
+    /**
+     * @var \Zend_Service_StrikeIron_BaseTest_MockSoapClient|mixed
+     */
+    protected $soapClient;
+
+    /**
+     * @var \Zend_Service_StrikeIron_Base|mixed
+     */
+    protected $base;
+
     protected function setUp(): void
     {
         $this->soapClient = new Zend_Service_StrikeIron_BaseTest_MockSoapClient();

--- a/tests/Zend/Service/StrikeIron/NoSoapTest.php
+++ b/tests/Zend/Service/StrikeIron/NoSoapTest.php
@@ -41,6 +41,11 @@ require_once 'Zend/Service/StrikeIron/BaseTest.php';
  */
 class Zend_Service_StrikeIron_NoSoapTest extends TestCase
 {
+    /**
+     * @var \Zend_Service_StrikeIron_BaseTest_MockSoapClient|mixed
+     */
+    protected $soapClient;
+
     protected function setUp(): void
     {
         $this->soapClient = new Zend_Service_StrikeIron_BaseTest_MockSoapClient();

--- a/tests/Zend/Service/StrikeIron/SalesUseTaxBasicTest.php
+++ b/tests/Zend/Service/StrikeIron/SalesUseTaxBasicTest.php
@@ -45,6 +45,16 @@ require_once 'Zend/Service/StrikeIron/SalesUseTaxBasic.php';
  */
 class Zend_Service_StrikeIron_SalesUseTaxBasicTest extends TestCase
 {
+    /**
+     * @var \stdclass|mixed
+     */
+    protected $soapClient;
+
+    /**
+     * @var \Zend_Service_StrikeIron_SalesUseTaxBasic|mixed
+     */
+    protected $service;
+
     protected function setUp(): void
     {
         $this->soapClient = new stdclass();

--- a/tests/Zend/Service/StrikeIron/StrikeIronTest.php
+++ b/tests/Zend/Service/StrikeIron/StrikeIronTest.php
@@ -39,6 +39,21 @@ require_once 'Zend/Service/StrikeIron.php';
  */
 class Zend_Service_StrikeIron_StrikeIronTest extends TestCase
 {
+    /**
+     * @var \stdclass|mixed
+     */
+    protected $soapClient;
+
+    /**
+     * @var array<string, \stdclass>|mixed
+     */
+    protected $options;
+
+    /**
+     * @var \Zend_Service_StrikeIron|mixed
+     */
+    protected $strikeIron;
+
     protected function setUp(): void
     {
         // stub out SOAPClient instance
@@ -111,6 +126,7 @@ class Zend_Service_StrikeIron_StrikeIronTest extends TestCase
  */
 class Zend_Service_StrikeIron_StrikeIronTest_StubbedBase
 {
+    protected $options;
     public function __construct($options)
     {
         $this->options = $options;

--- a/tests/Zend/Service/StrikeIron/USAddressVerificationTest.php
+++ b/tests/Zend/Service/StrikeIron/USAddressVerificationTest.php
@@ -45,6 +45,16 @@ require_once 'Zend/Service/StrikeIron/USAddressVerification.php';
  */
 class Zend_Service_StrikeIron_USAddressVerificationTest extends TestCase
 {
+    /**
+     * @var \stdclass|mixed
+     */
+    protected $soapClient;
+
+    /**
+     * @var \Zend_Service_StrikeIron_USAddressVerification|mixed
+     */
+    protected $service;
+
     protected function setUp(): void
     {
         $this->soapClient = new stdclass();

--- a/tests/Zend/Service/StrikeIron/ZipCodeInfoTest.php
+++ b/tests/Zend/Service/StrikeIron/ZipCodeInfoTest.php
@@ -45,6 +45,16 @@ require_once 'Zend/Service/StrikeIron/ZipCodeInfo.php';
  */
 class Zend_Service_StrikeIron_ZipCodeInfoTest extends TestCase
 {
+    /**
+     * @var \stdclass|mixed
+     */
+    protected $soapClient;
+
+    /**
+     * @var \Zend_Service_StrikeIron_ZipCodeInfo|mixed
+     */
+    protected $service;
+
     protected function setUp(): void
     {
         $this->soapClient = new stdclass();

--- a/tests/Zend/Service/WindowsAzure/SessionHandlerTest.php
+++ b/tests/Zend/Service/WindowsAzure/SessionHandlerTest.php
@@ -40,6 +40,8 @@ require_once 'Zend/Service/WindowsAzure/Storage/Table.php';
  */
 class Zend_Service_WindowsAzure_SessionHandlerTest extends TestCase
 {
+    protected $status;
+
     protected static $uniqId = 0;
 
     public function __construct()

--- a/tests/Zend/Stdlib/AllTests.php
+++ b/tests/Zend/Stdlib/AllTests.php
@@ -40,7 +40,7 @@ require_once 'Zend/Stdlib/SplPriorityQueueTest.php';
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  * @group      Zend_Stdlib
  */
-class Zend_EventManager_AllTests
+class Zend_Stdlib_AllTests
 {
     public static function main()
     {

--- a/tests/Zend/Stdlib/CallbackHandlerTest.php
+++ b/tests/Zend/Stdlib/CallbackHandlerTest.php
@@ -44,6 +44,16 @@ require_once 'Zend/Stdlib/TestAsset/SignalHandlers/ObjectCallback.php';
  */
 class Zend_Stdlib_CallbackHandlerTest extends TestCase
 {
+    /**
+     * @var mixed|mixed[]
+     */
+    protected $args;
+
+    /**
+     * @var bool
+     */
+    protected $error;
+
     public static function main()
     {
         $suite = new TestSuite(__CLASS__);

--- a/tests/Zend/Stdlib/PriorityQueueTest.php
+++ b/tests/Zend/Stdlib/PriorityQueueTest.php
@@ -40,6 +40,11 @@ require_once 'Zend/Stdlib/PriorityQueue.php';
  */
 class Zend_Stdlib_PriorityQueueTest extends TestCase
 {
+    /**
+     * @var \Zend_Stdlib_PriorityQueue|mixed
+     */
+    protected $queue;
+
     public static function main()
     {
         $suite = new TestSuite(__CLASS__);

--- a/tests/Zend/Stdlib/SplPriorityQueueTest.php
+++ b/tests/Zend/Stdlib/SplPriorityQueueTest.php
@@ -41,6 +41,11 @@ require_once 'Zend/Stdlib/SplPriorityQueue.php';
  */
 class Zend_Stdlib_SplPriorityQueueTest extends TestCase
 {
+    /**
+     * @var \Zend_Stdlib_SplPriorityQueue|mixed
+     */
+    protected $queue;
+
     public static function main()
     {
         $suite = new TestSuite(__CLASS__);

--- a/tests/Zend/Test/PHPUnit/ControllerTestCaseTest.php
+++ b/tests/Zend/Test/PHPUnit/ControllerTestCaseTest.php
@@ -56,6 +56,11 @@ require_once 'Zend/Controller/Action.php';
 class Zend_Test_PHPUnit_ControllerTestCaseTest extends TestCase
 {
     /**
+     * @var \Zend_Test_PHPUnit_ControllerTestCaseTest_Concrete|mixed
+     */
+    protected $testCase;
+
+    /**
      * Runs the test methods of this class.
      *
      * @return void

--- a/tests/Zend/Test/PHPUnit/Db/TestCaseTest.php
+++ b/tests/Zend/Test/PHPUnit/Db/TestCaseTest.php
@@ -43,6 +43,8 @@ require_once "Zend/Test/DbAdapter.php";
  */
 class Zend_Test_PHPUnit_Db_TestCaseTest extends Zend_Test_PHPUnit_DatabaseTestCase
 {
+    protected $databaseTester;
+
     /**
      * Contains a Database Connection
      *

--- a/tests/Zend/Validate/EmailAddressTest.php
+++ b/tests/Zend/Validate/EmailAddressTest.php
@@ -45,6 +45,11 @@ require_once 'Zend/Validate/EmailAddress.php';
 class Zend_Validate_EmailAddressTest extends TestCase
 {
     /**
+     * @var bool
+     */
+    protected $multipleOptionsDetected;
+
+    /**
      * Default instance created for all test methods
      *
      * @var Zend_Validate_EmailAddress

--- a/tests/Zend/ValidateTest.php
+++ b/tests/Zend/ValidateTest.php
@@ -51,6 +51,11 @@ class Zend_ValidateTest extends TestCase
     /**
      * @var bool
      */
+    protected $error;
+
+    /**
+     * @var bool
+     */
     protected $_errorOccurred;
 
     /**

--- a/tests/Zend/View/Helper/AttributeJsEscapingTest.php
+++ b/tests/Zend/View/Helper/AttributeJsEscapingTest.php
@@ -48,6 +48,16 @@ require_once 'Zend/Registry.php';
 class Zend_View_Helper_AttributeJsEscapingTest extends TestCase
 {
     /**
+     * @var \Zend_View|mixed
+     */
+    protected $view;
+
+    /**
+     * @var \Zend_View_Helper_FormSubmit|mixed
+     */
+    protected $helper;
+
+    /**
      * Runs the test methods of this class.
      *
      * @return void

--- a/tests/Zend/XmlRpc/ClientTest.php
+++ b/tests/Zend/XmlRpc/ClientTest.php
@@ -48,6 +48,16 @@ require_once 'Zend/Http/Client.php';
 class Zend_XmlRpc_ClientTest extends TestCase
 {
     /**
+     * @var mixed|\PHPUnit\Framework\MockObject\MockObject&\Zend_XmlRpc_Client_ServerIntrospection
+     */
+    protected $mockedIntrospector;
+
+    /**
+     * @var mixed|\PHPUnit\Framework\MockObject\MockObject&\Zend_Http_Client
+     */
+    protected $mockedHttpClient;
+
+    /**
      * @var Zend_Http_Client_Adapter_Abstract
      */
     protected $httpAdapter;

--- a/tests/Zend/XmlRpc/Request/HttpTest.php
+++ b/tests/Zend/XmlRpc/Request/HttpTest.php
@@ -46,6 +46,21 @@ require_once 'Zend/XmlRpc/Request/Http.php';
 class Zend_XmlRpc_Request_HttpTest extends TestCase
 {
     /**
+     * @var string|mixed
+     */
+    protected $xml;
+
+    /**
+     * @var \Zend_XmlRpc_Request_Http|mixed
+     */
+    protected $request;
+
+    /**
+     * @var array<string, mixed>|mixed
+     */
+    protected $server;
+
+    /**
      * Runs the test methods of this class.
      *
      * @return void
@@ -189,6 +204,14 @@ EOT;
 
 class Zend_XmlRpc_Request_HttpTest_Extension extends Zend_XmlRpc_Request_Http
 {
+    /**
+     * @var string|null
+     */
+    protected $method;
+    /**
+     * @var mixed[]
+     */
+    protected $params;
     public function __construct($method = null, $params = null)
     {
         $this->method = $method;


### PR DESCRIPTION
Fix bug [PHP 8.2: Dynamic Properties are deprecated'](https://php.watch/versions/8.2/dynamic-properties-deprecated) for test suite tests/Zend/**

### Work Done

- Removed [#[AllowDynamicProperties]](https://php.watch/versions/8.2/dynamic-properties-deprecated#AllowDynamicProperties) attribute added by me in `tests/Zend/**` at PR  #275 
- Used `rector` to add real properties needed by test case class `tests/Zend/**` because i concerns #AllowDynamicProperties will removed in php >=  8.3
  ```bash
  $ ./bin/rector --no-diffs tests/
  ```
  This config help `complete dynamic properties to class` https://github.com/Shardj/zf1-future/blob/1f1cc46bda2f1b2451a80d7663bfd1d94bcab343/rector.php#L16-L17

### What next 

After this PR merged into master, i will do the same thing for library/Zend to eliminate issue `Creation of dynamic property xxx  is deprecated` in library/Zend 

### For Reviewer

Please keep my git commit signing by merge branch, please don't use rebase ^^
