### PR TITLE
Fix deprecation message in php8 with null param with realpath()

### DIFF
--- a/bin/classmap_generator.php
+++ b/bin/classmap_generator.php
@@ -92,6 +92,8 @@ if (isset($opts->l)) {
         exit(2);
     }
     $libraryPath = $opts->l;
+} else {
+    $libraryPath = '.';
 }
 $libraryPath = str_replace(DIRECTORY_SEPARATOR, '/', realpath($libraryPath));
 


### PR DESCRIPTION
Fixes deprecation message when running on php8

`Deprecated: realpath(): Passing null to parameter #1 ($path) of type string is deprecated in XXX`