### PR TITLE
add "array" as allowed type of $value

### DIFF
--- a/library/Zend/Locale.php
+++ b/library/Zend/Locale.php
@@ -1528,7 +1528,7 @@ class Zend_Locale
      * Returns a localized information string, supported are several types of informations.
      * For detailed information about the types look into the documentation
      *
-     * @param  string             $value  Name to get detailed information about
+     * @param  array|string       $value  Name to get detailed information about
      * @param  string             $path   (Optional) Type of information to return
      * @param  string|Zend_Locale $locale (Optional) Locale|Language for which this informations should be returned
      * @return string|false The wished information in the given language

--- a/library/Zend/Locale/Data.php
+++ b/library/Zend/Locale/Data.php
@@ -959,9 +959,9 @@ class Zend_Locale_Data
     /**
      * Read the LDML file, get a single path defined value
      *
-     * @param  string      $locale
-     * @param  string      $path
-     * @param  bool|string $value
+     * @param  string            $locale
+     * @param  string            $path
+     * @param  array|bool|string $value
      * @return string
      * @throws Zend_Locale_Exception
      */


### PR DESCRIPTION
Apparently, an array is also an allowed type of the `$value` parameter
https://github.com/Shardj/zf1-future/blob/e90fae7b38e42869634f1aceec9856e667039f2b/library/Zend/Locale/Data.php#L982

This also relates to https://github.com/Shardj/zf1-future/blob/e90fae7b38e42869634f1aceec9856e667039f2b/library/Zend/Locale.php#L1536