### PR TITLE
Add check in DbTable Authentication Adapter for empty results when AmbiguityIdentity is TRUE

### DIFF
--- a/library/Zend/Auth/Adapter/DbTable.php
+++ b/library/Zend/Auth/Adapter/DbTable.php
@@ -527,8 +527,12 @@ class Zend_Auth_Adapter_DbTable implements Zend_Auth_Adapter_Interface
     protected function _authenticateValidateResult($resultIdentity)
     {
         $zendAuthCredentialMatchColumn = $this->_zendDb->foldCase('zend_auth_credential_match');
-
-        if ($resultIdentity[$zendAuthCredentialMatchColumn] != '1') {
+        
+        if (empty($resultIdentity)) {
+            $this->_authenticateResultInfo['code'] = Zend_Auth_Result::FAILURE_IDENTITY_NOT_FOUND;
+            $this->_authenticateResultInfo['messages'][] = 'A record with the supplied identity could not be found.';
+            return $this->_authenticateCreateAuthResult();
+        } elseif ($resultIdentity[$zendAuthCredentialMatchColumn] != '1') {
             $this->_authenticateResultInfo['code'] = Zend_Auth_Result::FAILURE_CREDENTIAL_INVALID;
             $this->_authenticateResultInfo['messages'][] = 'Supplied credential is invalid.';
             return $this->_authenticateCreateAuthResult();


### PR DESCRIPTION
Add check in DbTable Authentication Adapter for empty results when AmbiguityIdentity is TRUE

fixes #417 

Previously, _authenticateValidateResult expected a valid identity record to be passed as an argument, leading to an error when AmbiguityIdentity is TRUE but no matching identity records were found. Now, it gracefully handles the condition and sends the same failure message that _authenticateValidateResultSet sends when no matching records are found.