### PR TITLE
Add missing polyfill for 8.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,6 +14,7 @@
         "symfony/polyfill-ctype": "^1.30",
         "symfony/polyfill-mbstring": "^1.30",
         "symfony/polyfill-php81": "^1.30",
+        "symfony/polyfill-php82": "^1.30",
         "symfony/polyfill-php83": "^1.30"
     },
     "require-dev": {


### PR DESCRIPTION
This pull request adds support for PHP 8.2 compatibility by including the `symfony/polyfill-php82` package in the `composer.json` file.