### PR TITLE
getTranslator() docblocks for the Zend_Form family

### DIFF
--- a/library/Zend/File/Transfer/Adapter/Abstract.php
+++ b/library/Zend/File/Transfer/Adapter/Abstract.php
@@ -65,7 +65,7 @@ abstract class Zend_File_Transfer_Adapter_Abstract
     protected $_messages = [];
 
     /**
-     * @var Zend_Translate
+     * @var Zend_Translate_Adapter
      */
     protected $_translator;
 
@@ -1106,7 +1106,7 @@ abstract class Zend_File_Transfer_Adapter_Abstract
     /**
      * Set translator object for localization
      *
-     * @param  Zend_Translate|null $translator
+     * @param  Zend_Translate|Zend_Translate_Adapter|null $translator
      * @return Zend_File_Transfer_Adapter_Abstract
      * @throws Zend_File_Transfer_Exception
      */
@@ -1129,7 +1129,7 @@ abstract class Zend_File_Transfer_Adapter_Abstract
     /**
      * Retrieve localization translator object
      *
-     * @return Zend_Translate|null
+     * @return Zend_Translate_Adapter|null
      */
     public function getTranslator()
     {

--- a/library/Zend/Form.php
+++ b/library/Zend/Form.php
@@ -194,13 +194,13 @@ class Zend_Form implements Iterator, Countable, Zend_Validate_Interface
     protected $_subForms = [];
 
     /**
-     * @var Zend_Translate
+     * @var Zend_Translate_Adapter
      */
     protected $_translator;
 
     /**
      * Global default translation adapter
-     * @var Zend_Translate
+     * @var Zend_Translate_Adapter
      */
     protected static $_translatorDefault;
 
@@ -3068,7 +3068,7 @@ class Zend_Form implements Iterator, Countable, Zend_Validate_Interface
     /**
      * Retrieve translator object
      *
-     * @return Zend_Translate|null
+     * @return Zend_Translate_Adapter|null
      */
     public function getTranslator()
     {
@@ -3096,7 +3096,7 @@ class Zend_Form implements Iterator, Countable, Zend_Validate_Interface
     /**
      * Get global default translator object
      *
-     * @return null|Zend_Translate
+     * @return null|Zend_Translate_Adapter
      */
     public static function getDefaultTranslator()
     {

--- a/library/Zend/Form/DisplayGroup.php
+++ b/library/Zend/Form/DisplayGroup.php
@@ -103,7 +103,7 @@ class Zend_Form_DisplayGroup implements Iterator,Countable
     protected $_order;
 
     /**
-     * @var Zend_Translate
+     * @var Zend_Translate_Adapter
      */
     protected $_translator;
 
@@ -965,7 +965,7 @@ class Zend_Form_DisplayGroup implements Iterator,Countable
     /**
      * Retrieve translator object
      *
-     * @return Zend_Translate|null
+     * @return Zend_Translate_Adapter|null
      */
     public function getTranslator()
     {

--- a/library/Zend/Form/Element.php
+++ b/library/Zend/Form/Element.php
@@ -177,7 +177,7 @@ class Zend_Form_Element implements Zend_Validate_Interface
     protected $_required = false;
 
     /**
-     * @var Zend_Translate
+     * @var Zend_Translate_Adapter
      */
     protected $_translator;
 
@@ -412,7 +412,7 @@ class Zend_Form_Element implements Zend_Validate_Interface
     /**
      * Set translator object for localization
      *
-     * @param  Zend_Translate|null $translator
+     * @param  Zend_Translate|Zend_Translate_Adapter|null $translator
      * @return Zend_Form_Element
      */
     public function setTranslator($translator = null)
@@ -433,7 +433,7 @@ class Zend_Form_Element implements Zend_Validate_Interface
     /**
      * Retrieve localization translator object
      *
-     * @return Zend_Translate|null
+     * @return Zend_Translate_Adapter|null
      */
     public function getTranslator()
     {

--- a/library/Zend/Form/Element/File.php
+++ b/library/Zend/Form/Element/File.php
@@ -746,7 +746,7 @@ class Zend_Form_Element_File extends Zend_Form_Element_Xhtml
     /**
      * Retrieve localization translator object
      *
-     * @return Zend_Translate|null
+     * @return Zend_Translate_Adapter|null
      */
     public function getTranslator()
     {


### PR DESCRIPTION
Fixed doc blocks in form related classes - getTranslator()/getDefaultTranslator() returns the translate adapter, not the translate class.

Actual behavior is not modified. This is just updating the docs to match the implementation, and will potentially help uncover bugs by static analysis tools in applications that thought they're dealing with the translator instead of dealing with the adapter.

In the actual application I work on, we have a custom translate adapter, which we sometimes need to get out of the translator due to the extra functionality, and had been bitten a few times already by the fact we don't need to call getAdapter() to get it.