### PR TITLE
Fix: pin phpunit to 9 instead of latest (10) in github actions

### DIFF
--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -100,7 +100,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php-version }}
-          tools: phpunit
+          tools: phpunit:9
           extensions: memcached, memcache
           ini-values: ${{ env.PHP_INI_VALUES }}
 


### PR DESCRIPTION
Github action, sticky with phpunit 9 (now phpunit 10 is latest version on github action, zf1-future support phpunit 9 only)