### PR TITLE
Support for PHP 8.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Installable through git clone or through
 `composer require shardj/zf1-future` https://packagist.org/packages/shardj/zf1-future  
 
 # System Requirements
-ZF1 Future runs on any version of PHP between 7.1 and 8.1! (see composer.json)
+ZF1 Future runs on any version of PHP between 7.1 and 8.2! (see composer.json)
 
 # License
 The files in this archive are released under the Zend Framework license. You can find a copy of this license in [LICENSE.txt](LICENSE.txt).

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Installable through git clone or through
 `composer require shardj/zf1-future` https://packagist.org/packages/shardj/zf1-future  
 
 # System Requirements
-ZF1 Future runs on any version of PHP between 7.1 and 8.2! (see composer.json)
+ZF1 Future runs on any version of PHP between 7.1 and 8.1! (see composer.json)
 
 # License
 The files in this archive are released under the Zend Framework license. You can find a copy of this license in [LICENSE.txt](LICENSE.txt).

--- a/composer.json
+++ b/composer.json
@@ -37,8 +37,8 @@
     "require-dev": {
         "phpunit/phpunit": "^7|^8|^9",
         "php-parallel-lint/php-parallel-lint": "^1.3",
-        "rector/rector": "^0.12.19",
-        "yoast/phpunit-polyfills": "2.0"
+        "yoast/phpunit-polyfills": "2.0",
+        "rector/rector": "^1.2"
     },
     "archive": {
         "exclude": ["/demos", "/documentation", "/tests"]

--- a/library/Zend/Http/UserAgent/AbstractDevice.php
+++ b/library/Zend/Http/UserAgent/AbstractDevice.php
@@ -301,7 +301,7 @@ abstract class Zend_Http_UserAgent_AbstractDevice
         $server = [];
 
         // gets info from user agent chain
-        $uaExtract = $this->extractFromUserAgent($this->getUserAgent());
+        $uaExtract = static::extractFromUserAgent($this->getUserAgent());
 
         if (is_array($uaExtract)) {
             foreach ($uaExtract as $key => $info) {

--- a/library/Zend/Locale/Format.php
+++ b/library/Zend/Locale/Format.php
@@ -807,7 +807,7 @@ class Zend_Locale_Format
             }
         }
 
-        return implode($converted);
+        return implode('', $converted);
     }
 
     /**

--- a/library/Zend/Markup/Renderer/RendererAbstract.php
+++ b/library/Zend/Markup/Renderer/RendererAbstract.php
@@ -126,7 +126,7 @@ abstract class Zend_Markup_Renderer_RendererAbstract
         }
 
         if (isset($options['encoding'])) {
-            $this->setEncoding($options['encoding']);
+            static::setEncoding($options['encoding']);
         }
         if (isset($options['parser'])) {
             $this->setParser($options['parser']);

--- a/library/Zend/Pdf/Action/URI.php
+++ b/library/Zend/Pdf/Action/URI.php
@@ -107,7 +107,7 @@ class Zend_Pdf_Action_URI extends Zend_Pdf_Action
      */
     public function setUri($uri)
     {
-        $this->_validateUri($uri);
+        static::_validateUri($uri);
 
         $this->_actionDictionary->touch();
         $this->_actionDictionary->URI = new Zend_Pdf_Element_String($uri);

--- a/library/Zend/Pdf/Element.php
+++ b/library/Zend/Pdf/Element.php
@@ -29,6 +29,7 @@
  */
 abstract class Zend_Pdf_Element
 {
+    public $value;
     const TYPE_BOOL        = 1;
     const TYPE_NUMERIC     = 2;
     const TYPE_STRING      = 3;

--- a/library/Zend/Pdf/Element/String.php
+++ b/library/Zend/Pdf/Element/String.php
@@ -257,7 +257,7 @@ class Zend_Pdf_Element_String extends Zend_Pdf_Element
             }
         }
 
-        return implode($outEntries);
+        return implode('', $outEntries);
     }
 
 }

--- a/library/Zend/Pdf/Element/String/Binary.php
+++ b/library/Zend/Pdf/Element/String/Binary.php
@@ -81,7 +81,7 @@ class Zend_Pdf_Element_String_Binary extends Zend_Pdf_Element_String
             $chunks[] = '0';
         }
 
