### PR TITLE
Fixing typo in README.txt generation part

### DIFF
--- a/library/Zend/Tool/Project/Provider/Project.php
+++ b/library/Zend/Tool/Project/Provider/Project.php
@@ -221,7 +221,7 @@ EOS;
 README
 ======
 
-This directory should be used to place project specfic documentation including
+This directory should be used to place project specific documentation including
 but not limited to project notes, generated API/phpdoc documentation, or
 manual files generated or hand written.  Ideally, this directory would remain
 in your development environment only and should not be deployed with your


### PR DESCRIPTION
There is a issue I fixed that after generating new project the "docs/README.txt" file has typo in word "specific".