### PR TITLE
compataibility for php 8.2 to stop error Deprecated: Creation of dyna…

### DIFF
--- a/library/Zend/Controller/Action.php
+++ b/library/Zend/Controller/Action.php
@@ -92,6 +92,12 @@ abstract class Zend_Controller_Action implements Zend_Controller_Action_Interfac
     public $view;
 
     /**
+     * compataibility for php 8.2 to stop error Deprecated: Creation of dynamic property 
+     * @var object 
+     */
+    public  $contexts = null; 
+    
+    /**
      * Helper Broker to assist in routing help requests to the proper object
      *
      * @var Zend_Controller_Action_HelperBroker


### PR DESCRIPTION
…mic property

file change see attached Zend_Controller_Action

example of code below for controller for ajax json output 
class TestController extends Zend_Controller_Action
{
	public function init ()
	{
 $contextSwitch = $this->_helper->getHelper('contextSwitch');

		$contextSwitch->addActionContext('ajax-attribute-checker', 'json')->initContext('json');

}
public function ajaxAttributeCheckerAction ()
	{
	
	
			$this->view->return = array('yay'=>true);
		}
	}
}