### PR TITLE
Support X-Forwarded-Proto header

### DIFF
--- a/library/Zend/View/Helper/ServerUrl.php
+++ b/library/Zend/View/Helper/ServerUrl.php
@@ -56,6 +56,7 @@ class Zend_View_Helper_ServerUrl
             case (isset($_SERVER['HTTPS']) && ($_SERVER['HTTPS'] == 'on' || $_SERVER['HTTPS'] === true)):
             case (isset($_SERVER['HTTP_SCHEME']) && ($_SERVER['HTTP_SCHEME'] == 'https')):
             case (isset($_SERVER['SERVER_PORT']) && ($_SERVER['SERVER_PORT'] == 443)):
+            case (isset($_SERVER['HTTP_X_FORWARDED_PROTO']) && ($_SERVER['HTTP_X_FORWARDED_PROTO'] == 'https')):
                 $scheme = 'https';
                 break;
             default:

--- a/tests/Zend/View/Helper/ServerUrlTest.php
+++ b/tests/Zend/View/Helper/ServerUrlTest.php
@@ -53,6 +53,7 @@ class Zend_View_Helper_ServerUrlTest extends TestCase
     {
         $this->_serverBackup = $_SERVER;
         unset($_SERVER['HTTPS']);
+        unset($_SERVER['HTTP_X_FORWARDED_PROTO']);
     }
 
     /**
@@ -83,6 +84,15 @@ class Zend_View_Helper_ServerUrlTest extends TestCase
     {
         $_SERVER['HTTP_HOST'] = 'example.com';
         $_SERVER['HTTPS'] = 'on';
+
+        $url = new Zend_View_Helper_ServerUrl();
+        $this->assertEquals('https://example.com', $url->serverUrl());
+    }
+
+    public function testConstructorWithHostAndXForwardedProtoHttps()
+    {
+        $_SERVER['HTTP_HOST'] = 'example.com';
+        $_SERVER['HTTP_X_FORWARDED_PROTO'] = 'https';
 
         $url = new Zend_View_Helper_ServerUrl();
         $this->assertEquals('https://example.com', $url->serverUrl());


### PR DESCRIPTION
This adds support for the ubiquitous `X-Forwarded-Proto` header to return `https` URLs for servers behind load balancers. When zf1 was originally written, there were various less standardized headers in use.