### PR TITLE
Enabled testing of APCU for all PHP versions when running with all extensions enabled

### DIFF
--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -33,6 +33,8 @@ jobs:
       TESTS_ZEND_CACHE_LIBMEMCACHED_HOST: 127.0.0.1
       TESTS_ZEND_CACHE_LIBMEMCACHED_PORT: 11211
 
+      TESTS_ZEND_CACHE_APC_ENABLED: true
+
       # https://hub.docker.com/r/bitnami/openldap
       LDAP_ROOT: "dc=example,dc=com"
       LDAP_ALLOW_ANON_BINDING: false
@@ -112,15 +114,15 @@ jobs:
           #bare for PHP >=7.2
           - php-extensions-bare: "none, iconv, json, libxml, xml, dom, simplexml, xmlwriter, tokenizer, mbstring"
           #full for PHP <= 8.0
-          - php-extensions-full: "none, iconv, json, libxml, xml, dom, simplexml, xmlwriter, tokenizer, mbstring, ctype, openssl, curl, gd, posix, pdo_sqlite, pdo_mysql, fileinfo, zip, sqlite, soap, bcmath, igbinary, bz2, lzf, memcached, memcache, ldap, sqlite, mcrypt, rar"
+          - php-extensions-full: "none, iconv, json, libxml, xml, dom, simplexml, xmlwriter, tokenizer, mbstring, apcu, ctype, openssl, curl, gd, posix, pdo_sqlite, pdo_mysql, fileinfo, zip, sqlite, soap, bcmath, igbinary, bz2, lzf, memcached, memcache, ldap, sqlite, mcrypt, rar"
           - php-version: "7.1"
             php-extensions-bare: "none, iconv, json, libxml, xml, dom, simplexml, xmlwriter, tokenizer"
           - php-version: "8.1"
-            php-extensions-full: "none, iconv, json, libxml, xml, dom, simplexml, xmlwriter, tokenizer, mbstring, ctype, openssl, curl, gd, posix, pdo_sqlite, pdo_mysql, fileinfo, zip, sqlite, soap, bcmath, igbinary, bz2, lzf, memcached, memcache, ldap, sqlite, mcrypt"
+            php-extensions-full: "none, iconv, json, libxml, xml, dom, simplexml, xmlwriter, tokenizer, mbstring, apcu, ctype, openssl, curl, gd, posix, pdo_sqlite, pdo_mysql, fileinfo, zip, sqlite, soap, bcmath, igbinary, bz2, lzf, memcached, memcache, ldap, sqlite, mcrypt"
           - php-version: "8.2"
-            php-extensions-full: "none, iconv, json, libxml, xml, dom, simplexml, xmlwriter, tokenizer, mbstring, ctype, openssl, curl, gd, posix, pdo_sqlite, pdo_mysql, fileinfo, zip, sqlite, soap, bcmath, igbinary, bz2, lzf, memcached, memcache, ldap, sqlite, mcrypt"
+            php-extensions-full: "none, iconv, json, libxml, xml, dom, simplexml, xmlwriter, tokenizer, mbstring, apcu, ctype, openssl, curl, gd, posix, pdo_sqlite, pdo_mysql, fileinfo, zip, sqlite, soap, bcmath, igbinary, bz2, lzf, memcached, memcache, ldap, sqlite, mcrypt"
           - php-version: "8.3"
-            php-extensions-full: "none, iconv, json, libxml, xml, dom, simplexml, xmlwriter, tokenizer, mbstring, ctype, openssl, curl, gd, posix, pdo_sqlite, pdo_mysql, fileinfo, zip, sqlite, soap, bcmath, igbinary, bz2, lzf, memcached, memcache, ldap, sqlite"
+            php-extensions-full: "none, iconv, json, libxml, xml, dom, simplexml, xmlwriter, tokenizer, mbstring, apcu, ctype, openssl, curl, gd, posix, pdo_sqlite, pdo_mysql, fileinfo, zip, sqlite, soap, bcmath, igbinary, bz2, lzf, memcached, memcache, ldap, sqlite"
             experimental: true
 
     steps:
