### PR TITLE
Added more precise return types on Zend_Controller_Request_Http

### DIFF
--- a/library/Zend/Controller/Request/Http.php
+++ b/library/Zend/Controller/Request/Http.php
@@ -313,6 +313,8 @@ class Zend_Controller_Request_Http extends Zend_Controller_Request_Abstract
      * @param string $key
      * @param mixed $default Default value to use if key not found
      * @return mixed Returns null if key does not exist
+     *
+     * @phpstan-return ($key is null ? array<string, mixed> : mixed)
      */
     public function getPost($key = null, $default = null)
     {
@@ -332,6 +334,8 @@ class Zend_Controller_Request_Http extends Zend_Controller_Request_Abstract
      * @param string $key
      * @param mixed $default Default value to use if key not found
      * @return mixed Returns null if key does not exist
+     *
+     * @phpstan-return ($key is null ? array<string, mixed> : mixed)
      */
     public function getCookie($key = null, $default = null)
     {
@@ -350,6 +354,8 @@ class Zend_Controller_Request_Http extends Zend_Controller_Request_Abstract
      * @param string $key
      * @param mixed $default Default value to use if key not found
      * @return mixed Returns null if key does not exist
+     *
+     * @phpstan-return ($key is null ? array<string, mixed> : mixed)
      */
     public function getServer($key = null, $default = null)
     {
@@ -368,6 +374,8 @@ class Zend_Controller_Request_Http extends Zend_Controller_Request_Abstract
      * @param string $key
      * @param mixed $default Default value to use if key not found
      * @return mixed Returns null if key does not exist
+     *
+     * @phpstan-return ($key is null ? array<string, mixed> : mixed)
      */
     public function getEnv($key = null, $default = null)
     {

--- a/library/Zend/Controller/Request/Http.php
+++ b/library/Zend/Controller/Request/Http.php
@@ -271,6 +271,8 @@ class Zend_Controller_Request_Http extends Zend_Controller_Request_Abstract
      * @param string $key
      * @param mixed $default Default value to use if key not found
      * @return mixed Returns null if key does not exist
+     *
+     * @phpstan-return ($key is null ? array<string, mixed> : mixed)
      */
     public function getQuery($key = null, $default = null)
     {


### PR DESCRIPTION
when invoked without parameterts like `$post = $this->getRequest()->getPost();` with this PR we can assume we get an `array`.

this simplifies handling on the caller-side as we no longer get `mixed`.

the precise return type is inspired by [phpstan-src](https://github.com/phpstan/phpstan-src/blob/840a64f113c7ca10d5111719a0338914b0051ceb/src/Analyser/MutatingScope.php#L509-L511)