### PR TITLE
Zend_Http_Client-Adapter_Socket - check transfer-encoding header is a string (and not an array)

### DIFF
--- a/library/Zend/Http/Client/Adapter/Socket.php
+++ b/library/Zend/Http/Client/Adapter/Socket.php
@@ -411,8 +411,12 @@ class Zend_Http_Client_Adapter_Socket implements Zend_Http_Client_Adapter_Interf
             } else {
                 $this->close();
         require_once 'Zend/Http/Client/Adapter/Exception.php';
+                $encoding = $headers['transfer-encoding'];
+                if (is_array($encoding)) {
+                    $encoding = json_encode($encoding);
+                }
                 throw new Zend_Http_Client_Adapter_Exception('Cannot handle "' .
-                    $headers['transfer-encoding'] . '" transfer encoding');
+                    $encoding . '" transfer encoding');
             }
 
             // We automatically decode chunked-messages when writing to a stream

--- a/library/Zend/Http/Client/Adapter/Socket.php
+++ b/library/Zend/Http/Client/Adapter/Socket.php
@@ -357,7 +357,7 @@ class Zend_Http_Client_Adapter_Socket implements Zend_Http_Client_Adapter_Interf
         }
 
         // If we got a 'transfer-encoding: chunked' header
-        if (isset($headers['transfer-encoding'])) {
+        if (isset($headers['transfer-encoding']) && is_string($headers['trasnsfer-encoding'])) {
 
             if (strtolower($headers['transfer-encoding']) == 'chunked') {
 

--- a/library/Zend/Http/Client/Adapter/Socket.php
+++ b/library/Zend/Http/Client/Adapter/Socket.php
@@ -357,7 +357,7 @@ class Zend_Http_Client_Adapter_Socket implements Zend_Http_Client_Adapter_Interf
         }
 
         // If we got a 'transfer-encoding: chunked' header
-        if (isset($headers['transfer-encoding']) && is_string($headers['trasnsfer-encoding'])) {
+        if (isset($headers['transfer-encoding']) && is_string($headers['transfer-encoding'])) {
 
             if (strtolower($headers['transfer-encoding']) == 'chunked') {
 


### PR DESCRIPTION

I saw this error reported in some server logs - 

PHP Fatal error:  Uncaught TypeError: strtolower(): Argument #1 ($string) must be of type string, array given in ... /Zend/Http/Client/Adapter/Socket.php:362

Most http headers can be a single stringy value or an array of strings ... I'm not sure what the correct behaviour should be if there is more than one transfer-encoding (it feels like it's an error on the server my code connected to?). 

Anyway, after this, it'll just throw a Zend_Http_Client_Adapter_Exception instead - which feels like the only option?