### PR TITLE
Avoid undefined array key access inside url assembly

### DIFF
--- a/library/Zend/Controller/Router/Route/Module.php
+++ b/library/Zend/Controller/Router/Route/Module.php
@@ -251,10 +251,10 @@ class Zend_Controller_Router_Route_Module extends Zend_Controller_Router_Route_A
         }
         unset($params[$this->_moduleKey]);
 
-        $controller = $params[$this->_controllerKey];
+        $controller = $params[$this->_controllerKey] ?? null;
         unset($params[$this->_controllerKey]);
 
-        $action = $params[$this->_actionKey];
+        $action = $params[$this->_actionKey] ?? null;
         unset($params[$this->_actionKey]);
 
         foreach ($params as $key => $value) {


### PR DESCRIPTION
It is viable to end up passing an array of params here that has neither a controller and/or an action specified.

In the case of PHP 8.2, this will start throwing warnings about undefined array keys.

This change will keep the functionality identical, but will prevent warnings being thrown.