### PR TITLE
Fix deprecated usage of string functions in `BaseUrl` helper.

### DIFF
--- a/library/Zend/Controller/Front.php
+++ b/library/Zend/Controller/Front.php
@@ -559,7 +559,7 @@ class Zend_Controller_Front
     /**
      * Retrieve the currently set base URL
      *
-     * @return string
+     * @return string|null
      */
     public function getBaseUrl()
     {

--- a/library/Zend/View/Helper/BaseUrl.php
+++ b/library/Zend/View/Helper/BaseUrl.php
@@ -69,7 +69,7 @@ class Zend_View_Helper_BaseUrl extends Zend_View_Helper_Abstract
      */
     public function setBaseUrl($base)
     {
-        $this->_baseUrl = rtrim($base, '/\\');
+        $this->_baseUrl = rtrim($base ?? '', '/\\');
         return $this;
     }
 
@@ -105,6 +105,10 @@ class Zend_View_Helper_BaseUrl extends Zend_View_Helper_Abstract
         if (!isset($_SERVER['SCRIPT_NAME'])) {
             // We can't do much now can we? (Well, we could parse out by ".")
             return $url;
+        }
+
+        if ($url === null) {
+            return null;
         }
 
         if (($pos = strripos($url, basename($_SERVER['SCRIPT_NAME']))) !== false) {

--- a/library/Zend/View/Helper/BaseUrl.php
+++ b/library/Zend/View/Helper/BaseUrl.php
@@ -64,7 +64,7 @@ class Zend_View_Helper_BaseUrl extends Zend_View_Helper_Abstract
     /**
      * Set BaseUrl
      *
-     * @param  string $base
+     * @param  string|null $base
      * @return Zend_View_Helper_BaseUrl
      */
     public function setBaseUrl($base)
@@ -97,8 +97,8 @@ class Zend_View_Helper_BaseUrl extends Zend_View_Helper_Abstract
     /**
      * Remove Script filename from baseurl
      *
-     * @param  string $url
-     * @return string
+     * @param  string|null $url
+     * @return string|null
      */
     protected function _removeScriptName($url)
     {


### PR DESCRIPTION
Currently, the `BaseUrl` helper can use string functions (`strripos`, `rtrim`) on `null`, which emits a deprecation message.
I've created a fix to avoid that from happening in case that the `baseUrl` can't be determined and has to stay `null`.