### PR TITLE
Fix PHP Deprecated: Creation of dynamic property $zfBreakChainOnFailure from Zend_Form_Element

### DIFF
--- a/library/Zend/Form/Element.php
+++ b/library/Zend/Form/Element.php
@@ -199,7 +199,11 @@ class Zend_Form_Element implements Zend_Validate_Interface
      */
     protected $_validators = [];
 
-    protected array $_validatorBreakChainOnFailures = [];
+    /**
+     * Flags to break validation chain on failure.
+     * @var array
+     */
+    protected $_validatorBreakChainOnFailures = [];
 
     /**
      * Array of un-initialized validators

--- a/tests/Zend/Form/ElementTest.php
+++ b/tests/Zend/Form/ElementTest.php
@@ -86,6 +86,16 @@ class Zend_Form_ElementTest extends TestCase
     {
     }
 
+    protected function isBreakChainOnFailure(Zend_Form_Element $element, string $validator)
+    {
+        $reflection = new ReflectionClass($element);
+        $property = $reflection->getProperty('_validatorBreakChainOnFailures');
+        $property->setAccessible(true);
+        $breakChainOnFailures = $property->getValue($element);
+
+        return isset($breakChainOnFailures[$validator]) ? $breakChainOnFailures[$validator] : false;
+    }
+
     public function getView()
     {
         $view = new Zend_View();
@@ -325,7 +335,7 @@ class Zend_Form_ElementTest extends TestCase
         $this->assertFalse($this->element->isValid(''));
         $validator = $this->element->getValidator('NotEmpty');
         $this->assertTrue($validator instanceof Zend_Validate_NotEmpty);
-        $this->assertTrue($validator->zfBreakChainOnFailure);
+        $this->assertTrue($this->isBreakChainOnFailure($this->element, get_class($validator)));
     }
 
     /**
@@ -344,9 +354,9 @@ class Zend_Form_ElementTest extends TestCase
         $form->isValid(['username' => '#']);
 
         $validator = $username->getValidator('stringLength');
-        $this->assertTrue($validator->zfBreakChainOnFailure);
+        $this->assertTrue($this->isBreakChainOnFailure($username, get_class($validator)));
         $validator = $username->getValidator('regex');
-        $this->assertTrue($validator->zfBreakChainOnFailure);
+        $this->assertTrue($this->isBreakChainOnFailure($username, get_class($validator)));
     }
 
     public function testAutoInsertNotEmptyValidatorFlagTrueByDefault()
@@ -702,7 +712,7 @@ class Zend_Form_ElementTest extends TestCase
         $this->element->addValidator('digits');
         $validator = $this->element->getValidator('digits');
         $this->assertTrue($validator instanceof Zend_Validate_Digits, var_export($validator, 1));
-        $this->assertFalse($validator->zfBreakChainOnFailure);
+        $this->assertFalse($this->isBreakChainOnFailure($this->element, get_class($validator)));
     }
 
     public function testCanNotRetrieveSingleValidatorRegisteredAsStringUsingClassName()
@@ -722,7 +732,8 @@ class Zend_Form_ElementTest extends TestCase
         $this->element->addValidator($validator);
         $test = $this->element->getValidator('Zend_Validate_Digits');
         $this->assertSame($validator, $test);
-        $this->assertFalse($validator->zfBreakChainOnFailure);
+        $this->assertFalse($this->isBreakChainOnFailure($this->element, get_class($validator)));
+        $this->assertFalse($this->isBreakChainOnFailure($this->element, get_class($test)));
     }
 
     public function testOptionsAreCastToArrayWhenAddingValidator()
@@ -750,7 +761,8 @@ class Zend_Form_ElementTest extends TestCase
         $this->element->addValidator($validator);
         $test = $this->element->getValidator('digits');
         $this->assertSame($validator, $test);
-        $this->assertFalse($validator->zfBreakChainOnFailure);
+        $this->assertFalse($this->isBreakChainOnFailure($this->element, get_class($validator)));
+        $this->assertFalse($this->isBreakChainOnFailure($this->element, get_class($test)));
     }
 
     public function testRetrievingNamedValidatorShouldNotReorderValidators()
@@ -1736,10 +1748,10 @@ class Zend_Form_ElementTest extends TestCase
         $this->element->setOptions($options);
         $validator = $this->element->getValidator('notEmpty');
         $this->assertTrue($validator instanceof Zend_Validate_NotEmpty);
-        $this->assertTrue($validator->zfBreakChainOnFailure);
+        $this->assertTrue($this->isBreakChainOnFailure($this->element, get_class($validator)));
         $validator = $this->element->getValidator('digits');
         $this->assertTrue($validator instanceof Zend_Validate_Digits);
-        $this->assertTrue($validator->zfBreakChainOnFailure);
+        $this->assertTrue($this->isBreakChainOnFailure($this->element, get_class($validator)));
     }
 
     public function testSetOptionsSetsArrayOfAssociativeArrayValidators()
@@ -1762,10 +1774,10 @@ class Zend_Form_ElementTest extends TestCase
         $this->element->setOptions($options);
         $validator = $this->element->getValidator('notEmpty');
         $this->assertTrue($validator instanceof Zend_Validate_NotEmpty);
-        $this->assertTrue($validator->zfBreakChainOnFailure);
+        $this->assertTrue($this->isBreakChainOnFailure($this->element, get_class($validator)));
         $validator = $this->element->getValidator('digits');
         $this->assertTrue($validator instanceof Zend_Validate_Digits);
-        $this->assertTrue($validator->zfBreakChainOnFailure);
+        $this->assertTrue($this->isBreakChainOnFailure($this->element, get_class($validator)));
     }
 
     public function testSetOptionsSetsArrayOfStringFilters()
@@ -2225,9 +2237,9 @@ class Zend_Form_ElementTest extends TestCase
         $form->isValid(['username' => '#']);
 
         $validator = $username->getValidator('stringLength');
-        $this->assertTrue($validator->zfBreakChainOnFailure);
+        $this->assertTrue($this->isBreakChainOnFailure($username, get_class($validator)));
         $validator = $username->getValidator('regex');
-        $this->assertTrue($validator->zfBreakChainOnFailure);
+        $this->assertTrue($this->isBreakChainOnFailure($username, get_class($validator)));
     }
     
     /**


### PR DESCRIPTION
- Open issue: https://github.com/Shardj/zf1-future/issues/422

To reproduce the issue, I wrote a custom validator that implements `Zend_Validate_Interface`:

```
class Validator_JSON implements Zend_Validate_Interface
{
    private string $message;

    public function isValid($value): bool
    {
        json_decode($value);
        if (json_last_error() !== JSON_ERROR_NONE) {
            $this->message = "Invalid JSON: " . json_last_error_msg();
            return false;
        }

        return true;
    }

    public function getMessages(): array
    {
        return [$this->message];
    }
}
```

I then attached the custom validator to an element:
```
<?php
$element = new Zend_Form_Element_Textarea('textarea');
$element->addValidator(new Validator_JSON());
$element->isValid('hello')
```

Error encountered:
**PHP Deprecated:  Creation of dynamic property Validator_JSON::$zfBreakChainOnFailure is deprecated in Zend/Form/Element.php on line 1229**