@@ -159,7 +161,7 @@ jobs:
           restore-keys: ${{ runner.os }}-${{ matrix.php-version }}-composer-
 
       - name: Install dependencies
-        run: composer install --prefer-dist --no-progress --no-suggest
+        run: composer install --prefer-dist --no-progress --no-interaction
 
       - name: Lint PHP source files
         run: |
@@ -181,7 +183,7 @@ jobs:
           php-version: ${{ matrix.php-version }}
           tools: cs2pr
           extensions: ${{ matrix.php-extensions-full }}
-          ini-values: ${{ env.PHP_INI_VALUES }}
+          ini-values: ${{ env.PHP_INI_VALUES }}, apc.enable_cli=1
         env:
           # https://github.com/shivammathur/setup-php/issues/407#issuecomment-773675741
           fail-fast: true

--- a/library/Zend/Cache/Backend/Apc.php
+++ b/library/Zend/Cache/Backend/Apc.php
@@ -74,7 +74,7 @@ class Zend_Cache_Backend_Apc extends Zend_Cache_Backend implements Zend_Cache_Ba
     {
         $tmp = apcu_fetch($id);
         if (is_array($tmp)) {
-            return $tmp[0];
+            return $tmp[0] ?? false;
         }
         return false;
     }
@@ -89,7 +89,7 @@ class Zend_Cache_Backend_Apc extends Zend_Cache_Backend implements Zend_Cache_Ba
     {
         $tmp = apcu_fetch($id);
         if (is_array($tmp)) {
-            return $tmp[1];
+            return $tmp[1] ?? false;
         }
         return false;
     }

--- a/library/Zend/Cache/Backend/File.php
+++ b/library/Zend/Cache/Backend/File.php
@@ -250,6 +250,7 @@ class Zend_Cache_Backend_File extends Zend_Cache_Backend implements Zend_Cache_B
                 $this->_recursiveMkdirAndChmod($id);
             }
             if (!is_writable($path)) {
+                $this->_log('Zend_Cache_Backend_File::save() : path ' . $path . ' is not writable');
                 return false;
             }
         }
@@ -1011,14 +1012,20 @@ class Zend_Cache_Backend_File extends Zend_Cache_Backend implements Zend_Cache_B
         $result = false;
         $f = @fopen($file, 'ab+');
         if ($f) {
-            if ($this->_options['file_locking']) @flock($f, LOCK_EX);
+            if ($this->_options['file_locking']) {
+                @flock($f, LOCK_EX);
+            }
             fseek($f, 0);
             ftruncate($f, 0);
             $tmp = @fwrite($f, $string);
             if (!($tmp === FALSE)) {
                 $result = true;
+            } else {
+                $this->_log("Zend_Cache_Backend_File::_filePutContents() : failed to write contents");
             }
             @fclose($f);
+        } else {
+            $this->_log("Zend_Cache_Backend_File::_filePutContents() : we can't obtain handle");
         }
         @chmod($file, $this->_options['cache_file_perm']);
         return $result;

--- a/tests/Zend/Cache/AllTests.php
+++ b/tests/Zend/Cache/AllTests.php
@@ -104,9 +104,9 @@ class Zend_Cache_AllTests
             $skipTest = new Zend_Cache_ApcBackendTest_SkipTests();
             $skipTest->message = 'Tests are not enabled in TestConfiguration.php';
             $suite->addTest($skipTest);
