### PR TITLE
Handle edge case for failed splitText in lucene Html.php

### DIFF
--- a/library/Zend/Search/Lucene/Document/Html.php
+++ b/library/Zend/Search/Lucene/Document/Html.php
@@ -312,6 +312,10 @@ class Zend_Search_Lucene_Document_Html extends Zend_Search_Lucene_Document
             // Cut matched node
             $matchedWordNode = $node->splitText($token->getStartOffset());
 
+            if (!($matchedWordNode instanceof DOMText)) {
+                continue; // Skip this token if splitting failed
+            }
+
             // Retrieve HTML string representation for highlihted word
             $fullCallbackparamsList = $params;
             array_unshift($fullCallbackparamsList, $matchedWordNode->nodeValue);


### PR DESCRIPTION
Skip invalid tokens in Lucene highlighter to prevent fatal DOM errors

After calling splitText(), ensure the returned node is a valid DOMText instance. If not, skip processing that token. This prevents fatal errors when edge-case tokens result in invalid DOM nodes. 

This happened in our application as the HTML we were searching was broken. This fixed the issue in case of any broken HTML. $matchedWordNode was equal to false instead of a DOMText.