### PR TITLE
Fix object caching in Zend_Translate_Adapter

### DIFF
--- a/library/Zend/Translate/Adapter.php
+++ b/library/Zend/Translate/Adapter.php
@@ -350,11 +350,18 @@ abstract class Zend_Translate_Adapter {
         foreach ($options as $key => $option) {
             if ($key == 'locale') {
                 $locale = $option;
-            } else if ((isset($this->_options[$key]) && ($this->_options[$key] != $option)) ||
+            } else if ((isset($this->_options[$key]) && ($this->_options[$key] !== $option)) ||
                     !isset($this->_options[$key])) {
                 if (($key == 'log') && !($option instanceof Zend_Log)) {
                     require_once 'Zend/Translate/Exception.php';
                     throw new Zend_Translate_Exception('Instance of Zend_Log expected for option log');
+                }
+
+                if (isset($this->_options[$key])
+                    && (is_object($this->_options[$key]) && is_object($option))
+                    && (sha1(serialize($this->_options[$key])) == sha1(serialize($option)))
+                ) {
+                    continue;
                 }
 
                 if ($key == 'cache') {


### PR DESCRIPTION
  A few years ago we encountered a caching bottleneck in `Zend_Translate_Adapter`. 
Due to how object comparison works this was overloading our Redis Cache store as the system was caching everything.
We would essentially end up with lots of different instances being cached.
After investigating it turned out that there could be different instances of objects but with exactly the same properties. So essentially the same translations being cached multiple times due to how object comparison.

We used to host this fix in our own fork of zf1-future. Now I would like to merge it to upstream. 

Unit Tests are passing but please take a close look at the changes due their nature.