### PR TITLE
PHP-8.3.: fix decrement on bool

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,9 +11,10 @@
     "license": "BSD-3-Clause",
     "require": {
         "php": ">=7.1",
-        "symfony/polyfill-php81": "^1.24",
-        "symfony/polyfill-ctype": "^1.27",
-        "symfony/polyfill-mbstring": "^1.26"
+        "symfony/polyfill-ctype": "^1.31",
+        "symfony/polyfill-mbstring": "^1.31",
+        "symfony/polyfill-php81": "^1.31",
+        "symfony/polyfill-php83": "^1.31"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3",

--- a/composer.json
+++ b/composer.json
@@ -11,10 +11,10 @@
     "license": "BSD-3-Clause",
     "require": {
         "php": ">=7.1",
-        "symfony/polyfill-ctype": "^1.31",
-        "symfony/polyfill-mbstring": "^1.31",
-        "symfony/polyfill-php81": "^1.31",
-        "symfony/polyfill-php83": "^1.31"
+        "symfony/polyfill-ctype": "^1.30",
+        "symfony/polyfill-mbstring": "^1.30",
+        "symfony/polyfill-php81": "^1.30",
+        "symfony/polyfill-php83": "^1.30"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3",

--- a/library/Zend/Date.php
+++ b/library/Zend/Date.php
@@ -2509,14 +2509,14 @@ class Zend_Date extends Zend_Date_DateObject
                         }
 
                         if (($calc == 'set') || ($calc == 'cmp')) {
-                            if (isset($parsed['month'])) {
-                                --$parsed['month'];
+                            if (isset($parsed['month']) && is_numeric($parsed['month'])) {
+                                $parsed['month'] = (int) str_decrement(ltrim((string) $parsed['month'], '0'));
                             } else {
                                 $parsed['month'] = 0;
                             }
 
-                            if (isset($parsed['day'])) {
-                                --$parsed['day'];
+                            if (isset($parsed['day']) && is_numeric($parsed['day'])) {
+                                $parsed['day'] = (int) str_decrement(ltrim((string) $parsed['day'], '0'));
                             } else {
                                 $parsed['day'] = 0;
                             }


### PR DESCRIPTION
```
1) OpenMage\Tests\Unit\Mage\Reports\Helper\DataTest::testGetIntervals with data set "year: same year" (1, '2025-01-01', '2025-12-31', 'year')
Decrement on type bool has no effect, this will change in the next major version of PHP

/home/runner/work/magento-lts/magento-lts/vendor/shardj/zf1-future/library/Zend/Date.php:2514
/home/runner/work/magento-lts/magento-lts/vendor/shardj/zf1-future/library/Zend/Date.php:1003
/home/runner/work/magento-lts/magento-lts/vendor/shardj/zf1-future/library/Zend/Date.php:197
/home/runner/work/magento-lts/magento-lts/app/code/core/Mage/Reports/Helper/Data.php:69
/home/runner/work/magento-lts/magento-lts/tests/unit/Mage/Reports/Helper/DataTest.php:68
```

Found during adding some unit tests.