### PR TITLE
Fix/remove PHP 8.2 depreciation messages

### DIFF
--- a/library/Zend/Controller/Action.php
+++ b/library/Zend/Controller/Action.php
@@ -43,9 +43,9 @@ require_once 'Zend/Controller/Front.php';
 abstract class Zend_Controller_Action implements Zend_Controller_Action_Interface
 {
     /**
-     * @var array of existing class methods
+     * @var array|null array of existing class methods
      */
-    protected $_classMethods = [];
+    protected $_classMethods = null;
 
     /**
      * Word delimiters (used for normalizing view script paths)

--- a/library/Zend/Controller/Action.php
+++ b/library/Zend/Controller/Action.php
@@ -206,13 +206,14 @@ abstract class Zend_Controller_Action implements Zend_Controller_Action_Interfac
      * By default, the rendered contents are appended to the response. You may
      * specify the named body content segment to set by specifying a $name.
      *
-     * @see Zend_Controller_Response_Abstract::appendBody()
-     * @param  string|null $action Defaults to action registered in request object
-     * @param  string|null $name Response object named path segment to use; defaults to null
-     * @param  bool $noController  Defaults to false; i.e. use controller name as subdir in which to search for view script
+     * @param string|null $action Defaults to action registered in request object
+     * @param string|null $name Response object named path segment to use; defaults to null
+     * @param bool $noController Defaults to false; i.e. use controller name as subdir in which to search for view script
      * @return void
+     * @throws Zend_Controller_Exception
+     * @see Zend_Controller_Response_Abstract::appendBody()
      */
-    public function render($action = null, $name = null, $noController = false)
+    public function render(string $action = null, string $name = null, bool $noController = false)
     {
         if (!$this->getInvokeArg('noViewRenderer') && $this->_helper->hasHelper('viewRenderer')) {
             $this->_helper->viewRenderer->render($action, $name, $noController);
@@ -239,11 +240,12 @@ abstract class Zend_Controller_Action implements Zend_Controller_Action_Interfac
      * By default, the rendered contents are appended to the response. You may
      * specify the named body content segment to set by specifying a $name.
      *
-     * @param  string $script
-     * @param  string $name
+     * @param string $script
+     * @param string|null $name
      * @return void
+     * @throws Zend_Controller_Exception
      */
-    public function renderScript($script, $name = null)
+    public function renderScript(string $script, string $name = null)
     {
         if (!$this->getInvokeArg('noViewRenderer') && $this->_helper->hasHelper('viewRenderer')) {
             $this->_helper->viewRenderer->renderScript($script, $name);
@@ -261,12 +263,12 @@ abstract class Zend_Controller_Action implements Zend_Controller_Action_Interfac
      *
      * Used by render() to determine the path to the view script.
      *
-     * @param  string $action Defaults to action registered in request object
-     * @param  bool $noController  Defaults to false; i.e. use controller name as subdir in which to search for view script
+     * @param string|null $action Defaults to action registered in request object
+     * @param bool|null $noController  Defaults to false; i.e. use controller name as subdir in which to search for view script
      * @return string
      * @throws Zend_Controller_Exception with bad $action
      */
-    public function getViewScript($action = null, $noController = null)
+    public function getViewScript(?string $action = null, ?bool $noController = null): string
     {
         if (!$this->getInvokeArg('noViewRenderer') && $this->_helper->hasHelper('viewRenderer')) {
             $viewRenderer = $this->_helper->getHelper('viewRenderer');
@@ -308,7 +310,7 @@ abstract class Zend_Controller_Action implements Zend_Controller_Action_Interfac
      *
      * @return Zend_Controller_Request_Abstract
      */
-    public function getRequest()
+    public function getRequest(): ?Zend_Controller_Request_Abstract
     {
         return $this->_request;
     }
@@ -319,7 +321,7 @@ abstract class Zend_Controller_Action implements Zend_Controller_Action_Interfac
      * @param Zend_Controller_Request_Abstract $request
      * @return Zend_Controller_Action
      */
-    public function setRequest(Zend_Controller_Request_Abstract $request)
+    public function setRequest(Zend_Controller_Request_Abstract $request): Zend_Controller_Action
     {
         $this->_request = $request;
         return $this;
@@ -330,7 +332,7 @@ abstract class Zend_Controller_Action implements Zend_Controller_Action_Interfac
      *
      * @return Zend_Controller_Response_Abstract
      */
-    public function getResponse()
+    public function getResponse(): ?Zend_Controller_Response_Abstract
     {
         return $this->_response;
     }
@@ -341,7 +343,7 @@ abstract class Zend_Controller_Action implements Zend_Controller_Action_Interfac
      * @param Zend_Controller_Response_Abstract $response
      * @return Zend_Controller_Action
      */
-    public function setResponse(Zend_Controller_Response_Abstract $response)
+    public function setResponse(Zend_Controller_Response_Abstract $response): Zend_Controller_Action
     {
         $this->_response = $response;
         return $this;
@@ -353,7 +355,7 @@ abstract class Zend_Controller_Action implements Zend_Controller_Action_Interfac
      * @param array $args
      * @return Zend_Controller_Action
      */
-    protected function _setInvokeArgs(array $args = [])
+    protected function _setInvokeArgs(array $args = []): Zend_Controller_Action
     {
         $this->_invokeArgs = $args;
         return $this;
@@ -364,7 +366,7 @@ abstract class Zend_Controller_Action implements Zend_Controller_Action_Interfac
      *
      * @return array
      */
-    public function getInvokeArgs()
+    public function getInvokeArgs(): array
     {
         return $this->_invokeArgs;
     }
@@ -375,7 +377,7 @@ abstract class Zend_Controller_Action implements Zend_Controller_Action_Interfac
      * @param string $key
      * @return mixed
      */
-    public function getInvokeArg($key)
+    public function getInvokeArg(string $key)
     {
         if (isset($this->_invokeArgs[$key])) {
             return $this->_invokeArgs[$key];
@@ -387,10 +389,10 @@ abstract class Zend_Controller_Action implements Zend_Controller_Action_Interfac
     /**
      * Get a helper by name
      *
-     * @param  string $helperName
+     * @param string $helperName
      * @return Zend_Controller_Action_Helper_Abstract
      */
-    public function getHelper($helperName)
+    public function getHelper(string $helperName): Zend_Controller_Action_Helper_Abstract
     {
         return $this->_helper->{$helperName};
     }
@@ -398,10 +400,10 @@ abstract class Zend_Controller_Action implements Zend_Controller_Action_Interfac
     /**
      * Get a clone of a helper by name
      *
-     * @param  string $helperName
+     * @param string $helperName
      * @return Zend_Controller_Action_Helper_Abstract
      */
-    public function getHelperCopy($helperName)
+    public function getHelperCopy(string $helperName): Zend_Controller_Action_Helper_Abstract
     {
         return clone $this->_helper->{$helperName};
     }
@@ -412,7 +414,7 @@ abstract class Zend_Controller_Action implements Zend_Controller_Action_Interfac
      * @param Zend_Controller_Front $front
      * @return Zend_Controller_Action
      */
-    public function setFrontController(Zend_Controller_Front $front)
+    public function setFrontController(Zend_Controller_Front $front): Zend_Controller_Action
     {
         $this->_frontController = $front;
         return $this;
@@ -422,8 +424,9 @@ abstract class Zend_Controller_Action implements Zend_Controller_Action_Interfac
      * Retrieve Front Controller
      *
      * @return Zend_Controller_Front
+     * @throws Zend_Controller_Exception
      */
-    public function getFrontController()
+    public function getFrontController(): Zend_Controller_Front
     {
         // Used cache version if found
         if (null !== $this->_frontController) {
@@ -478,12 +481,12 @@ abstract class Zend_Controller_Action implements Zend_Controller_Action_Interfac
      * overridden to implement magic (dynamic) actions, or provide run-time
      * dispatching.
      *
-     * @param  string $methodName
-     * @param  array $args
+     * @param string $methodName
+     * @param array $args
      * @return void
      * @throws Zend_Controller_Action_Exception
      */
-    public function __call($methodName, $args)
+    public function __call(string $methodName, array $args)
     {
         require_once 'Zend/Controller/Action/Exception.php';
         if ('Action' == substr($methodName, -6)) {
@@ -499,6 +502,7 @@ abstract class Zend_Controller_Action implements Zend_Controller_Action_Interfac
      *
      * @param string $action Method name of action
      * @return void
+     * @throws Zend_Controller_Action_Exception
      */
     public function dispatch($action)
     {
@@ -551,8 +555,9 @@ abstract class Zend_Controller_Action implements Zend_Controller_Action_Interfac
      * @param null|Zend_Controller_Response_Abstract $response Optional response
      * object to use
      * @return Zend_Controller_Response_Abstract
+     * @throws Zend_Controller_Action_Exception
      */
-    public function run(Zend_Controller_Request_Abstract $request = null, Zend_Controller_Response_Abstract $response = null)
+    public function run(Zend_Controller_Request_Abstract $request = null, Zend_Controller_Response_Abstract $response = null): ?Zend_Controller_Response_Abstract
     {
         if (null !== $request) {
             $this->setRequest($request);
@@ -587,7 +592,7 @@ abstract class Zend_Controller_Action implements Zend_Controller_Action_Interfac
      * @param mixed $default
      * @return mixed
      */
-    protected function _getParam($paramName, $default = null)
+    protected function _getParam(string $paramName, $default = null)
     {
         return $this->getParam($paramName, $default);
     }
@@ -603,7 +608,7 @@ abstract class Zend_Controller_Action implements Zend_Controller_Action_Interfac
      * @param mixed $default
      * @return mixed
      */
-    public function getParam($paramName, $default = null)
+    public function getParam(string $paramName, $default = null)
     {
         $value = $this->getRequest()->getParam($paramName);
          if ((null === $value || '' === $value) && (null !== $default)) {
@@ -622,7 +627,7 @@ abstract class Zend_Controller_Action implements Zend_Controller_Action_Interfac
      * @deprecated Deprecated as of Zend Framework 1.7. Use
      *             setParam() instead.
      */
-    protected function _setParam($paramName, $value)
+    protected function _setParam(string $paramName, $value): Zend_Controller_Action
     {
         return $this->setParam($paramName, $value);
     }
@@ -634,7 +639,7 @@ abstract class Zend_Controller_Action implements Zend_Controller_Action_Interfac
      * @param mixed $value
      * @return Zend_Controller_Action
      */
-    public function setParam($paramName, $value)
+    public function setParam(string $paramName, $value): Zend_Controller_Action
     {
         $this->getRequest()->setParam($paramName, $value);
 
@@ -650,7 +655,7 @@ abstract class Zend_Controller_Action implements Zend_Controller_Action_Interfac
      * @deprecated Deprecated as of Zend Framework 1.7. Use
      *             hasParam() instead.
      */
-    protected function _hasParam($paramName)
+    protected function _hasParam(string $paramName): bool
     {
         return $this->hasParam($paramName);
     }
@@ -662,7 +667,7 @@ abstract class Zend_Controller_Action implements Zend_Controller_Action_Interfac
      * @param string $paramName
      * @return boolean
      */
-    public function hasParam($paramName)
+    public function hasParam(string $paramName): bool
     {
         return null !== $this->getRequest()->getParam($paramName);
     }
@@ -675,7 +680,7 @@ abstract class Zend_Controller_Action implements Zend_Controller_Action_Interfac
      * @deprecated Deprecated as of Zend Framework 1.7. Use
      *             getAllParams() instead.
      */
-    protected function _getAllParams()
+    protected function _getAllParams(): array
     {
         return $this->getAllParams();
     }
@@ -686,7 +691,7 @@ abstract class Zend_Controller_Action implements Zend_Controller_Action_Interfac
      *
      * @return array
      */
-    public function getAllParams()
+    public function getAllParams(): array
     {
         return $this->getRequest()->getParams();
     }
@@ -713,14 +718,14 @@ abstract class Zend_Controller_Action implements Zend_Controller_Action_Interfac
      * simply pass null values for them before specifying the parameters.
      *
      * @param string $action
-     * @param string $controller
-     * @param string $module
-     * @param array $params
+     * @param string|null $controller
+     * @param string|null $module
+     * @param array|null $params
      * @return void
      * @deprecated Deprecated as of Zend Framework 1.7. Use
      *             forward() instead.
      */
-    final protected function _forward($action, $controller = null, $module = null, array $params = null)
+    final protected function _forward(string $action, ?string $controller = null, ?string $module = null, array $params = null): void
     {
         $this->forward($action, $controller, $module, $params);
     }
@@ -746,12 +751,12 @@ abstract class Zend_Controller_Action implements Zend_Controller_Action_Interfac
      * simply pass null values for them before specifying the parameters.
      *
      * @param string $action
-     * @param string $controller
-     * @param string $module
-     * @param array $params
+     * @param string|null $controller
+     * @param string|null $module
+     * @param array|null $params
      * @return void
      */
-    final public function forward($action, $controller = null, $module = null, array $params = null)
+    final public function forward(string $action, ?string $controller = null, ?string $module = null, array $params = null): void
     {
         $request = $this->getRequest();
 
@@ -783,7 +788,7 @@ abstract class Zend_Controller_Action implements Zend_Controller_Action_Interfac
      * @deprecated Deprecated as of Zend Framework 1.7. Use
      *             redirect() instead.
      */
-    protected function _redirect($url, array $options = [])
+    protected function _redirect(string $url, array $options = []): void
     {
         $this->redirect($url, $options);
     }
@@ -797,7 +802,7 @@ abstract class Zend_Controller_Action implements Zend_Controller_Action_Interfac
      * @param array $options Options to be used when redirecting
      * @return void
      */
-    public function redirect($url, array $options = [])
+    public function redirect(string $url, array $options = []): void
     {
         $this->_helper->redirector->gotoUrl($url, $options);
     }

--- a/library/Zend/Controller/Action.php
+++ b/library/Zend/Controller/Action.php
@@ -45,13 +45,13 @@ abstract class Zend_Controller_Action implements Zend_Controller_Action_Interfac
     /**
      * @var array of existing class methods
      */
-    protected array $_classMethods;
+    protected $_classMethods = [];
 
     /**
      * Word delimiters (used for normalizing view script paths)
      * @var array
      */
-    protected $_delimiters;
+    protected $_delimiters = [];
 
     /**
      * Array of arguments provided to the constructor, minus the

--- a/library/Zend/Controller/Action.php
+++ b/library/Zend/Controller/Action.php
@@ -45,7 +45,7 @@ abstract class Zend_Controller_Action implements Zend_Controller_Action_Interfac
     /**
      * @var array of existing class methods
      */
-    protected $_classMethods;
+    protected array $_classMethods;
 
     /**
      * Word delimiters (used for normalizing view script paths)
@@ -92,10 +92,10 @@ abstract class Zend_Controller_Action implements Zend_Controller_Action_Interfac
     public $view;
 
     /**
-     * compataibility for php 8.2 to stop error Deprecated: Creation of dynamic property 
-     * @var object 
+     * compataibility for php 8.2 to stop error Deprecated: Creation of dynamic property
+     * @var object
      */
-    public  $contexts = null; 
+    public  $contexts = null;
     
     /**
      * Helper Broker to assist in routing help requests to the proper object
@@ -215,7 +215,7 @@ abstract class Zend_Controller_Action implements Zend_Controller_Action_Interfac
     public function render($action = null, $name = null, $noController = false)
     {
         if (!$this->getInvokeArg('noViewRenderer') && $this->_helper->hasHelper('viewRenderer')) {
-            return $this->_helper->viewRenderer->render($action, $name, $noController);
+            $this->_helper->viewRenderer->render($action, $name, $noController);
         }
 
         $view   = $this->initView();
@@ -246,7 +246,7 @@ abstract class Zend_Controller_Action implements Zend_Controller_Action_Interfac
     public function renderScript($script, $name = null)
     {
         if (!$this->getInvokeArg('noViewRenderer') && $this->_helper->hasHelper('viewRenderer')) {
-            return $this->_helper->viewRenderer->renderScript($script, $name);
+            $this->_helper->viewRenderer->renderScript($script, $name);
         }
 
         $view = $this->initView();

--- a/library/Zend/Controller/Action.php
+++ b/library/Zend/Controller/Action.php
@@ -93,7 +93,7 @@ abstract class Zend_Controller_Action implements Zend_Controller_Action_Interfac
 
     /**
      * compataibility for php 8.2 to stop error Deprecated: Creation of dynamic property
-     * @var object
+     * @var object|null
      */
     public  $contexts = null;
     

--- a/library/Zend/Session/SaveHandler/DbTable.php
+++ b/library/Zend/Session/SaveHandler/DbTable.php
@@ -227,7 +227,7 @@ class Zend_Session_SaveHandler_DbTable
      * @return Zend_Session_SaveHandler_DbTable
      * @throws Zend_Session_SaveHandler_Exception
      */
-    public function setLifetime($lifetime, $overrideLifetime = null)
+    public function setLifetime(int $lifetime, ?bool $overrideLifetime = null): Zend_Session_SaveHandler_DbTable
     {
         if ($lifetime < 0) {
             /**
@@ -240,7 +240,7 @@ class Zend_Session_SaveHandler_DbTable
         if (empty($lifetime)) {
             $this->_lifetime = (int) ini_get('session.gc_maxlifetime');
         } else {
-            $this->_lifetime = (int) $lifetime;
+            $this->_lifetime = $lifetime;
         }
 
         if ($overrideLifetime != null) {
@@ -266,9 +266,9 @@ class Zend_Session_SaveHandler_DbTable
      * @param boolean $overrideLifetime
      * @return Zend_Session_SaveHandler_DbTable
      */
-    public function setOverrideLifetime($overrideLifetime)
+    public function setOverrideLifetime(bool $overrideLifetime): Zend_Session_SaveHandler_DbTable
     {
-        $this->_overrideLifetime = (boolean) $overrideLifetime;
+        $this->_overrideLifetime = $overrideLifetime;
 
         return $this;
     }
@@ -313,6 +313,7 @@ class Zend_Session_SaveHandler_DbTable
      *
      * @param string $id
      * @return string
+     * @throws Zend_Db_Table_Exception
      */
     public function read($id): string
     {
@@ -337,6 +338,7 @@ class Zend_Session_SaveHandler_DbTable
      * @param string $id
      * @param string $data
      * @return boolean
+     * @throws Zend_Db_Table_Exception
      */
     public function write($id, $data): bool
     {
@@ -365,6 +367,7 @@ class Zend_Session_SaveHandler_DbTable
      *
      * @param string $id
      * @return boolean
+     * @throws Zend_Db_Table_Exception
      */
     public function destroy($id): bool
     {
@@ -391,6 +394,7 @@ class Zend_Session_SaveHandler_DbTable
      * Calls other protected methods for individual setup tasks and requirement checks
      *
      * @return void
+     * @throws Zend_Session_SaveHandler_Exception
      */
     protected function _setup(): void
     {
@@ -420,7 +424,7 @@ class Zend_Session_SaveHandler_DbTable
         }
 
         if (strpos($this->_name, '.')) {
-            list($this->_schema, $this->_name) = explode('.', $this->_name);
+            [$this->_schema, $this->_name] = explode('.', $this->_name);
         }
     }
 
@@ -528,7 +532,7 @@ class Zend_Session_SaveHandler_DbTable
                     $value = $this->_sessionName;
                     break;
                 case self::PRIMARY_ASSIGNMENT_SESSION_ID:
-                    $value = (string) $id;
+                    $value = $id;
                     break;
                 default:
                     $value = (string) $this->_primaryAssignment[$index];
@@ -581,6 +585,6 @@ class Zend_Session_SaveHandler_DbTable
      */
     protected function _getExpirationTime(Zend_Db_Table_Row_Abstract $row): int
     {
-        return (int) $row->{$this->_modifiedColumn} + (int) $this->_getLifetime($row);
+        return (int) $row->{$this->_modifiedColumn} + $this->_getLifetime($row);
     }
 }

--- a/library/Zend/Session/SaveHandler/DbTable.php
+++ b/library/Zend/Session/SaveHandler/DbTable.php
@@ -73,35 +73,35 @@ class Zend_Session_SaveHandler_DbTable
     /**
      * Session table primary key value assignment
      *
-     * @var array
+     * @var array|null
      */
     protected $_primaryAssignment = null;
 
     /**
      * Session table last modification time column
      *
-     * @var string
+     * @var string|null
      */
     protected $_modifiedColumn = null;
 
     /**
      * Session table lifetime column
      *
-     * @var string
+     * @var string|null
      */
     protected $_lifetimeColumn = null;
 
     /**
      * Session table data column
      *
-     * @var string
+     * @var string|null
      */
     protected $_dataColumn = null;
 
     /**
      * Session lifetime
      *
-     * @var int
+     * @var int|false
      */
     protected $_lifetime = false;
 
@@ -223,7 +223,7 @@ class Zend_Session_SaveHandler_DbTable
      * $lifetime === false resets lifetime to session.gc_maxlifetime
      *
      * @param int $lifetime
-     * @param boolean $overrideLifetime (optional)
+     * @param boolean|null $overrideLifetime (optional)
      * @return Zend_Session_SaveHandler_DbTable
      * @throws Zend_Session_SaveHandler_Exception
      */
@@ -253,7 +253,7 @@ class Zend_Session_SaveHandler_DbTable
     /**
      * Retrieve session lifetime
      *
-     * @return int
+     * @return bool|int
      */
     public function getLifetime()
     {
@@ -278,7 +278,7 @@ class Zend_Session_SaveHandler_DbTable
      *
      * @return boolean
      */
-    public function getOverrideLifetime()
+    public function getOverrideLifetime(): bool
     {
         return $this->_overrideLifetime;
     }
@@ -290,7 +290,7 @@ class Zend_Session_SaveHandler_DbTable
      * @param string $name
      * @return boolean
      */
-    public function open($save_path, $name)
+    public function open($save_path, $name): bool
     {
         $this->_sessionSavePath = $save_path;
         $this->_sessionName     = $name;
@@ -303,7 +303,7 @@ class Zend_Session_SaveHandler_DbTable
      *
      * @return boolean
      */
-    public function close()
+    public function close(): bool
     {
         return true;
     }
@@ -314,7 +314,7 @@ class Zend_Session_SaveHandler_DbTable
      * @param string $id
      * @return string
      */
-    public function read($id)
+    public function read($id): string
     {
         $return = '';
 
@@ -338,7 +338,7 @@ class Zend_Session_SaveHandler_DbTable
      * @param string $data
      * @return boolean
      */
-    public function write($id, $data)
+    public function write($id, $data): bool
     {
         $data = [$this->_modifiedColumn => time(),
                       $this->_dataColumn     => (string) $data];
@@ -366,7 +366,7 @@ class Zend_Session_SaveHandler_DbTable
      * @param string $id
      * @return boolean
      */
-    public function destroy($id)
+    public function destroy($id): bool
     {
         $this->delete($this->_getPrimary($id, self::PRIMARY_TYPE_WHERECLAUSE));
         return true; //always return true, since if nothing can be deleted, it is already deleted and thats OK.
@@ -378,7 +378,7 @@ class Zend_Session_SaveHandler_DbTable
      * @param int $maxlifetime
      * @return true
      */
-    public function gc($maxlifetime)
+    public function gc($maxlifetime): bool
     {
         $this->delete($this->getAdapter()->quoteIdentifier($this->_modifiedColumn, true) . ' + '
                     . $this->getAdapter()->quoteIdentifier($this->_lifetimeColumn, true) . ' < '
@@ -392,7 +392,7 @@ class Zend_Session_SaveHandler_DbTable
      *
      * @return void
      */
-    protected function _setup()
+    protected function _setup(): void
     {
         parent::_setup();
 
@@ -408,7 +408,7 @@ class Zend_Session_SaveHandler_DbTable
      * @return void
      * @throws Zend_Session_SaveHandler_Exception
      */
-    protected function _setupTableName()
+    protected function _setupTableName(): void
     {
         if (empty($this->_name) && basename(($this->_name = session_save_path())) != $this->_name) {
             /**
@@ -430,7 +430,7 @@ class Zend_Session_SaveHandler_DbTable
      * @return void
      * @throws Zend_Session_SaveHandler_Exception
      */
-    protected function _setupPrimaryAssignment()
+    protected function _setupPrimaryAssignment(): void
     {
         if ($this->_primaryAssignment === null) {
             $this->_primaryAssignment = [1 => self::PRIMARY_ASSIGNMENT_SESSION_ID];
@@ -469,7 +469,7 @@ class Zend_Session_SaveHandler_DbTable
      * @return void
      * @throws Zend_Session_SaveHandler_Exception
      */
-    protected function _checkRequiredColumns()
+    protected function _checkRequiredColumns(): void
     {
         if ($this->_modifiedColumn === null) {
             /**
@@ -505,10 +505,11 @@ class Zend_Session_SaveHandler_DbTable
      * Retrieve session table primary key values
      *
      * @param string $id
-     * @param string $type (optional; default: self::PRIMARY_TYPE_NUM)
+     * @param string|null $type (optional; default: self::PRIMARY_TYPE_NUM)
      * @return array
+     * @throws Zend_Db_Table_Exception
      */
-    protected function _getPrimary($id, $type = null)
+    protected function _getPrimary(string $id, ?string $type = null): array
     {
         $this->_setupPrimaryKey();
 
@@ -561,7 +562,7 @@ class Zend_Session_SaveHandler_DbTable
      * @param Zend_Db_Table_Row_Abstract $row
      * @return int
      */
-    protected function _getLifetime(Zend_Db_Table_Row_Abstract $row)
+    protected function _getLifetime(Zend_Db_Table_Row_Abstract $row): int
     {
         $return = $this->_lifetime;
 
@@ -578,8 +579,8 @@ class Zend_Session_SaveHandler_DbTable
      * @param Zend_Db_Table_Row_Abstract $row
      * @return int
      */
-    protected function _getExpirationTime(Zend_Db_Table_Row_Abstract $row)
+    protected function _getExpirationTime(Zend_Db_Table_Row_Abstract $row): int
     {
-        return (int) $row->{$this->_modifiedColumn} + $this->_getLifetime($row);
+        return (int) $row->{$this->_modifiedColumn} + (int) $this->_getLifetime($row);
     }
 }


### PR DESCRIPTION
I was getting deprecation notices after updating a project to PHP 8.2. 
Have added type hints and property defaults along with a general code tidy on the worked files.