### PR TITLE
[zend-progressbar] fix "stty: 'standard input': Inappropriate ioctl for device" spam

### DIFF
--- a/library/Zend/ProgressBar/Adapter/Console.php
+++ b/library/Zend/ProgressBar/Adapter/Console.php
@@ -239,9 +239,9 @@ class Zend_ProgressBar_Adapter_Console extends Zend_ProgressBar_Adapter
                 $this->_width = 80;
 
                 // Try to determine the width through stty
-                if (preg_match('#\d+ (\d+)#', (string) @shell_exec('stty size'), $match) === 1) {
+                if (preg_match('#\d+ (\d+)#', (string) @shell_exec('stty size 2>/dev/null'), $match) === 1) {
                     $this->_width = (int) $match[1];
-                } else if (preg_match('#columns = (\d+);#', (string) @shell_exec('stty'), $match) === 1) {
+                } else if (preg_match('#columns = (\d+);#', (string) @shell_exec('stty 2>/dev/null'), $match) === 1) {
                     $this->_width = (int) $match[1];
                 }
             }


### PR DESCRIPTION
Carries zf1s/zf1#155 which was created by @falkenhawk 

![fix Inappropriate ioctl for device spam](https://user-images.githubusercontent.com/14310995/205593020-48bb50d3-8240-4fc5-8ae9-40e273fd875d.png)