### PR TITLE
Compatibility with PHPUnit 9

### DIFF
--- a/library/Zend/Test/PHPUnit/ControllerTestCase.php
+++ b/library/Zend/Test/PHPUnit/ControllerTestCase.php
@@ -120,7 +120,7 @@ abstract class Zend_Test_PHPUnit_ControllerTestCase extends PHPUnit_Framework_Te
      *
      * Calls {@link bootstrap()} by default
      */
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->bootstrap();
     }
@@ -134,7 +134,7 @@ abstract class Zend_Test_PHPUnit_ControllerTestCase extends PHPUnit_Framework_Te
      * it. When done, sets the test case request and response objects into the
      * front controller.
      */
-    final public function bootstrap()
+    final public function bootstrap(): void
     {
         $this->reset();
         if (null !== $this->bootstrap) {


### PR DESCRIPTION
I found out #44 , and followed the advice of adding shims for the missing classes, including also adding

```php
use PHPUnit\Runner\Version;

final class PHPUnit_Runner_Version {
    public static function id(): string
    {
        return Version::id();
    }

    public static function series(): string
    {
        return Version::series();
    }

    public static function getVersionString(): string
    {
        return Version::getVersionString();
    }
}
```

For the sake of PHPUnit\Runner\Version that is otherwise final, so can't simply be extended, and PHPUnit_Framework_ExpectationFailedException is only referenced in doc comments, so it's not required for the tests to actually run.

Even after all that, I got
```
Fatal error: Declaration of Zend_Test_PHPUnit_ControllerTestCase::setUp() must be compatible with PHPUnit\Framework\TestCase::setUp(): void in C:\...\vendor\shardj\zf1-future\library\Zend\Test\PHPUnit\ControllerTestCase.php on line 123
```

After explicitly adding `: void` to the return type, it works, so this is a PR to fix this. bootstrap()... I thought I might as well... It's a final method already, so it won't cause issues.