### PR TITLE
Adding Mysqli support for connection flags

### DIFF
--- a/library/Zend/Db/Adapter/Mysqli.php
+++ b/library/Zend/Db/Adapter/Mysqli.php
@@ -308,6 +308,9 @@ class Zend_Db_Adapter_Mysqli extends Zend_Db_Adapter_Abstract
         if(!empty($this->_config['driver_options'])) {
             foreach($this->_config['driver_options'] as $option=>$value) {
                 if(is_string($option)) {
+                    if ($option === 'flags') {
+                        continue;
+                    }
                     // Suppress warnings here
                     // Ignore it if it's not a valid constant
                     $option = @constant(strtoupper($option));
@@ -327,7 +330,10 @@ class Zend_Db_Adapter_Mysqli extends Zend_Db_Adapter_Abstract
             $this->_config['password'],
             $this->_config['dbname'],
             $port,
-            $socket
+            $socket,
+            isset($this->_config['driver_options'], $this->_config['driver_options']['flags'])
+                ? (int)$this->_config['driver_options']['flags']
+                : 0
         );
 
         if ($_isConnected === false || mysqli_connect_errno()) {


### PR DESCRIPTION
mysqli connection flags will allow, among other things, enable compression. It's something that is possible with Pdo_Mysql, but not with the Mysqli driver - at least not without the changes in this PR.

Here is an example usage:
```
$db = Zend_Db::factory(
    'Mysqli',
    [
        'host' => '...',
        'username' => '...',
        'password' => '...',
        'dbname' => '...',
        'port' => '...',
        'driver_options' => [
            'flags' => MYSQLI_CLIENT_COMPRESS,
        ]
    ]
);

$result = $db->query(
    "SHOW STATUS WHERE Variable_name IN ('Bytes_sent', 'Bytes_received', 'Compression')"
)->fetchAll();

print_r($result);
```
Which should output:
```
Array
(
    [0] => Array
        (
            [Variable_name] => Bytes_received
            [Value] => 264
        )

    [1] => Array
        (
            [Variable_name] => Bytes_sent
            [Value] => 194
        )

    [2] => Array
        (
            [Variable_name] => Compression
            [Value] => ON
        )

)
```