### PR TITLE
fix Dojo ComboBox autocomplete param in declarative mode

### DIFF
--- a/library/Zend/Dojo/View/Helper/ComboBox.php
+++ b/library/Zend/Dojo/View/Helper/ComboBox.php
@@ -68,6 +68,12 @@ class Zend_Dojo_View_Helper_ComboBox extends Zend_Dojo_View_Helper_Dijit
         if (!array_key_exists('id', $attribs)) {
             $attribs['id'] = $id;
         }
+
+        // required for correct type casting in declarative mode
+        if (isset($params['autocomplete'])) {
+            $params['autocomplete'] = ($params['autocomplete']) ? 'true' : 'false';
+        }
+
         if (array_key_exists('store', $params) && is_array($params['store'])) {
             // using dojo.data datastore
             if (false !== ($store = $this->_renderStore($params['store'], $id))) {
@@ -100,10 +106,6 @@ class Zend_Dojo_View_Helper_ComboBox extends Zend_Dojo_View_Helper_Dijit
             return $html;
         }
 
-        // required for correct type casting in declerative mode
-        if (isset($params['autocomplete'])) {
-            $params['autocomplete'] = ($params['autocomplete']) ? 'true' : 'false';
-        }
         // do as normal select
         $attribs = $this->_prepareDijit($attribs, $params, 'element');
         return $this->view->formSelect($id, $value, $attribs, $options);

--- a/tests/Zend/Dojo/View/Helper/ComboBoxTest.php
+++ b/tests/Zend/Dojo/View/Helper/ComboBoxTest.php
@@ -153,6 +153,88 @@ class Zend_Dojo_View_Helper_ComboBoxTest extends TestCase
         $this->assertMatchesRegularExpression('/<select[^>]*(dojoType="dijit.form.ComboBox")/', $html, $html);
     }
 
+    public function testShouldAllowDeclarativeDijitCreationAsSelectWithoutAutocomplete()
+    {
+        $html = $this->helper->comboBox(
+            'elementId',
+            'someCombo',
+            [
+                'autocomplete' => false,
+            ],
+            [],
+            [
+                'red' => 'Rouge',
+                'blue' => 'Bleu',
+                'white' => 'Blanc',
+                'orange' => 'Orange',
+                'black' => 'Noir',
+                'green' => 'Vert',
+            ]
+        );
+        $this->assertStringContainsString('autocomplete="false"', $html);
+    }
+
+    public function testShouldAllowProgrammaticDijitCreationAsSelectWithoutAutocomplete()
+    {
+        Zend_Dojo_View_Helper_Dojo::setUseProgrammatic();
+        $html = $this->helper->comboBox(
+            'elementId',
+            'someCombo',
+            [
+                'autocomplete' => false,
+            ],
+            [],
+            [
+                'red' => 'Rouge',
+                'blue' => 'Bleu',
+                'white' => 'Blanc',
+                'orange' => 'Orange',
+                'black' => 'Noir',
+                'green' => 'Vert',
+            ]
+        );
+        $dijit = $this->view->dojo()->getDijit('elementId');
+        $this->assertNotNull($dijit);
+        $this->assertArrayHasKey('autocomplete', $dijit);
+        $this->assertEquals('false', $dijit['autocomplete']);
+    }
+
+    public function testShouldAllowDeclarativeDijitCreationAsRemoterWithoutAutocomplete()
+    {
+        $html = $this->helper->comboBox(
+            'elementId',
+            'someCombo',
+            [
+                'store' => 'stateStore',
+                'storeType' => 'dojo.data.ItemFileReadStore',
+                'storeParams' => ['url' => 'states.txt'],
+                'searchAttr' => 'name',
+                'autocomplete' => false,
+            ]
+        );
+        $this->assertStringContainsString('autocomplete="false"', $html);
+    }
+
+    public function testShouldAllowProgrammaticDijitCreationAsRemoterWithoutAutocomplete()
+    {
+        Zend_Dojo_View_Helper_Dojo::setUseProgrammatic();
+        $html = $this->helper->comboBox(
+            'elementId',
+            'someCombo',
+            [
+                'store' => 'stateStore',
+                'storeType' => 'dojo.data.ItemFileReadStore',
+                'storeParams' => ['url' => 'states.txt'],
+                'searchAttr' => 'name',
+                'autocomplete' => false,
+            ]
+        );
+        $dijit = $this->view->dojo()->getDijit('elementId');
+        $this->assertNotNull($dijit);
+        $this->assertArrayHasKey('autocomplete', $dijit);
+        $this->assertEquals('false', $dijit['autocomplete']);
+    }
+
     public function testShouldAllowProgrammaticDijitCreationAsSelect()
     {
         Zend_Dojo_View_Helper_Dojo::setUseProgrammatic();


### PR DESCRIPTION
When creating a Dojo ComboBox form element declaratively, the autocomplete parameter was not properly added as attribute to the html element. This error only occurred when used in combination with a data store. 

This fix simply moves up lines 103-106 which address the conversion of the autocomplete parameter to a string.
The early returns in lines 85 and 106 broke this feature for ComboBoxes with a data store.

Added test cases accordingly.