### PR TITLE
PHP8.4: Fixes missing escape parameter

### DIFF
--- a/library/Zend/Auth/Adapter/Http/Resolver/File.php
+++ b/library/Zend/Auth/Adapter/Http/Resolver/File.php
@@ -157,7 +157,7 @@ class Zend_Auth_Adapter_Http_Resolver_File implements Zend_Auth_Adapter_Http_Res
 
         // No real validation is done on the contents of the password file. The
         // assumption is that we trust the administrators to keep it secure.
-        while (($line = fgetcsv($fp, 512, ':')) !== false) {
+        while (($line = fgetcsv($fp, 512, ':', '"', '\\')) !== false) {
             if ($line[0] == $username && $line[1] == $realm) {
                 $password = $line[2];
                 fclose($fp);


### PR DESCRIPTION
... its required with php 8.4.