### PR TITLE
Fix Zend_Pdf_Element regression by added $value prop

### DIFF
--- a/.rector.php
+++ b/.rector.php
@@ -24,6 +24,10 @@ return RectorConfig::configure()
         CodeQuality\Class_\CompleteDynamicPropertiesRector::class
     ])
     ->withSkip([
+        # see https://github.com/Shardj/zf1-future/pull/453
+        CodeQuality\Class_\CompleteDynamicPropertiesRector::class => [
+            __DIR__ . '/library/Zend/Pdf/Element.php',
+        ],
         Php53\FuncCall\DirNameFileConstantToDirConstantRector::class,
         Php53\Ternary\TernaryToElvisRector::class,
         Php54\Array_\LongArrayToShortArrayRector::class,

--- a/library/Zend/Pdf/Element.php
+++ b/library/Zend/Pdf/Element.php
@@ -27,11 +27,10 @@
  * @copyright  Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  *
- * @property mixed $value
+ * @property mixed $value see https://github.com/Shardj/zf1-future/pull/453
  */
 abstract class Zend_Pdf_Element
 {
-    public $value;
     public const TYPE_BOOL        = 1;
     public const TYPE_NUMERIC     = 2;
     public const TYPE_STRING      = 3;


### PR DESCRIPTION
By @sreichel's Phpstan error fixes in #475 / v1.24.3, the same regression was reintroduced again, which I have fixed last Oct in #453.

Please read #453 thread for more details.