### PR TITLE
Extend native SessionHandlerInterface

### DIFF
--- a/library/Zend/Session/SaveHandler/Interface.php
+++ b/library/Zend/Session/SaveHandler/Interface.php
@@ -30,52 +30,6 @@
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  * @see        http://php.net/session_set_save_handler
  */
-interface Zend_Session_SaveHandler_Interface
+interface Zend_Session_SaveHandler_Interface extends SessionHandlerInterface
 {
-
-    /**
-     * Open Session - retrieve resources
-     *
-     * @param string $save_path
-     * @param string $name
-     */
-    public function open($save_path, $name);
-
-    /**
-     * Close Session - free resources
-     *
-     */
-    public function close();
-
-    /**
-     * Read session data
-     *
-     * @param string $id
-     */
-    public function read($id);
-
-    /**
-     * Write Session - commit data to resource
-     *
-     * @param string $id
-     * @param mixed $data
-     */
-    public function write($id, $data);
-
-    /**
-     * Destroy Session - remove data from resource for
-     * given session id
-     *
-     * @param string $id
-     */
-    public function destroy($id);
-
-    /**
-     * Garbage Collection - remove old session data older
-     * than $maxlifetime (in seconds)
-     *
-     * @param int $maxlifetime
-     */
-    public function gc($maxlifetime);
-
 }


### PR DESCRIPTION
See https://www.php.net/manual/en/class.sessionhandlerinterface.php

This change allows classes that implement Zend_Session_SaveHandler_Interface to use typed properties. 

This also makes it easier to start migrating to [Laminas\Session](https://github.com/laminas/laminas-session/blob/b66d575c96e0cfc79e83c7729684df05a07bf40b/src/SaveHandler/SaveHandlerInterface.php)

Functionally, nothing changes. 