### PR TITLE
zend-validate fix issue: File "Intelligentmail.php" does not exist 

### DIFF
--- a/library/Zend/Validate/Barcode/Intelligentmail.php
+++ b/library/Zend/Validate/Barcode/Intelligentmail.php
@@ -30,7 +30,7 @@ require_once 'Zend/Validate/Barcode/AdapterAbstract.php';
  * @copyright  Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  */
-class Zend_Validate_Barcode_IntelligentMail extends Zend_Validate_Barcode_AdapterAbstract
+class Zend_Validate_Barcode_Intelligentmail extends Zend_Validate_Barcode_AdapterAbstract
 {
     /**
      * Allowed barcode lengths

--- a/tests/Zend/Validate/BarcodeTest.php
+++ b/tests/Zend/Validate/BarcodeTest.php
@@ -345,7 +345,6 @@ class Zend_Validate_BarcodeTest extends TestCase
 
     public function testINTELLIGENTMAIL()
     {
-        $this->markTestSkipped('on linux not found Zend\Validate\Barcode\Intelligentmail.php');
         $barcode = new Zend_Validate_Barcode('intelligentmail');
         $this->assertTrue($barcode->isValid('01234567094987654321'));
         $this->assertFalse($barcode->isValid('123'));


### PR DESCRIPTION
### Problem

On case sensitive file name system (linux) code bellow
```php 
new Zend_Validate_Barcode('intelligentmail');
```
will raise exception not found file `Zend/Validate/Validate/Barcode/Intelligentmail.php`

Logic load barcode $adapter file here
https://github.com/Shardj/zf1-future/blob/26aaf166415a16c6168b76b041b7df4a6a156046/library/Zend/Validate/Barcode.php#L132-L140

### Root cause

- one of the causes of the bug - commit: [Renamed to library/Zend/Validate/Barcode/IntelligentMail.php](https://github.com/Shardj/zf1-future/commits/d822ef15e4c27f116c5bc25a2967c25b9ecac59c/library/Zend/Validate/Barcode/Intelligentmail.php?browsing_rename_history=true&new_path=library/Zend/Validate/Barcode/IntelligentMail.php&original_branch=master)
- Class name `Zend_Validate_Barcode_IntelligentMail` not match rule in line 132 `$adapter = ucfirst(strtolower($adapter)); `

### What in PR

Reopen test case `Zend_Validate_BarcodeTest.php::testINTELLIGENTMAIL`  -  https://github.com/hungtrinh/zf1-future/actions/runs/4434747808/jobs/7781048143#step:10:261

Fix above bug by: https://github.com/hungtrinh/zf1-future/actions/runs/4434966231/jobs/7781528244
- Correctly class name to `Zend_Validate_Barcode_Intelligentmail` 
- Rollback file name from `IntelligentMail.php` to `Intelligentmail.php`

Ref 
- why i know origin file name is `Intelligentmail.php` - see here https://github.com/Shardj/zf1-future/commits/d822ef15e4c27f116c5bc25a2967c25b9ecac59c/library/Zend/Validate/Barcode/Intelligentmail.php?browsing_rename_history=true&new_path=library/Zend/Validate/Barcode/IntelligentMail.php&original_branch=master
- how to fix bug - see here https://github.com/zf1s/zf1/commit/514800d