### PR TITLE
Fix str_replace null in Zend_Form_Element::_getErrorMessages()

### DIFF
--- a/library/Zend/Form/Element.php
+++ b/library/Zend/Form/Element.php
@@ -2346,7 +2346,7 @@ class Zend_Form_Element implements Zend_Validate_Interface
             } elseif ($this->isArray() || is_array($value)) {
                 $aggregateMessages = [];
                 foreach ($value as $val) {
-                    $aggregateMessages[] = str_replace('%value%', $val, $message);
+                    $aggregateMessages[] = str_replace('%value%', (string) $val, $message);
                 }
                 $aggregateMessages = array_unique($aggregateMessages); //prevent repeating the identical error message for multichoice-items
                 if (count($aggregateMessages)) {


### PR DESCRIPTION
> Deprecated: str_replace(): Passing null to parameter # 2 ($replace) of type array|string is deprecated in //zf1-future/library/Zend/Form/Element.php on line 2349


```php
set_include_path('library');

require_once 'Zend/Loader/Autoloader.php';
Zend_Loader_Autoloader::getInstance();

$e = new Zend_Form_Element_Text('test');
$e->setIsArray(true)
    ->addValidator('Int')
    ->addFilter(new Zend_Filter_Null(Zend_Filter_Null::STRING))
    ->addErrorMessage('Invalid %value%');

$e->isValid(['']);
```

Other places in the function have already been adjusted: https://github.com/Shardj/zf1-future/commit/673290a89df19e42a8992737b54287b70fec971c#diff-4de0f6e712ea2a7c9a1bcd60f804afb239d82095cfa68e28e18e2946d2b4abc4