### PR TITLE
Fix destructor chain for SMTP transports

### DIFF
--- a/library/Zend/Mail/Protocol/Abstract.php
+++ b/library/Zend/Mail/Protocol/Abstract.php
@@ -451,7 +451,7 @@ abstract class Zend_Mail_Protocol_Abstract
         }
 
         do {
-            $this->_response[] = $result = $this->_receive($timeout);
+            $this->_response[] = $result = $this->_receive($timeout) ?? '';
             list($cmd, $more, $msg) = preg_split('/([\s-]+)/', $result, 2, PREG_SPLIT_DELIM_CAPTURE);
 
             if ($errMsg !== '') {

--- a/library/Zend/Mail/Protocol/Abstract.php
+++ b/library/Zend/Mail/Protocol/Abstract.php
@@ -451,7 +451,13 @@ abstract class Zend_Mail_Protocol_Abstract
         }
 
         do {
-            $this->_response[] = $result = $this->_receive($timeout) ?? '';
+            $this->_response[] = $result = $this->_receive($timeout);
+
+            if($result === false) {
+                // _receive() returned EOF, return empty msg string
+            	return $msg;
+            }
+
             list($cmd, $more, $msg) = preg_split('/([\s-]+)/', $result, 2, PREG_SPLIT_DELIM_CAPTURE);
 
             if ($errMsg !== '') {

--- a/library/Zend/Mail/Protocol/Smtp.php
+++ b/library/Zend/Mail/Protocol/Smtp.php
@@ -148,6 +148,18 @@ class Zend_Mail_Protocol_Smtp extends Zend_Mail_Protocol_Abstract
     }
 
 
+    /**         
+     * Class destructor to cleanup open resources
+     *
+     * @return void
+     */
+    public function __destruct()
+    {
+        $this->quit();
+        parent::__destruct();
+    }
+
+
     /**
      * Connect to the server with the parameters given in the constructor.
      *


### PR DESCRIPTION
Zend_Mail_Protocol_Smtp didn't have a destructor whereas its parent class Zend_Mail_Protocol_Abstract has. Yet, in PHO parent destructors have to be called explicitly.

This pull request adds a destructor to Zend_Mail_Protocol_Smtp that quits a potential open session and then calls the parent destructor.