### PR TITLE
Keep pdo mysql adapter fetch digit field type BC with php <= 8.0 

### DIFF
--- a/library/Zend/Db/Adapter/Pdo/Mysql.php
+++ b/library/Zend/Db/Adapter/Pdo/Mysql.php
@@ -110,6 +110,14 @@ class Zend_Db_Adapter_Pdo_Mysql extends Zend_Db_Adapter_Pdo_Abstract
             $this->_config['driver_options'][1002] = $initCommand; // 1002 = PDO::MYSQL_ATTR_INIT_COMMAND
         }
 
+        if (PHP_VERSION_ID >= 80100) {
+            // ensure $config['driver_options'] is an array
+            $this->_config['driver_options'] = $this->_config['driver_options'] ?? [];
+            if (!isset($this->_config['driver_options'][PDO::ATTR_STRINGIFY_FETCHES])) {
+                $this->_config['driver_options'][PDO::ATTR_STRINGIFY_FETCHES] = true;
+            }
+        }
+
         parent::_connect();
     }
 

--- a/tests/Zend/Db/Adapter/Pdo/MysqlTest.php
+++ b/tests/Zend/Db/Adapter/Pdo/MysqlTest.php
@@ -350,6 +350,28 @@ class Zend_Db_Adapter_Pdo_MysqlTest extends Zend_Db_Adapter_Pdo_TestCommon
             "BC with php < 8.1, fetch numeric field type will return 'digit' string instead of int or float type in php >= 8.1.\nSee: https://www.php.net/manual/en/migration81.incompatible.php#migration81.incompatible.pdo.mysql"
         );
     }
+
+    /**
+     * https://www.php.net/manual/en/migration81.incompatible.php#migration81.incompatible.pdo.mysql
+     * @inheritDoc
+     */
+    public function testAdapterZendConfigEmptyDriverOptions()
+    {
+        $params = $this->_util->getParams();
+        $params['driver_options'] = [];
+        $params = new Zend_Config($params);
+
+        $db = Zend_Db::factory($this->getDriver(), $params);
+        $db->getConnection();
+
+        $config = $db->getConfig();
+
+        if (PHP_VERSION_ID >= 80100) {
+            $this->assertEquals([PDO::ATTR_STRINGIFY_FETCHES => true], $config['driver_options']);
+        } else {
+            $this->assertSame([], $config['driver_options']);
+        }
+    }
 }
 
 class ZendTest_Db_Adapter_Pdo_Mysql extends Zend_Db_Adapter_Pdo_Mysql

--- a/tests/Zend/Db/Adapter/Pdo/MysqlTest.php
+++ b/tests/Zend/Db/Adapter/Pdo/MysqlTest.php
@@ -331,6 +331,25 @@ class Zend_Db_Adapter_Pdo_MysqlTest extends Zend_Db_Adapter_Pdo_TestCommon
     {
         return 'Pdo_Mysql';
     }
+
+    public function testGivenBeforePhp81WhenFetchDataOnDigitFieldThenPdoMysqlWillReturnStringDigit()
+    {
+        $params = $this->_util->getParams();
+        $db = Zend_Db::factory($this->getDriver(), $params);
+        $db->getConnection();
+
+        $select = $this->_db->select();
+        $select->from('zfproducts');
+        $stmt = $this->_db->query($select);
+        $products = $stmt->fetchAll();
+
+        $productId = $products[0]['product_id'] ?? '-1';
+        $this->assertSame(
+            '1',
+            $productId,
+            "BC with php < 8.1, fetch numeric field type will return 'digit' string instead of int or float type in php >= 8.1.\nSee: https://www.php.net/manual/en/migration81.incompatible.php#migration81.incompatible.pdo.mysql"
+        );
+    }
 }
 
 class ZendTest_Db_Adapter_Pdo_Mysql extends Zend_Db_Adapter_Pdo_Mysql


### PR DESCRIPTION
Close #323

### Task done

- Specification PDO fetch mysql int type will return php 'int' string instead of php int type (test case)
   https://github.com/Shardj/zf1-future/blob/048b066903190d22c1bef8c3b62b12943f8ca3b9/tests/Zend/Db/Adapter/Pdo/MysqlTest.php#L335-L352
   Fail since php 8.1 https://github.com/hungtrinh/zf1-future/actions/runs/4171264561/jobs/7221025095#step:7:436
- Specification PDO mysql adapter will init connection with driver_options `PDO::ATTR_STRINGIFY_FETCHES` is on (test case)
   https://github.com/Shardj/zf1-future/blob/7c3911ca2933c8b57ea0a54d04eca4bfe1d73320/tests/Zend/Db/Adapter/Pdo/MysqlTest.php#L354-L374
  Fail since php 8.1 https://github.com/hungtrinh/zf1-future/actions/runs/4171266288/jobs/7221028465#step:7:445
- Production code fulfil 2 specifications above
   https://github.com/Shardj/zf1-future/blob/7c3911ca2933c8b57ea0a54d04eca4bfe1d73320/library/Zend/Db/Adapter/Pdo/Mysql.php#L113-L119
   2 Spec done https://github.com/hungtrinh/zf1-future/actions/runs/4171334806/jobs/7221167701#step:7:248
