### PR TITLE
Fixed bug #467: Added trait check in Zend_Loader to prevent Zend_Exce…

### DIFF
--- a/library/Zend/Loader.php
+++ b/library/Zend/Loader.php
@@ -51,7 +51,10 @@ class Zend_Loader
      */
     public static function loadClass($class, $dirs = null)
     {
-        if (class_exists($class, false) || interface_exists($class, false)) {
+        if (class_exists($class, false)
+            || interface_exists($class, false)
+            || trait_exists($class, false)
+        ) {
             return;
         }
 
@@ -82,7 +85,10 @@ class Zend_Loader
             self::loadFile($file, null, true);
         }
 
-        if (!class_exists($class, false) && !interface_exists($class, false)) {
+        if (!class_exists($class, false)
+            && !interface_exists($class, false)
+            && !trait_exists($class, false)
+        ) {
             require_once 'Zend/Exception.php';
             throw new Zend_Exception("File \"$file\" does not exist or class \"$class\" was not found in the file");
         }

--- a/tests/Zend/Loader/AllTests.php
+++ b/tests/Zend/Loader/AllTests.php
@@ -36,6 +36,7 @@ require_once 'Zend/Loader/Autoloader/ResourceTest.php';
 require_once 'Zend/Loader/ClassMapAutoloaderTest.php';
 require_once 'Zend/Loader/PluginLoaderTest.php';
 require_once 'Zend/Loader/StandardAutoloaderTest.php';
+require_once 'Zend/Loader/LoaderTest.php';
 
 /**
  * @category   Zend
@@ -64,6 +65,7 @@ class Zend_Loader_AllTests
         $suite->addTestSuite('Zend_Loader_ClassMapAutoloaderTest');
         $suite->addTestSuite('Zend_Loader_PluginLoaderTest');
         $suite->addTestSuite('Zend_Loader_StandardAutoloaderTest');
+        $suite->addTestSuite('Zend_Loader_LoaderTest');
 
         return $suite;
     }

--- a/tests/Zend/Loader/LoaderTest.php
+++ b/tests/Zend/Loader/LoaderTest.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+use Yoast\PHPUnitPolyfills\TestCases\TestCase;
+use PHPUnit\Framework\TestSuite;
+use PHPUnit\TextUI\TestRunner;
+
+/**
+ * Zend Framework
+ *
+ * LICENSE
+ *
+ * This source file is subject to the new BSD license that is bundled
+ * with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://framework.zend.com/license/new-bsd
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@zend.com so we can send you a copy immediately.
+ *
+ * @category   Zend
+ * @package    Zend_Loader
+ * @subpackage UnitTests
+ * @copyright  Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license    http://framework.zend.com/license/new-bsd     New BSD License
+ * @version    $Id $
+ */
+
+if (!defined('PHPUnit_MAIN_METHOD')) {
+    define('PHPUnit_MAIN_METHOD', 'Zend_Loader_LoaderTest::main');
+}
+
+/**
+ * @package    Zend_Loader
+ * @subpackage UnitTests
+ * @copyright  Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license    http://framework.zend.com/license/new-bsd     New BSD License
+ * @group      Loader
+ */
+class Zend_Loader_LoaderTest extends TestCase
+{
+    public static function main()
+    {
+        $suite = new TestSuite(__CLASS__);
+        $result = (new resources_Runner())->run($suite);
+    }
+
+    public function testLoadTraitDoesNotThrowException()
+    {
+        $traitName = 'Zend_Loader_TestAsset_TestTrait';
+
+        $this->assertFalse(trait_exists($traitName, false));
+
+        Zend_Loader::loadClass($traitName);
+
+        $this->assertTrue(trait_exists($traitName, false));
+    }
+}
+
+if (PHPUnit_MAIN_METHOD === 'Zend_Loader_LoaderTest::main') {
+    Zend_Loader_LoaderTest::main();
+}

--- a/tests/Zend/Loader/TestAsset/TestTrait.php
+++ b/tests/Zend/Loader/TestAsset/TestTrait.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Zend Framework
+ *
+ * LICENSE
+ *
+ * This source file is subject to the new BSD license that is bundled
+ * with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://framework.zend.com/license/new-bsd
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@zend.com so we can send you a copy immediately.
+ *
+ * @category   Zend
+ * @package    Loader
+ * @subpackage UnitTests
+ * @copyright  Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license    http://framework.zend.com/license/new-bsd     New BSD License
+ * @version    $Id$
+ */
+
+/**
+ * @package    Zend_Loader
+ * @subpackage UnitTests
+ * @copyright  Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license    http://framework.zend.com/license/new-bsd     New BSD License
+ * @group      Loader
+ */
+trait Zend_Loader_TestAsset_TestTrait
+{
+}


### PR DESCRIPTION
**Issue Summary**
Zend_Loader::loadClass() throws a Zend_Exception when attempting to check for trait existence. The issue occurs because Zend_Loader only verifies class_exists($class, false), but does not account for trait_exists($class, false).

**Fix Summary**
Added trait_exists($class, false) check in Zend_Loader::loadClass().
Prevents Zend_Exception from being thrown when a trait is loaded.
Ensures that traits can be properly autoloaded without breaking execution.

**Expected Behavior**
Zend_Loader::loadClass() should recognize traits without throwing an exception.

**Testing & Verification**
Added a test case to verify that Zend_Loader::loadClass() properly handles traits.
Confirmed that the fix does not affect standard class autoloading.

**Related Issues**
Closes #467
