### PR TITLE
Made all E_STRICT uses conditional.

### DIFF
--- a/library/Zend/Log.php
+++ b/library/Zend/Log.php
@@ -594,14 +594,17 @@ class Zend_Log
             E_USER_ERROR        => Zend_Log::ERR,
             E_CORE_ERROR        => Zend_Log::ERR,
             E_RECOVERABLE_ERROR => Zend_Log::ERR,
-            E_STRICT            => Zend_Log::DEBUG,
         ];
         // PHP 5.3.0+
         if (defined('E_DEPRECATED')) {
-            $this->_errorHandlerMap['E_DEPRECATED'] = Zend_Log::DEBUG;
+            $this->_errorHandlerMap[E_DEPRECATED] = Zend_Log::DEBUG;
         }
         if (defined('E_USER_DEPRECATED')) {
-            $this->_errorHandlerMap['E_USER_DEPRECATED'] = Zend_Log::DEBUG;
+            $this->_errorHandlerMap[E_USER_DEPRECATED] = Zend_Log::DEBUG;
+        }
+        // Deprecated in PHP 8.4
+        if (defined('E_STRICT') && version_compare(PHP_VERSION, '8.4.0', '<')) {
+            $this->_errorHandlerMap[E_STRICT] = Zend_Log::DEBUG;
         }
 
         $this->_registeredErrorHandler = true;

--- a/library/Zend/Stdlib/CallbackHandler.php
+++ b/library/Zend/Stdlib/CallbackHandler.php
@@ -93,7 +93,11 @@ class Zend_Stdlib_CallbackHandler
      */
     protected function registerCallback($callback)
     {
-        set_error_handler([$this, 'errorHandler'], E_STRICT);
+        $errorLevel = (defined('E_STRICT') && version_compare(PHP_VERSION, '8.4.0', '<'))
+            ? (E_ALL | E_STRICT)
+            : E_ALL;
+
+        set_error_handler([$this, 'errorHandler'], $errorLevel);
         $callable = is_callable($callback);
         restore_error_handler();
         if (!$callable || $this->error) {
@@ -102,7 +106,7 @@ class Zend_Stdlib_CallbackHandler
         }
 
         // If pecl/weakref is not installed, simply store the callback and return
-        set_error_handler([$this, 'errorHandler'], E_WARNING);
+        set_error_handler([$this, 'errorHandler'], $errorLevel);
         $callable = class_exists('WeakRef');
         restore_error_handler();
         if (!$callable || $this->error) {

--- a/library/Zend/Tool/Framework/Loader/Abstract.php
+++ b/library/Zend/Tool/Framework/Loader/Abstract.php
@@ -88,6 +88,10 @@ abstract class Zend_Tool_Framework_Loader_Abstract
 
         $loadedClasses = [];
 
+        $newLevel = (defined('E_STRICT') && version_compare(PHP_VERSION, '8.4.0', '<'))
+            ? (E_ALL | ~E_STRICT)
+            : E_ALL;
+
         // loop through files and find the classes declared by loading the file
         foreach ($this->_retrievedFiles as $file) {
             if(is_dir($file)) {
@@ -95,7 +99,7 @@ abstract class Zend_Tool_Framework_Loader_Abstract
             }
 
             $classesLoadedBefore = get_declared_classes();
-            $oldLevel = error_reporting(E_ALL | ~E_STRICT); // remove strict so that other packages wont throw warnings
+            $oldLevel = error_reporting($newLevel); // remove strict so that other packages wont throw warnings
             // should we lint the files here? i think so
             include_once $file;
             error_reporting($oldLevel); // restore old error level


### PR DESCRIPTION
Check the presence of the E_STRICT constant, plus requiring PHP prior to 8.4.

Also fix uses of E_DEPRECATED and E_USER_DEPRECATED which seems to have been oversight in the original implementation, i.e. E_DEPRECATED and E_USER_DEPRECATED errors are now logged by Zend_Log as DEBUG rather than INFO.

Fixes #483
