### PR TITLE
Change Zend_Db_Select::order to accept separate column and direction

### DIFF
--- a/library/Zend/Db/Select.php
+++ b/library/Zend/Db/Select.php
@@ -631,7 +631,7 @@ class Zend_Db_Select
                     continue;
                 }
                 $direction = self::SQL_ASC;
-                if (is_array($val) && count(val) == 2) {
+                if (is_array($val) && count($val) == 2) {
                     if(strtoupper($val[1]) == self::SQL_DESC)
                         $direction = self::SQL_DESC;
                     $val = $val[0];

--- a/library/Zend/Db/Select.php
+++ b/library/Zend/Db/Select.php
@@ -609,9 +609,12 @@ class Zend_Db_Select
      * @param mixed $spec The column(s) and direction to order by.
      * @return $this This Zend_Db_Select object.
      */
-    public function order($spec)
+    public function order($spec, $dir = NULL)
     {
         if (!is_array($spec)) {
+            if (is_string($dir)) {
+                $spec = [$spec, $dir];
+            }
             $spec = [$spec];
         }
 
@@ -628,7 +631,11 @@ class Zend_Db_Select
                     continue;
                 }
                 $direction = self::SQL_ASC;
-                if (preg_match('/(.*\W)(' . self::SQL_ASC . '|' . self::SQL_DESC . ')\b/si', $val, $matches)) {
+                if (is_array($val) && count(val) == 2) {
+                    if(strtoupper($val[1]) == self::SQL_DESC)
+                        $direction = self::SQL_DESC;
+                    $val = $val[0];
+                } elseif (preg_match('/(.*\W)(' . self::SQL_ASC . '|' . self::SQL_DESC . ')\b/si', $val, $matches)) {
                     $val = trim($matches[1]);
                     $direction = $matches[2];
                 }

--- a/tests/Zend/Db/Select/TestCommon.php
+++ b/tests/Zend/Db/Select/TestCommon.php
@@ -1276,6 +1276,27 @@ abstract class Zend_Db_Select_TestCommon extends Zend_Db_TestSetup
         $this->assertEquals(1, $result[0]['product_id']);
     }
 
+    protected function _selectOrderByAscTwoArg()
+    {
+        $select = $this->_db->select()
+            ->from('zfproducts')
+            ->order('product_id', 'ASC');
+        return $select;
+    }
+    
+    public function testSelectOrderByAscTwoArg()
+    {
+        $select = $this->_selectOrderByAscTwoArg();
+        $stmt = $this->_db->query($select);
+        $result = $stmt->fetchAll();
+        $this->assertEquals(
+            3,
+            count($result),
+            'Expected count of result set to be 3'
+        );
+        $this->assertEquals(1, $result[0]['product_id']);
+    }
+
     protected function _selectOrderByPosition()
     {
         $select = $this->_db->select()
@@ -1375,6 +1396,42 @@ abstract class Zend_Db_Select_TestCommon extends Zend_Db_TestSetup
             'Expected count of result set to be 2'
         );
         $this->assertEquals(3, $result[0]['product_id']);
+    }
+
+    protected function _selectOrderByDescTwoArg()
+    {
+        $select = $this->_db->select()
+            ->from('zfproducts')
+            ->order('product_id', 'DESC');
+        return $select;
+    }
+    
+    public function testSelectOrderByDescTwoArg()
+    {
+        $select = $this->_selectOrderByDescTwoArg();
+        $stmt = $this->_db->query($select);
+        $result = $stmt->fetchAll();
+        $this->assertEquals(
+            3,
+            count($result),
+            'Expected count of result set to be 3'
+        );
+        $this->assertEquals(3, $result[0]['product_id']);
+    }
+    
+    public function testSelectOrderByTwoForms()
+    {
+        $selectA = $this->_db->select()
+            ->from('zfproducts')
+            ->order(['product_name ASC', 'product_id DESC']);
+        $selectB = $this->_db->select()
+            ->from('zfproducts')
+            ->order([['product_name', 'ASC'], ['product_id', 'DESC']]);
+        $this->assertEquals(
+            (string)$selectA,
+            (string)$selectB,
+            'Expected two forms of order call to give same result'
+       );
     }
 
     /**


### PR DESCRIPTION
I feel like calling `$select->order("$col $dir")` looks really smelly. This PR allows instead calling `$select->order($col, $dir)`,
as well as calling `$select->order([[$col0, $dir0], [$col1, $dir1]])`.