### PR TITLE
further php8.1 fix following fdae0c2

### DIFF
--- a/library/Zend/Db/Statement.php
+++ b/library/Zend/Db/Statement.php
@@ -191,7 +191,7 @@ abstract class Zend_Db_Statement implements Zend_Db_Statement_Interface
         if (!empty($q)) {
             $escapeChar = preg_quote($escapeChar);
             // this segfaults only after 65,000 characters instead of 9,000
-            $sql = preg_replace("/$q([^$q{$escapeChar}]*|($qe)*)*$q/s", '', $sql);
+            $sql = preg_replace("/$q([^$q{$escapeChar}]*|($qe)*)*$q/s", '', (string) $sql);
         }
 
         // get a version of the SQL statement with all quoted


### PR DESCRIPTION
The previous fix missed an earlier conditional use of the $sql variable and thus it should be cast to string too in case it is triggered.