### PR TITLE
Fixed null deprecation in Zend/Pdf/Resource/Font/Simple

### DIFF
--- a/library/Zend/Pdf/Resource/Font/Simple.php
+++ b/library/Zend/Pdf/Resource/Font/Simple.php
@@ -173,6 +173,10 @@ abstract class Zend_Pdf_Resource_Font_Simple extends Zend_Pdf_Resource_Font
      */
     public function getCoveredPercentage($string, $charEncoding = '')
     {
+        if ($string === null || $string === '') {
+            return 0;
+        }
+
         /* Convert the string to UTF-16BE encoding so we can match the string's
          * character codes to those found in the cmap.
          */
@@ -261,6 +265,10 @@ abstract class Zend_Pdf_Resource_Font_Simple extends Zend_Pdf_Resource_Font
      */
     public function encodeString($string, $charEncoding)
     {
+        if ($string === null || $string === '') {
+            return '';
+        }
+
         if (PHP_OS == 'AIX') {
             return $string; // returning here b/c AIX doesnt know what CP1252 is
         }
@@ -279,6 +287,10 @@ abstract class Zend_Pdf_Resource_Font_Simple extends Zend_Pdf_Resource_Font
      */
     public function decodeString($string, $charEncoding)
     {
+        if ($string === null || $string === '') {
+            return '';
+        }
+
         return iconv('CP1252', $charEncoding, $string);
     }
 }


### PR DESCRIPTION
I tried to fix the `iconv()` null deprecation on parameter #3 in the sources that use the PDF lib, but that proved to be very difficult to pin. Even numerous fixes in `drawText()` (maybe it's not from it) the errors keep popping up. 