-        return pack('H*' , implode($chunks));
+        return pack('H*' , implode('', $chunks));
     }
 
 

--- a/library/Zend/Search/Lucene/Document/Html.php
+++ b/library/Zend/Search/Lucene/Document/Html.php
@@ -478,6 +478,6 @@ class Zend_Search_Lucene_Document_Html extends Zend_Search_Lucene_Document
             $outputFragments[] = $this->_doc->saveXML($bodyNodes->item($count));
         }
 
-        return implode($outputFragments);
+        return implode('', $outputFragments);
     }
 }

--- a/library/Zend/Service/Rackspace/Files/Container.php
+++ b/library/Zend/Service/Rackspace/Files/Container.php
@@ -24,6 +24,7 @@ require_once 'Zend/Service/Rackspace/Files.php';
 
 class Zend_Service_Rackspace_Files_Container
 {
+    public $service;
     const ERROR_PARAM_FILE_CONSTRUCT = 'The Zend_Service_Rackspace_Files passed in construction is not valid';
 
     const ERROR_PARAM_ARRAY_CONSTRUCT = 'The array passed in construction is not valid';

--- a/library/Zend/Service/WindowsAzure/Storage/Blob.php
+++ b/library/Zend/Service/WindowsAzure/Storage/Blob.php
@@ -1127,7 +1127,7 @@ class Zend_Service_WindowsAzure_Storage_Blob extends Zend_Service_WindowsAzure_S
 		$size = strlen($contents);
 		if ($size >= self::MAX_BLOB_TRANSFER_SIZE) {
 			require_once 'Zend/Service/WindowsAzure/Exception.php';
-			throw new Zend_Service_WindowsAzure_Exception('Page blob size must not be larger than ' + self::MAX_BLOB_TRANSFER_SIZE . ' bytes.');
+			throw new Zend_Service_WindowsAzure_Exception('Page blob size must not be larger than ' . self::MAX_BLOB_TRANSFER_SIZE . ' bytes.');
 		}
 
 		// Create metadata headers

--- a/library/Zend/Soap/Client/Local.php
+++ b/library/Zend/Soap/Client/Local.php
@@ -42,6 +42,7 @@ if (extension_loaded('soap')) {
  */
 class Zend_Soap_Client_Local extends Zend_Soap_Client
 {
+    public $server;
     /**
      * Server object
      *

--- a/library/Zend/Validate/Abstract.php
+++ b/library/Zend/Validate/Abstract.php
@@ -233,7 +233,7 @@ abstract class Zend_Validate_Abstract implements Zend_Validate_Interface
         } elseif (is_array($value)) {
             $value = $this->_implodeRecursive($value);
         } else {
-            $value = implode((array) $value);
+            $value = implode('', (array) $value);
         }
 
         if ($this->getObscureValue()) {

--- a/library/Zend/Validate/Hostname.php
+++ b/library/Zend/Validate/Hostname.php
@@ -2421,6 +2421,6 @@ class Zend_Validate_Hostname extends Zend_Validate_Abstract
             }
         }
 
-        return implode($decoded);
+        return implode('', $decoded);
     }
 }

--- a/library/Zend/Wildfire/Plugin/FirePhp.php
+++ b/library/Zend/Wildfire/Plugin/FirePhp.php
@@ -816,10 +816,7 @@ class Zend_Wildfire_Plugin_FirePhp implements Zend_Wildfire_Plugin_Interface
 
         foreach( $this->_messages as $message ) {
             if (!$message->getDestroy()) {
-                $this->send($message->getMessage(),
-                            $message->getLabel(),
-                            $message->getStyle(),
-                            $message->getOptions());
+                static::send($message->getMessage(), $message->getLabel(), $message->getStyle(), $message->getOptions());
             }
         }
 

--- a/library/Zend/Wildfire/Plugin/FirePhp.php
+++ b/library/Zend/Wildfire/Plugin/FirePhp.php
@@ -46,6 +46,7 @@ require_once 'Zend/Wildfire/Plugin/Interface.php';
  */
 class Zend_Wildfire_Plugin_FirePhp implements Zend_Wildfire_Plugin_Interface
 {
+    public $objectFilters;
     /**
      * Plain log style.
      */

--- a/library/Zend/XmlRpc/Value.php
+++ b/library/Zend/XmlRpc/Value.php
@@ -158,7 +158,7 @@ abstract class Zend_XmlRpc_Value
     {
         if (!$this->_xml) {
             $this->generateXml();
-            $this->_xml = (string) $this->getGenerator();
+            $this->_xml = (string) static::getGenerator();
         }
         return $this->_xml;
     }
@@ -526,6 +526,6 @@ abstract class Zend_XmlRpc_Value
      */
     protected function _setXML($xml)
     {
-        $this->_xml = $this->getGenerator()->stripDeclaration($xml);
+        $this->_xml = static::getGenerator()->stripDeclaration($xml);
     }
 }

--- a/rector.php
+++ b/rector.php
@@ -4,7 +4,21 @@ declare(strict_types=1);
 
 use Rector\CodeQuality\Rector\Class_\CompleteDynamicPropertiesRector;
 use Rector\Config\RectorConfig;
+use Rector\Php53\Rector\FuncCall\DirNameFileConstantToDirConstantRector;
+use Rector\Php53\Rector\Ternary\TernaryToElvisRector;
+use Rector\Php54\Rector\Array_\LongArrayToShortArrayRector;
+use Rector\Php55\Rector\Class_\ClassConstantToSelfClassRector;
+use Rector\Php55\Rector\String_\StringClassNameToClassConstantRector;
+use Rector\Php56\Rector\FuncCall\PowToExpRector;
+use Rector\Php70\Rector\FuncCall\MultiDirnameRector;
+use Rector\Php70\Rector\FuncCall\RandomFunctionRector;
+use Rector\Php70\Rector\StmtsAwareInterface\IfIssetToCoalescingRector;
+use Rector\Php70\Rector\Ternary\TernaryToNullCoalescingRector;
+use Rector\Php70\Rector\Variable\WrapVariableVariableNameInCurlyBracesRector;
+use Rector\Php71\Rector\FuncCall\RemoveExtraParametersRector;
+use Rector\Php71\Rector\List_\ListToArrayDestructRector;
 use Rector\Set\ValueObject\LevelSetList;
+use Rector\ValueObject\PhpVersion;
 
 return static function (RectorConfig $rectorConfig): void {
     $rectorConfig->paths([
@@ -15,9 +29,27 @@ return static function (RectorConfig $rectorConfig): void {
     // register a single rule
     // https://github.com/rectorphp/rector/blob/main/docs/rector_rules_overview.md#completedynamicpropertiesrector
     $rectorConfig->rule(CompleteDynamicPropertiesRector::class);
+    $rectorConfig->skip([
+        MultiDirnameRector::class,
+        DirNameFileConstantToDirConstantRector::class,
+        ListToArrayDestructRector::class,
+        ClassConstantToSelfClassRector::class,
+        RemoveExtraParametersRector::class,
+        IfIssetToCoalescingRector::class,
+        StringClassNameToClassConstantRector::class,
+        TernaryToElvisRector::class,
+        RandomFunctionRector::class,
+        LongArrayToShortArrayRector::class,
+        WrapVariableVariableNameInCurlyBracesRector::class,
+        TernaryToNullCoalescingRector::class,
+        PowToExpRector::class,
+        __DIR__ . '/tests/Zend/Loader/_files/ParseError.php',
+    ]);
+    $a = pow(12, 23);
 
     // define sets of rules
-    // $rectorConfig->sets([
-    //     LevelSetList::UP_TO_PHP_82
-    // ]);
+    $rectorConfig->sets([
+        LevelSetList::UP_TO_PHP_82
+    ]);
+    $rectorConfig->phpVersion(PhpVersion::PHP_71);
 };

--- a/tests/Zend/Layout/FunctionalTest.php
+++ b/tests/Zend/Layout/FunctionalTest.php
@@ -57,7 +57,6 @@ class Zend_Layout_FunctionalTest extends Zend_Test_PHPUnit_ControllerTestCase
     protected function set_up()
     {
         $this->bootstrap = [$this, 'appBootstrap'];
-        parent::set_up();
     }
 
     public function appBootstrap()


### PR DESCRIPTION
Updates the codebase utilizing Rector.

* Fixed non-static calls to static methods
* Declared undefined properties
* Fixed bad string concatenation
* Use consistent implode (bonus)