### PR TITLE
Fixed the version test since the latest release.

### DIFF
--- a/tests/Zend/VersionTest.php
+++ b/tests/Zend/VersionTest.php
@@ -59,8 +59,8 @@ class Zend_VersionTest extends TestCase
         $expect = -1;
         // unit test breaks if ZF version > 1.x
         for ($i = 0; $i <= 1; $i++) {
-            for ($j = 0; $j <= 21; $j++) {
-                for ($k = 0; $k < 20; $k++) {
+            for ($j = 0; $j <= 22; $j++) {
+                for ($k = 0; $k <= 99; $k++) {
                     foreach (['dev', 'pr', 'PR', 'alpha', 'a1', 'a2', 'beta', 'b1', 'b2', 'RC', 'RC1', 'RC2', 'RC3', '', 'pl1', 'PL1'] as $rel) {
                         $ver = "$i.$j.$k$rel";
                         $normalizedVersion = strtolower(Zend_Version::VERSION);


### PR DESCRIPTION
Future releases should update the digits in the loops to match the largest number that this part of the version vector has ever reached. For the middle part, this is now 22, but the last part is now preemptively increased to 99.

NOTE: Remaining CI issues are both due to PHP extensions.

The PHP 8.1+ failures are discussed in #305

The PHP 8.2+ deprecation notice appears to be related to the memcache extension, which only recently fixed this notice, and I guess haven't made a release since fixing it. See https://github.com/websupport-sk/pecl-memcache/commit/26c0f5130050649762c550e0dac07d4f371e68d5