### PR TITLE
SUPEE-10752 from Magento 1.9.3.9

### DIFF
--- a/library/Zend/Validate/EmailAddress.php
+++ b/library/Zend/Validate/EmailAddress.php
@@ -429,7 +429,9 @@ class Zend_Validate_EmailAddress extends Zend_Validate_Abstract
             // Quoted-string characters are: DQUOTE *(qtext/quoted-pair) DQUOTE
             $qtext      = '\x20-\x21\x23-\x5b\x5d-\x7e'; // %d32-33 / %d35-91 / %d93-126
             $quotedPair = '\x20-\x7e'; // %d92 %d32-126
-            if (preg_match('/^"(['. $qtext .']|\x5c[' . $quotedPair . '])*"$/', $this->localPart)) {
+            if ((0 === (strcmp($this->localPart, strip_tags($this->localPart))))
+                && (0 === (strcmp($this->localPart, htmlspecialchars_decode($this->localPart))))
+                && (preg_match('/^"(['. $qtext .']|\x5c[' . $quotedPair . '])*"$/', $this->localPart))) {
                 $result = true;
             } else {
                 $this->_error(self::DOT_ATOM);


### PR DESCRIPTION
Hi everybody, at https://github.com/OpenMage/magento-lts we're finishing the migration from an old patched version of ZF1 to ZF1Future via composer. @sreichel created a list of patches that the were applied to ZF1 over the years and we're now trying to merge them into ZF1Future itself (the ones that make sense to merge obviously).

This PR is the attempt to merge security patch SUPEE-10752 from Magento 1.9.3.9.
It is very hard nowadays to find the details of the old patches, what I've found so far:
- [a copy of the original patch file](https://github.com/brentwpeterson/magento-patches/blob/master/CE1.9/PATCH_SUPEE-10752_CE_v1.9.1.1_v1-2018-06-11-04-32-08.sh)
- [a blog post with some details](https://www.orangemantra.com/blog/magento-1-supee-10752-security-patch-release-need-know/)

I don't have knowledge to understand what this patch is really doing, apart from understanding that it's about the escaping of the local part of the host validation.

Hope this is useful anyways.
Thank you!