### PR TITLE
Partial helper pull vars from view model

### DIFF
--- a/library/Zend/View/Helper/Partial.php
+++ b/library/Zend/View/Helper/Partial.php
@@ -110,6 +110,8 @@ class Zend_View_Helper_Partial extends Zend_View_Helper_Abstract
                     $view->assign($objectKey, $model);
                 } elseif (method_exists($model, 'toArray')) {
                     $view->assign($model->toArray());
+                } elseif (method_exists($model, 'getVars')) {
+                    $view->assign($model->getVars());
                 } else {
                     $view->assign(get_object_vars($model));
                 }

--- a/tests/Zend/View/Helper/PartialTest.php
+++ b/tests/Zend/View/Helper/PartialTest.php
@@ -281,6 +281,19 @@ class Zend_View_Helper_PartialTest extends TestCase
         $test = $this->helper->setObjectKey('foo');
         $this->assertSame($this->helper, $test);
     }
+
+    public function testWhenSecondParamsIsViewModelThenPartialUseGetVarsToSetsViewVariables()
+    {
+        $view = new Zend_View([
+            'scriptPath' => $this->basePath . '/default/views/scripts'
+        ]);
+        $this->helper->setView($view);
+        $view->foo = 'partial script can access first';
+        $view->bar = 'partial script can access second';
+        $return = $this->helper->partial('partialVars.phtml', $view);
+        $this->assertStringContainsString(sprintf('%s: %s', 'foo', 'partial script can access first'), $return);
+        $this->assertStringContainsString(sprintf('%s: %s', 'bar', 'partial script can access second'), $return);
+    }
 }
 
 class Zend_View_Helper_PartialTest_Aggregate


### PR DESCRIPTION
Close #328

Explained root cause here https://github.com/Shardj/zf1-future/issues/328#issuecomment-1442987008.

### Solution

check if second param of partial helper has method `getVars` then use this method to pull model data for partial script 
