### PR TITLE
PHP8.4: Replace xml_set_object() with callable arrays in Translate ad…

### DIFF
--- a/.phpstan.dist.baseline.php
+++ b/.phpstan.dist.baseline.php
@@ -23380,24 +23380,6 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/library/Zend/Translate/Adapter/Ini.php',
 ];
 $ignoreErrors[] = [
-	'rawMessage' => 'Method Zend_Translate_Adapter_Qt::_contentElement() is unused.',
-	'identifier' => 'method.unused',
-	'count' => 1,
-	'path' => __DIR__ . '/library/Zend/Translate/Adapter/Qt.php',
-];
-$ignoreErrors[] = [
-	'rawMessage' => 'Method Zend_Translate_Adapter_Qt::_endElement() is unused.',
-	'identifier' => 'method.unused',
-	'count' => 1,
-	'path' => __DIR__ . '/library/Zend/Translate/Adapter/Qt.php',
-];
-$ignoreErrors[] = [
-	'rawMessage' => 'Method Zend_Translate_Adapter_Qt::_startElement() is unused.',
-	'identifier' => 'method.unused',
-	'count' => 1,
-	'path' => __DIR__ . '/library/Zend/Translate/Adapter/Qt.php',
-];
-$ignoreErrors[] = [
 	'rawMessage' => 'PHPDoc tag @param references unknown parameter: $option',
 	'identifier' => 'parameter.notFound',
 	'count' => 1,
@@ -23426,24 +23408,6 @@ $ignoreErrors[] = [
 	'identifier' => 'property.onlyWritten',
 	'count' => 1,
 	'path' => __DIR__ . '/library/Zend/Translate/Adapter/Qt.php',
-];
-$ignoreErrors[] = [
-	'rawMessage' => 'Method Zend_Translate_Adapter_Tbx::_contentElement() is unused.',
-	'identifier' => 'method.unused',
-	'count' => 1,
-	'path' => __DIR__ . '/library/Zend/Translate/Adapter/Tbx.php',
-];
-$ignoreErrors[] = [
-	'rawMessage' => 'Method Zend_Translate_Adapter_Tbx::_endElement() is unused.',
-	'identifier' => 'method.unused',
-	'count' => 1,
-	'path' => __DIR__ . '/library/Zend/Translate/Adapter/Tbx.php',
-];
-$ignoreErrors[] = [
-	'rawMessage' => 'Method Zend_Translate_Adapter_Tbx::_startElement() is unused.',
-	'identifier' => 'method.unused',
-	'count' => 1,
-	'path' => __DIR__ . '/library/Zend/Translate/Adapter/Tbx.php',
 ];
 $ignoreErrors[] = [
 	'rawMessage' => 'PHPDoc tag @param references unknown parameter: $option',
@@ -23482,24 +23446,6 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/library/Zend/Translate/Adapter/Tmx.php',
 ];
 $ignoreErrors[] = [
-	'rawMessage' => 'Method Zend_Translate_Adapter_Xliff::_contentElement() is unused.',
-	'identifier' => 'method.unused',
-	'count' => 1,
-	'path' => __DIR__ . '/library/Zend/Translate/Adapter/Xliff.php',
-];
-$ignoreErrors[] = [
-	'rawMessage' => 'Method Zend_Translate_Adapter_Xliff::_endElement() is unused.',
-	'identifier' => 'method.unused',
-	'count' => 1,
-	'path' => __DIR__ . '/library/Zend/Translate/Adapter/Xliff.php',
-];
-$ignoreErrors[] = [
-	'rawMessage' => 'Method Zend_Translate_Adapter_Xliff::_startElement() is unused.',
-	'identifier' => 'method.unused',
-	'count' => 1,
-	'path' => __DIR__ . '/library/Zend/Translate/Adapter/Xliff.php',
-];
-$ignoreErrors[] = [
 	'rawMessage' => 'PHPDoc tag @param references unknown parameter: $option',
 	'identifier' => 'parameter.notFound',
 	'count' => 1,
@@ -23516,24 +23462,6 @@ $ignoreErrors[] = [
 	'identifier' => 'property.onlyWritten',
 	'count' => 1,
 	'path' => __DIR__ . '/library/Zend/Translate/Adapter/Xliff.php',
-];
-$ignoreErrors[] = [
-	'rawMessage' => 'Method Zend_Translate_Adapter_XmlTm::_contentElement() is unused.',
-	'identifier' => 'method.unused',
-	'count' => 1,
-	'path' => __DIR__ . '/library/Zend/Translate/Adapter/XmlTm.php',
-];
-$ignoreErrors[] = [
-	'rawMessage' => 'Method Zend_Translate_Adapter_XmlTm::_endElement() is unused.',
-	'identifier' => 'method.unused',
-	'count' => 1,
-	'path' => __DIR__ . '/library/Zend/Translate/Adapter/XmlTm.php',
-];
-$ignoreErrors[] = [
-	'rawMessage' => 'Method Zend_Translate_Adapter_XmlTm::_startElement() is unused.',
-	'identifier' => 'method.unused',
-	'count' => 1,
-	'path' => __DIR__ . '/library/Zend/Translate/Adapter/XmlTm.php',
 ];
 $ignoreErrors[] = [
 	'rawMessage' => 'PHPDoc tag @param references unknown parameter: $option',

--- a/library/Zend/Translate/Adapter/Qt.php
+++ b/library/Zend/Translate/Adapter/Qt.php
@@ -73,10 +73,9 @@ class Zend_Translate_Adapter_Qt extends Zend_Translate_Adapter {
 
         $encoding = $this->_findEncoding($filename);
         $this->_file = xml_parser_create($encoding);
-        xml_set_object($this->_file, $this);
         xml_parser_set_option($this->_file, XML_OPTION_CASE_FOLDING, 0);
-        xml_set_element_handler($this->_file, "_startElement", "_endElement");
-        xml_set_character_data_handler($this->_file, "_contentElement");
+        xml_set_element_handler($this->_file, [$this, '_startElement'], [$this, '_endElement']);
+        xml_set_character_data_handler($this->_file, [$this, '_contentElement']);
 
         try {
             Zend_Xml_Security::scanFile($filename);

--- a/library/Zend/Translate/Adapter/Tbx.php
+++ b/library/Zend/Translate/Adapter/Tbx.php
@@ -68,10 +68,9 @@ class Zend_Translate_Adapter_Tbx extends Zend_Translate_Adapter {
 
         $encoding = $this->_findEncoding($filename);
         $this->_file = xml_parser_create($encoding);
-        xml_set_object($this->_file, $this);
         xml_parser_set_option($this->_file, XML_OPTION_CASE_FOLDING, 0);
-        xml_set_element_handler($this->_file, "_startElement", "_endElement");
-        xml_set_character_data_handler($this->_file, "_contentElement");
+        xml_set_element_handler($this->_file, [$this, '_startElement'], [$this, '_endElement']);
+        xml_set_character_data_handler($this->_file, [$this, '_contentElement']);
 
         try {
             Zend_Xml_Security::scanFile($filename);

--- a/library/Zend/Translate/Adapter/Tmx.php
+++ b/library/Zend/Translate/Adapter/Tmx.php
@@ -73,10 +73,9 @@ class Zend_Translate_Adapter_Tmx extends Zend_Translate_Adapter {
 
         $encoding = $this->_findEncoding($filename);
         $this->_file = xml_parser_create($encoding);
-        xml_set_object($this->_file, $this);
         xml_parser_set_option($this->_file, XML_OPTION_CASE_FOLDING, 0);
-        xml_set_element_handler($this->_file, "_startElement", "_endElement");
-        xml_set_character_data_handler($this->_file, "_contentElement");
+        xml_set_element_handler($this->_file, [$this, '_startElement'], [$this, '_endElement']);
+        xml_set_character_data_handler($this->_file, [$this, '_contentElement']);
 
         try {
             Zend_Xml_Security::scanFile($filename);

--- a/library/Zend/Translate/Adapter/Xliff.php
+++ b/library/Zend/Translate/Adapter/Xliff.php
@@ -80,10 +80,9 @@ class Zend_Translate_Adapter_Xliff extends Zend_Translate_Adapter {
         $encoding      = $this->_findEncoding($filename);
         $this->_target = $locale;
         $this->_file   = xml_parser_create($encoding);
-        xml_set_object($this->_file, $this);
         xml_parser_set_option($this->_file, XML_OPTION_CASE_FOLDING, 0);
-        xml_set_element_handler($this->_file, "_startElement", "_endElement");
-        xml_set_character_data_handler($this->_file, "_contentElement");
+        xml_set_element_handler($this->_file, [$this, '_startElement'], [$this, '_endElement']);
+        xml_set_character_data_handler($this->_file, [$this, '_contentElement']);
 
         try {
             Zend_Xml_Security::scanFile($filename);

--- a/library/Zend/Translate/Adapter/XmlTm.php
+++ b/library/Zend/Translate/Adapter/XmlTm.php
@@ -68,10 +68,9 @@ class Zend_Translate_Adapter_XmlTm extends Zend_Translate_Adapter {
 
         $encoding    = $this->_findEncoding($filename);
         $this->_file = xml_parser_create($encoding);
-        xml_set_object($this->_file, $this);
         xml_parser_set_option($this->_file, XML_OPTION_CASE_FOLDING, 0);
-        xml_set_element_handler($this->_file, "_startElement", "_endElement");
-        xml_set_character_data_handler($this->_file, "_contentElement");
+        xml_set_element_handler($this->_file, [$this, '_startElement'], [$this, '_endElement']);
+        xml_set_character_data_handler($this->_file, [$this, '_contentElement']);
 
         try {
             Zend_Xml_Security::scanFile($filename);


### PR DESCRIPTION
# Fix PHP 8.4 deprecation: replace `xml_set_object()` with callable arrays in Translate adapters

## Summary

PHP 8.4 deprecated `xml_set_object()` ([PHP RFC](https://wiki.php.net/rfc/deprecate_functions_with_overloaded_signatures)), causing deprecation warnings when using any of the XML-based translation adapters. This PR removes the deprecated call across all affected adapters and replaces string-based method references with proper callable arrays.

## Changes

Removed `xml_set_object($parser, $this)` and updated the string method names passed to `xml_set_element_handler()` and `xml_set_character_data_handler()` to use `[$this, '_methodName']` callables in:

- `library/Zend/Translate/Adapter/Tmx.php`
- `library/Zend/Translate/Adapter/Tbx.php`
- `library/Zend/Translate/Adapter/Qt.php`
- `library/Zend/Translate/Adapter/Xliff.php`
- `library/Zend/Translate/Adapter/XmlTm.php`

**Before:**

```php
xml_set_object($this->_file, $this);
xml_set_element_handler($this->_file, "_startElement", "_endElement");
xml_set_character_data_handler($this->_file, "_contentElement");
```

**After:**

```php
xml_set_element_handler($this->_file, [$this, '_startElement'], [$this, '_endElement']);
xml_set_character_data_handler($this->_file, [$this, '_contentElement']);
```

## Backwards Compatibility

This change is fully backwards compatible:

- **Callable arrays (`[$object, 'method']`) have been valid since PHP 5.3.0** — well before any PHP version this library targets.
- The `xml_set_*_handler()` functions have accepted any valid PHP callable (including callable arrays) since PHP 4. Passing a callable array was always the more correct approach; `xml_set_object()` was merely a convenience that allowed passing bare strings as shorthand.
- `xml_set_object()` is *deprecated* in PHP 8.4, not removed. Existing installations on PHP ≤ 8.3 are unaffected by this change in behaviour; they simply no longer emit the deprecation notice.
- No public API, interface, or behaviour is altered — only the internal wiring of the XML parser callbacks.

## Testing

Existing unit tests for the affected adapters cover this change. No new tests are required as the observable behaviour is identical.
