### PR TITLE
Fix "Undefined variable $c" in Zend_XmlRpc_Server::setResponseClass()

### DIFF
--- a/library/Zend/XmlRpc/Server.php
+++ b/library/Zend/XmlRpc/Server.php
@@ -465,7 +465,7 @@ class Zend_XmlRpc_Server extends Zend_Server_Abstract
     public function setResponseClass($class)
     {
         if (!class_exists($class) ||
-            ($c = new ReflectionClass($class) && !$c->isSubclassOf('Zend_XmlRpc_Response'))) {
+            (($c = new ReflectionClass($class)) && !$c->isSubclassOf('Zend_XmlRpc_Response'))) {
 
             require_once 'Zend/XmlRpc/Server/Exception.php';
             throw new Zend_XmlRpc_Server_Exception('Invalid response class');


### PR DESCRIPTION
The `setResponseClass()` method of `Zend_XmlRpc_Server` cannot be used because it throws an error: "Undefined variable $c".

This can be tested by running the corresponding unit test:

```
$ ./bin/phpunit --stderr -d memory_limit=-1  tests/Zend/XmlRpc/ServerTest.php
PHPUnit 9.6.21 by Sebastian Bergmann and contributors.
..........E........................E.                             37 / 37 (100%)
Time: 00:00.052, Memory: 8.00 MB
There were 2 errors:
1) Zend_XmlRpc_ServerTest::testSetResponseClass
Undefined variable $c
/var/www/html/limesurvey/upload/zf1-future/library/Zend/XmlRpc/Server.php:468
/var/www/html/limesurvey/upload/zf1-future/tests/Zend/XmlRpc/ServerTest.php:272
2) Zend_XmlRpc_ServerTest::testPassingInvalidResponseClassThrowsException
Undefined variable $c
/var/www/html/limesurvey/upload/zf1-future/library/Zend/XmlRpc/Server.php:468
/var/www/html/limesurvey/upload/zf1-future/tests/Zend/XmlRpc/ServerTest.php:667
ERRORS!
Tests: 37, Assertions: 98, Errors: 2.
```

Commit [273916d](https://github.com/Shardj/zf1-future/commit/273916d) broke this by replacing the `and` operator by `&&`, because `&&` has precedence over the assignment, while `and` doesn't. Adding the parenthesis solves the issue.