### PR TITLE
PDO: Fix partial error return when using a encrypted connection

### DIFF
--- a/library/Zend/Db/Adapter/Pdo/Abstract.php
+++ b/library/Zend/Db/Adapter/Pdo/Abstract.php
@@ -147,7 +147,17 @@ abstract class Zend_Db_Adapter_Pdo_Abstract extends Zend_Db_Adapter_Abstract
              * @see Zend_Db_Adapter_Exception
              */
             require_once 'Zend/Db/Adapter/Exception.php';
-            throw new Zend_Db_Adapter_Exception($e->getMessage(), $e->getCode(), $e);
+
+            $message = $e->getMessage();
+            if ($e->getPrevious() !== null && preg_match('~^SQLSTATE\[HY000\] \[\d{1,4}\]\s$~', $message)) {
+                // See https://bugs.php.net/bug.php?id=76604
+                $message .= $e->getPrevious()->getMessage();
+            }
+
+            /**
+             * @see Zend_Db_Adapter_Exception
+             */
+            throw new Zend_Db_Adapter_Exception($message, $e->getCode(), $e);
         }
 
     }


### PR DESCRIPTION
This fixes a problem with the original Zend1 repository we fixed [in our fork](https://github.com/Icinga/icingaweb2-vendor-zf1/blob/master/library/Zend/Db/Adapter/Pdo/Abstract.php#L136) a while ago. This only affects SSL MySQL connections, regular MySQL works fine.

## How to reproduce (taken from the [PHP bug report](https://bugs.php.net/bug.php?id=76604)):
```php
try {
        $pdo = new PDO(
                'mysql:host=localhost.localdomain;dbname=foo',
                'foo',
                'bar',
                array(
                        PDO::MYSQL_ATTR_SSL_KEY    => '/home/vagrant/newcerts/server-key.pem',
                        PDO::MYSQL_ATTR_SSL_CERT   => '/home/vagrant/newcerts/server-cert.pem',
                        PDO::MYSQL_ATTR_SSL_CA     => '/home/vagrant/newcerts/ca.pem',
                        PDO::MYSQL_ATTR_SSL_CIPHER => 'DHE-RSA-AES256-GCM-SHA384'
                )
        );
} catch (PDOException $e) {
        echo '# Actual:' . PHP_EOL;
        echo $e->getMessage() . PHP_EOL;
        echo '# Expected:' . PHP_EOL;
        echo $e->getMessage() . $e->getPrevious()->getMessage() . PHP_EOL;
}
```

## Expected output
`SQLSTATE[HY000] [2002] PDO::__construct(): SSL operation failed with code 1. OpenSSL Error messages:
error:140830B5:SSL routines:ssl3_client_hello:no ciphers available`

## Actual output
`SQLSTATE[HY000] [2002] `