### PR TITLE
Basic Sendgrid Transport Class

### DIFF
--- a/library/Zend/Mail/Transport/SendgridSmtp.php
+++ b/library/Zend/Mail/Transport/SendgridSmtp.php
@@ -1,6 +1,6 @@
 <?php
 
-class WN_Mail_Transport_SendgridSmtp extends WN_Mail_Transport_Smtp
+class Zend_Mail_Transport_SendgridSmtp extends Zend_Mail_Transport_Smtp
 {
     /**
      * ClickTracking status
@@ -18,13 +18,13 @@ class WN_Mail_Transport_SendgridSmtp extends WN_Mail_Transport_Smtp
 
     public function __construct($options)
     {
-         if (!isset($options['host'])) {
-             throw new Zend_Application_Resource_Exception(
-                 'A host is necessary for smtp transport,'
-                 . ' but none was given'
-             );
-         }
-         $this->setClickTracking($options['clicktrack'] ?? false);
+        if (!isset($options['host'])) {
+            throw new Zend_Application_Resource_Exception(
+                'A host is necessary for smtp transport,'
+                . ' but none was given'
+            );
+        }
+        $this->setClickTracking($options['clicktrack'] ?? false);
 
         $options['port'] = $options['port'] ?? 465;
         $options['username'] = $options['apikey'] ?? $options['username'];
@@ -37,7 +37,7 @@ class WN_Mail_Transport_SendgridSmtp extends WN_Mail_Transport_Smtp
      *
      * @param bool $status
      * @return void
-     * 
+     */ 
     public function setClickTracking($bool)
     {
         $this->clickTracking = $bool;
@@ -60,7 +60,7 @@ class WN_Mail_Transport_SendgridSmtp extends WN_Mail_Transport_Smtp
      * Get ClickTracking status
      *
      * @return bool
-     * 
+     */ 
     public function getClickTracking()
     {
         return $this->clickTracking;
@@ -71,7 +71,7 @@ class WN_Mail_Transport_SendgridSmtp extends WN_Mail_Transport_Smtp
      *
      * @param   string $key
      * @param   mixed $value
-     * 
+     */ 
     public function setOption($key, $value)
     {
         $this->apiOptions[$key] = $value;
@@ -81,7 +81,7 @@ class WN_Mail_Transport_SendgridSmtp extends WN_Mail_Transport_Smtp
      * Get API options
      *
      * @return array
-     * 
+     */ 
     public function getOptions()
     {
         return $this->apiOptions;
@@ -92,7 +92,7 @@ class WN_Mail_Transport_SendgridSmtp extends WN_Mail_Transport_Smtp
      *
      * @param   array $options
      * @return  void
-     * 
+     */ 
     public function setOptionsArray(array $options)
     {
         $this->apiOptions = $options;

--- a/library/Zend/Mail/Transport/SendgridSmtp.php
+++ b/library/Zend/Mail/Transport/SendgridSmtp.php
@@ -93,7 +93,7 @@ class Zend_Mail_Transport_SendgridSmtp extends Zend_Mail_Transport_Smtp
      * @param   array $options
      * @return  void
      */ 
-    public function setOptionsArray(array $options)
+    public function setOptions(array $options)
     {
         $this->apiOptions = $options;
     }

--- a/library/Zend/Mail/Transport/SendgridSmtp.php
+++ b/library/Zend/Mail/Transport/SendgridSmtp.php
@@ -1,0 +1,109 @@
+<?php
+
+class WN_Mail_Transport_SendgridSmtp extends WN_Mail_Transport_Smtp
+{
+    /**
+     * ClickTracking status
+     *
+     * @var bool
+     */
+    protected $clickTracking = false;
+
+    /**
+     * API Options
+     *
+     * @var array
+     */
+    private $apiOptions = [];
+
+    public function __construct($options)
+    {
+         if (!isset($options['host'])) {
+             throw new Zend_Application_Resource_Exception(
+                 'A host is necessary for smtp transport,'
+                 . ' but none was given'
+             );
+         }
+         $this->setClickTracking($options['clicktrack'] ?? false);
+
+        $options['port'] = $options['port'] ?? 465;
+        $options['username'] = $options['apikey'] ?? $options['username'];
+        $options['ssl'] = true;
+        parent::__construct($options);
+    }
+
+    /**
+     * Set ClickTracking status
+     *
+     * @param bool $status
+     * @return void
+     * 
+    public function setClickTracking($bool)
+    {
+        $this->clickTracking = $bool;
+
+        $overrideOptions = [
+            "filters" => [
+                "clicktrack" => [
+                    "settings" => [
+                        "enable" => $this->clickTracking,
+                        "enable_text" => $this->clickTracking,
+                    ]
+                ]
+            ]
+        ];
+
+        $this->apiOptions = array_merge_recursive($this->apiOptions, $overrideOptions);
+    }
+
+    /**
+     * Get ClickTracking status
+     *
+     * @return bool
+     * 
+    public function getClickTracking()
+    {
+        return $this->clickTracking;
+    }
+
+    /**
+     * Set API option
+     *
+     * @param   string $key
+     * @param   mixed $value
+     * 
+    public function setOption($key, $value)
+    {
+        $this->apiOptions[$key] = $value;
+    }
+
+    /**
+     * Get API options
+     *
+     * @return array
+     * 
+    public function getOptions()
+    {
+        return $this->apiOptions;
+    }
+
+    /**
+     * Set API options
+     *
+     * @param   array $options
+     * @return  void
+     * 
+    public function setOptionsArray(array $options)
+    {
+        $this->apiOptions = $options;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    protected function _prepareHeaders($headers)
+    {
+        $headers['X-SMTPAPI'] = Zend_Json::encode($this->apiOptions);
+        parent::_prepareHeaders($headers);
+    }
+}


### PR DESCRIPTION
Basic SendgridSmtp class to support setting custom options via headers and also basic flag for click tracking.
We used this in production before we moved to a SendgridApi class but that has a dependency on the Sendgrid PHP Library which I am not sure if you would allow it, maybe by using a suggested dependency in composer?