### PR TITLE
Silence deprecation warning for SOAP_FUNCTIONS_ALL on 8.4+

### DIFF
--- a/library/Zend/Soap/Server.php
+++ b/library/Zend/Soap/Server.php
@@ -545,7 +545,7 @@ class Zend_Soap_Server implements Zend_Server_Interface
     public function addFunction($function, $namespace = '')
     {
         // Bail early if set to SOAP_FUNCTIONS_ALL
-        if ($this->_functions == SOAP_FUNCTIONS_ALL) {
+        if ($this->_functions == @SOAP_FUNCTIONS_ALL) {
             return $this;
         }
 
@@ -561,8 +561,8 @@ class Zend_Soap_Server implements Zend_Server_Interface
             $this->_functions = array_merge($this->_functions, $function);
         } elseif (is_string($function) && function_exists($function)) {
             $this->_functions[] = $function;
-        } elseif ($function == SOAP_FUNCTIONS_ALL) {
-            $this->_functions = SOAP_FUNCTIONS_ALL;
+        } elseif ($function == @SOAP_FUNCTIONS_ALL) {
+            $this->_functions = @SOAP_FUNCTIONS_ALL;
         } else {
             require_once 'Zend/Soap/Server/Exception.php';
             throw new Zend_Soap_Server_Exception('Invalid function specified');

--- a/tests/Zend/Soap/ServerTest.php
+++ b/tests/Zend/Soap/ServerTest.php
@@ -359,9 +359,9 @@ class Zend_Soap_ServerTest extends TestCase
         $server = new Zend_Soap_Server();
 
         // SOAP_FUNCTIONS_ALL as a value should pass
-        $server->addFunction(SOAP_FUNCTIONS_ALL);
+        $server->addFunction(@SOAP_FUNCTIONS_ALL);
         $server->addFunction('substr');
-        $this->assertEquals([SOAP_FUNCTIONS_ALL], $server->getFunctions());
+        $this->assertEquals([@SOAP_FUNCTIONS_ALL], $server->getFunctions());
     }
 
     public function testSetClass()


### PR DESCRIPTION
Simplest fix, just use the silence operator. When PHP 9 actually gets rid of this, we'll need to change this to i.e. using version_compare.

Fixes GH-508.