### PR TITLE
Fix Zend_Debug::dump() xdebug quirk.

### DIFF
--- a/library/Zend/Debug.php
+++ b/library/Zend/Debug.php
@@ -82,19 +82,20 @@ class Zend_Debug
         var_dump($var);
         $output = ob_get_clean();
 
-        // neaten the newlines and indents
-        $output = preg_replace("/\]\=\>\n(\s+)/m", "] => ", $output);
+        $varDumpIsOverloaded = extension_loaded('xdebug') && str_contains((string) ini_get('xdebug.mode'), 'develop');
+
+        if (!$varDumpIsOverloaded) {
+            // neaten the newlines and indents
+            $output = preg_replace("/\]\=\>\n(\s+)/m", '] => ', $output);
+        }
+
         if (self::getSapi() == 'cli') {
             $output = PHP_EOL . $label
                     . PHP_EOL . $output
                     . PHP_EOL;
         } else {
-            if(!extension_loaded('xdebug')) {
-                $flags = ENT_QUOTES;
-                // PHP 5.4.0+
-                if (defined('ENT_SUBSTITUTE')) {
-                    $flags = ENT_QUOTES | ENT_SUBSTITUTE;
-                }
+            if (!$varDumpIsOverloaded) {
+                $flags = ENT_QUOTES | ENT_SUBSTITUTE;
                 $output = htmlspecialchars($output, $flags);
             }
 


### PR DESCRIPTION
In the special case a user has xdebug enabled, but disabled the developer overrides (xdebug.mode=profile instead of xdebug=develop,profile) the var_dump() function will remain unchanged, and it's output needs to be escaped as well.

I also removed the useless if(defined...) since support for PHP 5 was dropped.