### PR TITLE
Pdo sqlite keep bc since php81

### DIFF
--- a/library/Zend/Db/Adapter/Pdo/Sqlite.php
+++ b/library/Zend/Db/Adapter/Pdo/Sqlite.php
@@ -91,6 +91,14 @@ class Zend_Db_Adapter_Pdo_Sqlite extends Zend_Db_Adapter_Pdo_Abstract
         $this->_config['username'] = null;
         $this->_config['password'] = null;
 
+        if (PHP_VERSION_ID >= 80100) {
+            // ensure $config['driver_options'] is an array
+            $config['driver_options'] = empty($config['driver_options']) ? array() : $config['driver_options'];
+            if (!isset($config['driver_options'][PDO::ATTR_STRINGIFY_FETCHES])) {
+                $config['driver_options'][PDO::ATTR_STRINGIFY_FETCHES] = true;
+            }
+        }
+
         return parent::__construct($config);
     }
 

--- a/library/Zend/Db/Adapter/Pdo/Sqlite.php
+++ b/library/Zend/Db/Adapter/Pdo/Sqlite.php
@@ -93,7 +93,7 @@ class Zend_Db_Adapter_Pdo_Sqlite extends Zend_Db_Adapter_Pdo_Abstract
 
         if (PHP_VERSION_ID >= 80100) {
             // ensure $config['driver_options'] is an array
-            $config['driver_options'] = empty($config['driver_options']) ? array() : $config['driver_options'];
+            $config['driver_options'] = $config['driver_options'] ?? [];
             if (!isset($config['driver_options'][PDO::ATTR_STRINGIFY_FETCHES])) {
                 $config['driver_options'][PDO::ATTR_STRINGIFY_FETCHES] = true;
             }

--- a/tests/Zend/Db/Adapter/Pdo/SqliteTest.php
+++ b/tests/Zend/Db/Adapter/Pdo/SqliteTest.php
@@ -261,4 +261,26 @@ class Zend_Db_Adapter_Pdo_SqliteTest extends Zend_Db_Adapter_Pdo_TestCommon
         $value = $this->_db->quote($string);
         $this->assertEquals("'1\\000'", $value);
     }
+
+    /**
+     * https://www.php.net/manual/en/migration81.incompatible.php#migration81.incompatible.pdo.sqlite
+     * @inheritDoc
+     */
+    public function testAdapterZendConfigEmptyDriverOptions()
+    {
+        $params = $this->_util->getParams();
+        $params['driver_options'] = '';
+        $params = new Zend_Config($params);
+
+        $db = Zend_Db::factory($this->getDriver(), $params);
+        $db->getConnection();
+
+        $config = $db->getConfig();
+
+        if (PHP_VERSION_ID >= 80100) {
+            $this->assertEquals(array(PDO::ATTR_STRINGIFY_FETCHES => true), $config['driver_options']);
+        } else {
+            $this->assertEquals(array(), $config['driver_options']);
+        }
+    }
 }

--- a/tests/Zend/Db/Adapter/Pdo/SqliteTest.php
+++ b/tests/Zend/Db/Adapter/Pdo/SqliteTest.php
@@ -269,7 +269,7 @@ class Zend_Db_Adapter_Pdo_SqliteTest extends Zend_Db_Adapter_Pdo_TestCommon
     public function testAdapterZendConfigEmptyDriverOptions()
     {
         $params = $this->_util->getParams();
-        $params['driver_options'] = '';
+        $params['driver_options'] = [];
         $params = new Zend_Config($params);
 
         $db = Zend_Db::factory($this->getDriver(), $params);
@@ -278,9 +278,9 @@ class Zend_Db_Adapter_Pdo_SqliteTest extends Zend_Db_Adapter_Pdo_TestCommon
         $config = $db->getConfig();
 
         if (PHP_VERSION_ID >= 80100) {
-            $this->assertEquals(array(PDO::ATTR_STRINGIFY_FETCHES => true), $config['driver_options']);
+            $this->assertEquals([PDO::ATTR_STRINGIFY_FETCHES => true], $config['driver_options']);
         } else {
-            $this->assertEquals(array(), $config['driver_options']);
+            $this->assertEquals([], $config['driver_options']);
         }
     }
 }


### PR DESCRIPTION
- Carries https://github.com/zf1s/zf1/pull/157 which was created by @partikus (keep BC for sqlite adapter when php >=8.1)
- Github action, sticky with phpunit 9 (now phpunit 10 is latest version on github action, zf1-future support phpunit 9 only)
