### PR TITLE
Composer add dev tool Rector

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,8 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^9",
-        "php-parallel-lint/php-parallel-lint": "^1.3"
+        "php-parallel-lint/php-parallel-lint": "^1.3",
+        "rector/rector": "^0.14.8"
     },
     "archive": {
         "exclude": ["/demos", "/documentation", "/tests"]

--- a/rector.php
+++ b/rector.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\CodeQuality\Rector\Class_\CompleteDynamicPropertiesRector;
+use Rector\Config\RectorConfig;
+use Rector\Set\ValueObject\LevelSetList;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->paths([
+        __DIR__ . '/library',
+        __DIR__ . '/tests',
+    ]);
+
+    // register a single rule
+    // https://github.com/rectorphp/rector/blob/main/docs/rector_rules_overview.md#completedynamicpropertiesrector
+    $rectorConfig->rule(CompleteDynamicPropertiesRector::class);
+
+    // define sets of rules
+    // $rectorConfig->sets([
+    //     LevelSetList::UP_TO_PHP_82
+    // ]);
+};


### PR DESCRIPTION
### Purpose

Rector help migrate zf1-future  to higher PHP version more efficient, consistent, safely

Near future help fix some common bug like:
- Dynamic Properties are deprecated on PHP 8.2
- Deprecated Passing null to parameter error on PHP 8.1

### Work done

- Added Rector to composer.json dev section
- Setting rule `CompleteDynamicPropertiesRector` help fix issue 'PHP 8.2: Dynamic Properties are deprecated'

### What next

After this PR merged, i will use `./bin/rector tests` to fix 'PHP 8.2: Dynamic Properties are deprecated' tests source `tests/Zend`

Next, `./bin/rector library` to fix `PHP 8.2: Dynamic Properties are deprecated` core source `library/Zend`

### How to use

On the contributor's computer

```bash
composer install
./bin/rector tests
./bin/rector library
````

### For contributor

Future, when need migrate zf-future to higher PHP version or fix some common bug please add
- Add minimal [rector rule](https://github.com/rectorphp/rector/blob/main/docs/rector_rules_overview.md) into here [./rector.php](https://github.com/hungtrinh/zf1-future/blob/1bd767e5dda811db1e870bfb761941038a72dbf7/rector.php)
- Run `./bin/rector`
- Make sure unit test run success on php 7.4 -> 8.x
```bash
docker run -e CI:true -u "$(id -u):$(id -g)" -w "$(pwd)" -v "$(pwd):$(pwd)" php:8.2-rc-cli-alpine -d memory_limit=-1 ./bin/phpunit -v --bootstrap tests/TestHelper.php tests/Zend/AllTests.php

docker run -e CI:true  -u "$(id -u):$(id -g)" -w "$(pwd)" -v "$(pwd):$(pwd)" php:8.1-cli-alpine  -d memory_limit=-1 ./bin/phpunit -v --bootstrap tests/TestHelper.php tests/Zend/AllTests.php

docker run -e CI:true  -u "$(id -u):$(id -g)" -w "$(pwd)" -v "$(pwd):$(pwd)" php:8.0-cli-alpine -d memory_limit=-1 ./bin/phpunit -v --bootstrap tests/TestHelper.php tests/Zend/AllTests.php

docker run  -e CI:true -u "$(id -u):$(id -g)" -w "$(pwd)" -v "$(pwd):$(pwd)" php:7.4-cli-alpine -d memory_limit=-1 ./bin/phpunit -v --bootstrap tests/TestHelper.php tests/Zend/AllTests.php

```

### Reference:

- https://github.com/rectorphp/rector
- https://github.com/rectorphp/rector/blob/main/docs/rector_rules_overview.md#completedynamicpropertiesrector