### PR TITLE
Apply Magento security patch SUPEE-9652/10570

### DIFF
--- a/library/Zend/Mail/Transport/Sendmail.php
+++ b/library/Zend/Mail/Transport/Sendmail.php
@@ -119,14 +119,20 @@ class Zend_Mail_Transport_Sendmail extends Zend_Mail_Transport_Abstract
                 );
             }
 
-            set_error_handler([$this, '_handleMailErrors']);
-            $result = mail(
-                $this->recipients,
-                $this->_mail->getSubject(),
-                $this->body,
-                $this->header,
-                $this->parameters);
-            restore_error_handler();
+            $fromEmailHeader = str_replace(' ', '', $this->parameters);
+            // Sanitize the From header
+            if (!Zend_Validate::is($fromEmailHeader, 'EmailAddress')) {
+                throw new Zend_Mail_Transport_Exception('Potential code injection in From header');
+            } else {
+                set_error_handler([$this, '_handleMailErrors']);
+                $result = mail(
+                    $this->recipients,
+                    $this->_mail->getSubject(),
+                    $this->body,
+                    $this->header,
+                    $fromEmailHeader);
+                restore_error_handler();
+            }
         }
 
         if ($this->_errstr !== null || !$result) {


### PR DESCRIPTION
[OpenMage](https://github.com/OpenMage/magento-lts) will move to zf1-future and i'm currently looking for changes to lib/Zend made by Magento or community.

Found this security related change ...

- 9652: https://magento.stackexchange.com/a/158714/46249
- 10570: https://magento.stackexchange.com/a/215331/46249