### PR TITLE
Fixed: TypeError: round(): Argument #1 ($num) must be of type int|float

### DIFF
--- a/library/Zend/Db/Profiler/Firebug.php
+++ b/library/Zend/Db/Profiler/Firebug.php
@@ -133,7 +133,7 @@ class Zend_Db_Profiler_Firebug extends Zend_Db_Profiler
 
         $this->_totalElapsedTime += $profile->getElapsedSecs();
 
-        $this->_message->addRow([(string)round($profile->getElapsedSecs(),5),
+        $this->_message->addRow([(string)round((float)$profile->getElapsedSecs(),5),
                                       $profile->getQuery(),
                                       ($params=$profile->getQueryParams())?$params:null]);
 

--- a/library/Zend/Locale/Math.php
+++ b/library/Zend/Locale/Math.php
@@ -65,9 +65,9 @@ class Zend_Locale_Math
     public static function round($op1, $precision = 0)
     {
         if (self::$_bcmathDisabled) {
-            $op1 = round($op1, $precision);
+            $op1 = round((float)$op1, $precision);
             if (strpos((string) $op1, 'E') === false) {
-                return self::normalize(round($op1, $precision));
+                return self::normalize(round((float)$op1, $precision));
             }
         }
 


### PR DESCRIPTION
Original PR ... OpenMage/magento-lts#1403

I did not change Zend/Locale/Format.php, it should be fixed in `Zend_Locale_Math::round()`.