-        } elseif (!extension_loaded('apc')) {
+        } elseif (!extension_loaded('apcu')) {
             $skipTest = new Zend_Cache_ApcBackendTest_SkipTests();
-            $skipTest->message = "Extension 'APC' is not loaded";
+            $skipTest->message = "Extension 'apcu' is not loaded";
             $suite->addTest($skipTest);
         } else {
             $suite->addTestSuite('Zend_Cache_ApcBackendTest');
@@ -218,9 +218,9 @@ class Zend_Cache_AllTests
             $skipTest = new Zend_Cache_TwoLevelsBackendTest_SkipTests();
             $skipTest->message = 'Tests are not enabled in TestConfiguration.php';
             $suite->addTest($skipTest);
-        } elseif (!extension_loaded('apc')) {
+        } elseif (!extension_loaded('apcu')) {
             $skipTest = new Zend_Cache_TwoLevelsBackendTest_SkipTests();
-            $skipTest->message = "Extension 'APC' is not loaded";
+            $skipTest->message = "Extension 'apcu' is not loaded";
             $suite->addTest($skipTest);
         } else {
             $suite->addTestSuite('Zend_Cache_TwoLevelsBackendTest');

--- a/tests/Zend/Cache/ApcBackendTest.php
+++ b/tests/Zend/Cache/ApcBackendTest.php
@@ -175,9 +175,6 @@ class Zend_Cache_ApcBackendTest extends Zend_Cache_CommonExtendedBackendTest
     {
     }
 
-    /**
-     * @doesNotPerformAssertions
-     */
     public function testSaveCorrectCall()
     {
         $this->_instance->setDirectives(['logging' => false]);
@@ -185,9 +182,6 @@ class Zend_Cache_ApcBackendTest extends Zend_Cache_CommonExtendedBackendTest
         $this->_instance->setDirectives(['logging' => true]);
     }
 
-    /**
-     * @doesNotPerformAssertions
-     */
     public function testSaveWithNullLifeTime()
     {
         $this->_instance->setDirectives(['logging' => false]);
@@ -195,9 +189,6 @@ class Zend_Cache_ApcBackendTest extends Zend_Cache_CommonExtendedBackendTest
         $this->_instance->setDirectives(['logging' => true]);
     }
 
-    /**
-     * @doesNotPerformAssertions
-     */
     public function testSaveWithSpecificLifeTime()
     {
         $this->_instance->setDirectives(['logging' => false]);
@@ -205,9 +196,6 @@ class Zend_Cache_ApcBackendTest extends Zend_Cache_CommonExtendedBackendTest
         $this->_instance->setDirectives(['logging' => true]);
     }
 
-    /**
-     * @doesNotPerformAssertions
-     */
     public function testGetMetadatas($notag = true)
     {
         parent::testGetMetadatas($notag);

--- a/tests/Zend/Cache/TwoLevelsBackendTest.php
+++ b/tests/Zend/Cache/TwoLevelsBackendTest.php
@@ -99,30 +99,45 @@ class Zend_Cache_TwoLevelsBackendTest extends Zend_Cache_CommonExtendedBackendTe
     public function testSaveOverwritesIfFastIsFull()
     {
         $slowBackend = 'File';
-        $fastBackend = $this->createMock('Zend_Cache_Backend_Apc');
-        $fastBackend->expects($this->at(0))
+        $fastBackend = $this->createPartialMock('Zend_Cache_Backend_Apc', ['getFillingPercentage']);
+        $fastBackend->expects($this->exactly(2))
             ->method('getFillingPercentage')
-            ->will($this->returnValue(0));
-        $fastBackend->expects($this->at(1))
-            ->method('getFillingPercentage')
-            ->will($this->returnValue(90));
-
+            ->willReturn(0, 90);
 
         $slowBackendOptions = [
-            'cache_dir' => $this->_cache_dir
+            'cache_dir' => $this->_cache_dir,
         ];
+
+        $logStream = fopen('php://temp/maxmemory:4194304', 'a+b');
+        $logger = new Zend_Log(new Zend_Log_Writer_Stream($logStream));
         $cache = new Zend_Cache_Backend_TwoLevels([
             'fast_backend' => $fastBackend,
             'slow_backend' => $slowBackend,
             'slow_backend_options' => $slowBackendOptions,
             'stats_update_factor' => 1
         ]);
+        $cache->setDirectives(['logging' => true, 'logger' => $logger]);
 
         $id = 'test' . uniqid();
-        $this->assertTrue($cache->save(10, $id)); //fast usage at 0%
-        
-        $this->assertTrue($cache->save(100, $id)); //fast usage at 90%
-        $this->assertEquals(100, $cache->load($id));
+
+        $saveResult = $cache->save(10, $id);
+        $failMessage = 'Failed to save when fast usage is 0. Two level logs: ' . "\n" .
+            stream_get_contents($logStream, -1, 0);
+        $this->assertTrue($saveResult, $failMessage); //fast usage at 0%
+
+        $logger->debug('Finished saving when usage is at 0');
+
+        $saveResult = $cache->save(100, $id);
+        $failMessage = 'Failed to save when fast usage is 90. Two level logs: ' . "\n" .
+            stream_get_contents($logStream, -1, 0);
+        $this->assertTrue($saveResult, $failMessage); //fast usage at 90%
+
+        $logger->debug('Finished saving when usage is at 90');
+
+        $loadResult = $cache->load($id);
+        $failMessage = 'Failed to load when fast usage is 90. Two level logs: ' . "\n" .
+            stream_get_contents($logStream, -1, 0);
+        $this->assertEquals(100, $loadResult, $failMessage);
     }
     
     /**

--- a/tests/Zend/Cache/WinCacheBackendTest.php
+++ b/tests/Zend/Cache/WinCacheBackendTest.php
@@ -198,9 +198,6 @@ class Zend_Cache_WinCacheBackendTest extends Zend_Cache_CommonExtendedBackendTes
         $this->markTestSkipped('This test skipped due to limitations in this adapter.');
     }
 
-    /**
-     * @doesNotPerformAssertions
-     */
     public function testSaveCorrectCall()
     {
         $this->_instance->setDirectives(['logging' => false]);
@@ -208,9 +205,6 @@ class Zend_Cache_WinCacheBackendTest extends Zend_Cache_CommonExtendedBackendTes
         $this->_instance->setDirectives(['logging' => true]);
     }
 
-    /**
-     * @doesNotPerformAssertions
-     */
     public function testSaveWithNullLifeTime()
     {
         $this->_instance->setDirectives(['logging' => false]);
@@ -218,9 +212,6 @@ class Zend_Cache_WinCacheBackendTest extends Zend_Cache_CommonExtendedBackendTes
         $this->_instance->setDirectives(['logging' => true]);
     }
 
-    /**
-     * @doesNotPerformAssertions
-     */
     public function testSaveWithSpecificLifeTime()
     {
         $this->_instance->setDirectives(['logging' => false]);
@@ -228,9 +219,6 @@ class Zend_Cache_WinCacheBackendTest extends Zend_Cache_CommonExtendedBackendTes
         $this->_instance->setDirectives(['logging' => true]);
     }
 
-    /**
-     * @doesNotPerformAssertions
-     */
     public function testGetMetadatas($notag = true)
     {
         parent::testGetMetadatas($notag);

--- a/tests/Zend/Cache/XcacheBackendTest.php
+++ b/tests/Zend/Cache/XcacheBackendTest.php
@@ -129,9 +129,7 @@ class Zend_Cache_XcacheBackendTest extends Zend_Cache_CommonBackendTest
     public function testCleanModeNotMatchingTags3()
     {
     }
-    /**
-     * @doesNotPerformAssertions
-     */
+
     public function testSaveCorrectCall()
     {
         $this->_instance->setDirectives(['logging' => false]);
@@ -139,9 +137,6 @@ class Zend_Cache_XcacheBackendTest extends Zend_Cache_CommonBackendTest
         $this->_instance->setDirectives(['logging' => true]);
     }
 
-    /**
-     * @doesNotPerformAssertions
-     */
     public function testSaveWithNullLifeTime()
     {
         $this->_instance->setDirectives(['logging' => false]);
@@ -149,9 +144,6 @@ class Zend_Cache_XcacheBackendTest extends Zend_Cache_CommonBackendTest
         $this->_instance->setDirectives(['logging' => true]);
     }
 
-    /**
-     * @doesNotPerformAssertions
-     */
     public function testSaveWithSpecificLifeTime()
     {
         $this->_instance->setDirectives(['logging' => false]);

--- a/tests/Zend/Cache/ZendServerDiskTest.php
+++ b/tests/Zend/Cache/ZendServerDiskTest.php
@@ -126,9 +126,7 @@ class Zend_Cache_ZendServerDiskTest extends Zend_Cache_CommonBackendTest
     public function testCleanModeNotMatchingTags3()
     {
     }
-    /**
-     * @doesNotPerformAssertions
-     */
+
     public function testSaveCorrectCall()
     {
         $this->_instance->setDirectives(['logging' => false]);
@@ -136,9 +134,6 @@ class Zend_Cache_ZendServerDiskTest extends Zend_Cache_CommonBackendTest
         $this->_instance->setDirectives(['logging' => true]);
     }
 
-    /**
-     * @doesNotPerformAssertions
-     */
     public function testSaveWithNullLifeTime()
     {
         $this->_instance->setDirectives(['logging' => false]);
@@ -146,9 +141,6 @@ class Zend_Cache_ZendServerDiskTest extends Zend_Cache_CommonBackendTest
         $this->_instance->setDirectives(['logging' => true]);
     }
 
-    /**
-     * @doesNotPerformAssertions
-     */
     public function testSaveWithSpecificLifeTime()
     {
         $this->_instance->setDirectives(['logging' => false]);

--- a/tests/Zend/Cache/ZendServerShMemTest.php
+++ b/tests/Zend/Cache/ZendServerShMemTest.php
@@ -126,9 +126,7 @@ class Zend_Cache_ZendServerShMemTest extends Zend_Cache_CommonBackendTest
     public function testCleanModeNotMatchingTags3()
     {
     }
-    /**
-     * @doesNotPerformAssertions
-     */
+
     public function testSaveCorrectCall()
     {
         $this->_instance->setDirectives(['logging' => false]);
@@ -136,9 +134,6 @@ class Zend_Cache_ZendServerShMemTest extends Zend_Cache_CommonBackendTest
         $this->_instance->setDirectives(['logging' => true]);
     }
 
-    /**
-     * @doesNotPerformAssertions
-     */
     public function testSaveWithNullLifeTime()
     {
         $this->_instance->setDirectives(['logging' => false]);
@@ -146,9 +141,6 @@ class Zend_Cache_ZendServerShMemTest extends Zend_Cache_CommonBackendTest
         $this->_instance->setDirectives(['logging' => true]);
     }
 
-    /**
-     * @doesNotPerformAssertions
-     */
     public function testSaveWithSpecificLifeTime()
     {
         $this->_instance->setDirectives(['logging' => false]);


### PR DESCRIPTION
Enabled testing of APCU for all PHP versions when running with all extensions enabled;

Removed a few instances of erroneous doesNotPerformAssertions annotations.

----

With APC(u) enabled, there are two test failures:
```
1) Zend_Cache_TwoLevelsBackendTest::testSaveOverwritesIfFastIsFull
Failed asserting that false is true.

/home/runner/work/zf1-future/zf1-future/tests/Zend/Cache/TwoLevelsBackendTest.php:124
/home/runner/work/zf1-future/zf1-future/tests/resources/Runner.php:20
/home/runner/work/zf1-future/zf1-future/tests/Zend/AllTests.php:143
/home/runner/work/zf1-future/zf1-future/tests/Zend/AllTests.php:[267](https://github.com/boenrobot/zf1-future/actions/runs/5821371801/job/15783687811#step:14:268)
phpvfscomposer:///home/runner/work/zf1-future/zf1-future/vendor/phpunit/phpunit/phpunit:60

2) Zend_Cache_TwoLevelsBackendTest::testSaveReturnsTrueIfFastIsFullOnFirstSave
Failed asserting that null matches expected 90.

/home/runner/work/zf1-future/zf1-future/tests/Zend/Cache/TwoLevelsBackendTest.php:152
/home/runner/work/zf1-future/zf1-future/tests/resources/Runner.php:20
/home/runner/work/zf1-future/zf1-future/tests/Zend/AllTests.php:143
/home/runner/work/zf1-future/zf1-future/tests/Zend/AllTests.php:267
phpvfscomposer:///home/runner/work/zf1-future/zf1-future/vendor/phpunit/phpunit/phpunit:60
```

And honestly, I'm not entirely sure what's going on there, as I've never used two level cache. I wonder if I should mark those tests incomplete and we move on? Is this a legit bug that needs fixing? And if it's a legit bug, I'm not sure how to fix it.