### PR TITLE
Create a local cache for performance

### DIFF
--- a/library/Zend/Locale/Data.php
+++ b/library/Zend/Locale/Data.php
@@ -61,6 +61,14 @@ class Zend_Locale_Data
     private static $_cache = null;
 
     /**
+     * Local copy of cache
+     *
+     * @var array
+     */
+    private static $_cacheList = [];
+    private static $_cacheContent = [];
+
+    /**
      * Internal value to remember if cache supports tags
      *
      * @var boolean
@@ -335,12 +343,16 @@ class Zend_Locale_Data
 
         $val = urlencode((string) $val);
         $id  = self::_filterCacheId('Zend_LocaleL_' . $locale . '_' . $path . '_' . $val);
+        if (isset(self::$_cacheList[$id])) {
+            return self::$_cacheList[$id];
+        }
         if (!self::$_cacheDisabled && ($result = self::$_cache->load($id))) {
-            return unserialize($result);
+            self::$_cacheList[$id] = unserialize($result);
+            return self::$_cacheList[$id];
         }
 
         $temp = [];
-        switch(strtolower((string) $path)) {
+        switch (strtolower((string) $path)) {
             case 'language':
                 $temp = self::_getFile($locale, '/ldml/localeDisplayNames/languages/language', 'type');
                 break;
@@ -947,12 +959,13 @@ class Zend_Locale_Data
 
         if (isset(self::$_cache)) {
             if (self::$_cacheTags) {
-                self::$_cache->save( serialize($temp), $id, ['Zend_Locale']);
+                self::$_cache->save(serialize($temp), $id, ['Zend_Locale']);
             } else {
-                self::$_cache->save( serialize($temp), $id);
+                self::$_cache->save(serialize($temp), $id);
             }
         }
 
+        self::$_cacheList[$id] = $temp;
         return $temp;
     }
 
@@ -982,13 +995,18 @@ class Zend_Locale_Data
         if (is_array($value)) {
             $val = implode('_' , $value);
         }
+
         $val = urlencode((string) $val);
         $id  = self::_filterCacheId('Zend_LocaleC_' . $locale . '_' . $path . '_' . $val);
+        if (isset(self::$_cacheContent[$id])) {
+            return self::$_cacheContent[$id];
+        }
         if (!self::$_cacheDisabled && ($result = self::$_cache->load($id))) {
-            return unserialize($result);
+            self::$_cacheContent[$id] = unserialize($result);
+            return self::$_cacheContent[$id];
         }
 
-        switch(strtolower((string) $path)) {
+        switch (strtolower((string) $path)) {
             case 'language':
                 $temp = self::_getFile($locale, '/ldml/localeDisplayNames/languages/language[@type=\'' . $value . '\']', 'type');
                 break;
@@ -1500,12 +1518,13 @@ class Zend_Locale_Data
         }
         if (isset(self::$_cache)) {
             if (self::$_cacheTags) {
-                self::$_cache->save( serialize($temp), $id, ['Zend_Locale']);
+                self::$_cache->save(serialize($temp), $id, ['Zend_Locale']);
             } else {
-                self::$_cache->save( serialize($temp), $id);
+                self::$_cache->save(serialize($temp), $id);
             }
         }
 
+        self::$_cacheContent[$id] = $temp;
         return $temp;
     }
 


### PR DESCRIPTION
I'm using **Zend_Locale_Format::toNumber**, and I noticed that this is a little slow.
Instead of reading from cache each time we call _toNumber_, we are reading from cache one time, and after we are using a local copy.

Here is a before (65ms) / after (29ms) for the same page with Blackfire:

![zend-before](https://user-images.githubusercontent.com/31816829/229880991-9850ca11-751a-4ba9-a06b-699b11c9bb61.png)

![zend-after](https://user-images.githubusercontent.com/31816829/229881016-f2e13b8f-6b1d-4837-be2c-e33feb999eda.png)

A graph (for before):
![scandale](https://user-images.githubusercontent.com/31816829/230036104-246fb0ee-eba5-4350-b14a-4cb09add009b.png)



Tested with PHP 8.0 and 8.2.
I hope this is good.