### PR TITLE
PHPUnit Compatibility

### DIFF
--- a/library/Zend/Test/PHPUnit/Constraint/DomQuery.php
+++ b/library/Zend/Test/PHPUnit/Constraint/DomQuery.php
@@ -28,7 +28,7 @@ if (class_exists('PHPUnit\Runner\Version')) {
 	$id = '0.0.0';
 }
 
-if (version_compare($id, '8.0', '>=')) {
+if (version_compare($id, '6.0', '>=')) {
 	include(dirname(__FILE__) . DIRECTORY_SEPARATOR . 'DomQuery80.php');
 
 	class Zend_Test_PHPUnit_Constraint_DomQuery extends Zend_Test_PHPUnit_Constraint_DomQuery80

--- a/library/Zend/Test/PHPUnit/Constraint/DomQuery.php
+++ b/library/Zend/Test/PHPUnit/Constraint/DomQuery.php
@@ -20,12 +20,25 @@
  * @version    $Id$
  */
 
-if (version_compare(PHPUnit_Runner_Version::id(), '4.1', '>=')) {
+if (class_exists('PHPUnit\Runner\Version')) {
+	$id = PHPUnit\Runner\Version::id();
+} elseif (class_exists('PHPUnit_Runner_Version')) {
+	$id = PHPUnit_Runner_Version::id();
+} else {
+	$id = '0.0.0';
+}
+
+if (version_compare($id, '8.0', '>=')) {
+	include(dirname(__FILE__) . DIRECTORY_SEPARATOR . 'DomQuery80.php');
+
+	class Zend_Test_PHPUnit_Constraint_DomQuery extends Zend_Test_PHPUnit_Constraint_DomQuery80
+	{}
+} elseif (version_compare($id, '4.1', '>=')) {
     include(dirname(__FILE__) . DIRECTORY_SEPARATOR . 'DomQuery41.php');
 
     class Zend_Test_PHPUnit_Constraint_DomQuery extends Zend_Test_PHPUnit_Constraint_DomQuery41
     {}
-} elseif (version_compare(PHPUnit_Runner_Version::id(), '3.5', '>=')) {
+} elseif (version_compare($id, '3.5', '>=')) {
     include(dirname(__FILE__) . DIRECTORY_SEPARATOR . 'DomQuery37.php');
 
     class Zend_Test_PHPUnit_Constraint_DomQuery extends Zend_Test_PHPUnit_Constraint_DomQuery37

--- a/library/Zend/Test/PHPUnit/Constraint/DomQuery80.php
+++ b/library/Zend/Test/PHPUnit/Constraint/DomQuery80.php
@@ -1,0 +1,439 @@
+<?php
+/**
+ * Zend Framework
+ *
+ * LICENSE
+ *
+ * This source file is subject to the new BSD license that is bundled
+ * with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://framework.zend.com/license/new-bsd
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@zend.com so we can send you a copy immediately.
+ *
+ * @category   Zend
+ * @package    Zend_Test
+ * @subpackage PHPUnit
+ * @copyright  Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license    http://framework.zend.com/license/new-bsd     New BSD License
+ * @version    $Id$
+ */
+
+use PHPUnit\Framework\Constraint\Constraint;
+use SebastianBergmann\Comparator\ComparisonFailure;
+
+/** @see Zend_Dom_Query */
+require_once 'Zend/Dom/Query.php';
+
+/**
+ * Zend_Dom_Query-based PHPUnit Constraint
+ *
+ * @uses       Constraint
+ * @category   Zend
+ * @package    Zend_Test
+ * @subpackage PHPUnit
+ * @copyright  Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license    http://framework.zend.com/license/new-bsd     New BSD License
+ */
+class Zend_Test_PHPUnit_Constraint_DomQuery80 extends Constraint
+{
+    /**#@+
+     * Assertion type constants
+     */
+    public const ASSERT_QUERY            = 'assertQuery';
+    public const ASSERT_CONTENT_CONTAINS = 'assertQueryContentContains';
+    public const ASSERT_CONTENT_REGEX    = 'assertQueryContentRegex';
+    public const ASSERT_CONTENT_COUNT    = 'assertQueryCount';
+    public const ASSERT_CONTENT_COUNT_MIN= 'assertQueryCountMin';
+    public const ASSERT_CONTENT_COUNT_MAX= 'assertQueryCountMax';
+    /**#@-*/
+
+    /**
+     * Current assertion type
+     * @var string
+     */
+    protected $_assertType        = null;
+
+    /**
+     * Available assertion types
+     * @var array
+     */
+    protected $_assertTypes       = [
+        self::ASSERT_QUERY,
+        self::ASSERT_CONTENT_CONTAINS,
+        self::ASSERT_CONTENT_REGEX,
+        self::ASSERT_CONTENT_COUNT,
+        self::ASSERT_CONTENT_COUNT_MIN,
+        self::ASSERT_CONTENT_COUNT_MAX,
+    ];
+
+    /**
+     * Content being matched
+     * @var string
+     */
+    protected $_content           = null;
+
+    /**
+     * Whether or not assertion is negated
+     * @var bool
+     */
+    protected $_negate            = false;
+
+    /**
+     * CSS selector or XPath path to select against
+     * @var string
+     */
+    protected $_path              = null;
+
+    /**
+     * Whether or not to use XPath when querying
+     * @var bool
+     */
+    protected $_useXpath          = false;
+
+    /**
+     * XPath namespaces
+     * @var array
+     */
+    protected $_xpathNamespaces = [];
+
+    /**
+     * Constructor; setup constraint state
+     *
+     * @param  string $path CSS selector path
+     * @return void
+     */
+    public function __construct($path)
+    {
+        $this->_path = $path;
+    }
+
+    /**
+     * Indicate negative match
+     *
+     * @param  bool $flag
+     * @return void
+     */
+    public function setNegate($flag = true)
+    {
+        $this->_negate = $flag;
+    }
+
+    /**
+     * Whether or not path is a straight XPath expression
+     *
+     * @param  bool $flag
+     * @return Zend_Test_PHPUnit_Constraint_DomQuery41
+     */
+    public function setUseXpath($flag = true)
+    {
+        $this->_useXpath = (bool) $flag;
+        return $this;
+    }
+
+    /**
+     * Evaluate an object to see if it fits the constraints
+     *
+     * @param  string $content Response content to be matched against (haystack)
+     * @param  null|string $assertType Assertion type
+     * @param  string $match (optional) String to match (needle), may be required depending on assertion type
+     * @return bool
+     *
+     * NOTE:
+     * Drastic changes up to PHPUnit 3.5.15 this was:
+     *     public function evaluate($other, $assertType = null)
+     * In PHPUnit 3.6.0 they changed the interface into this:
+     *     public function evaluate($other, $description = '', $returnResult = FALSE)
+     * We use the new interface for PHP-strict checking, but emulate the old one
+     */
+    public function evaluate_compat($content, $assertType = '', $match = FALSE)
+    {
+        if (strstr($assertType, 'Not')) {
+            $this->setNegate(true);
+            $assertType = str_replace('Not', '', $assertType);
+        }
+
+        if (strstr($assertType, 'Xpath')) {
+            $this->setUseXpath(true);
+            $assertType = str_replace('Xpath', 'Query', $assertType);
+        }
+
+        if (!in_array($assertType, $this->_assertTypes)) {
+            require_once 'Zend/Test/PHPUnit/Constraint/Exception.php';
+            throw new Zend_Test_PHPUnit_Constraint_Exception(sprintf('Invalid assertion type "%s" provided to %s constraint', $assertType, __CLASS__));
+        }
+
+        $this->_assertType = $assertType;
+
+        $method   = $this->_useXpath ? 'queryXpath' : 'query';
+        $domQuery = new Zend_Dom_Query($content);
+        $domQuery->registerXpathNamespaces($this->_xpathNamespaces);
+        $result   = $domQuery->$method($this->_path);
+
+        switch ($assertType) {
+            case self::ASSERT_CONTENT_CONTAINS:
+                if (!$match) {
+                    require_once 'Zend/Test/PHPUnit/Constraint/Exception.php';
+                    throw new Zend_Test_PHPUnit_Constraint_Exception('No content provided against which to match');
+                }
+                $this->_content = $match;
+                return ($this->_negate)
+                    ? $this->_notMatchContent($result, $match)
+                    : $this->_matchContent($result, $match);
+            case self::ASSERT_CONTENT_REGEX:
+                if (!$match) {
+                    require_once 'Zend/Test/PHPUnit/Constraint/Exception.php';
+                    throw new Zend_Test_PHPUnit_Constraint_Exception('No pattern provided against which to match');
+                }
+                $this->_content = $match;
+                return ($this->_negate)
+                    ? $this->_notRegexContent($result, $match)
+                    : $this->_regexContent($result, $match);
+            case self::ASSERT_CONTENT_COUNT:
+            case self::ASSERT_CONTENT_COUNT_MIN:
+            case self::ASSERT_CONTENT_COUNT_MAX:
+                if ($match === false) {
+                    require_once 'Zend/Test/PHPUnit/Constraint/Exception.php';
+                    throw new Zend_Test_PHPUnit_Constraint_Exception('No count provided against which to compare');
+                }
+                $this->_content = $match;
+                return $this->_countContent($result, $match, $assertType);
+            case self::ASSERT_QUERY:
+            default:
+                if ($this->_negate) {
+                    return (0 == count($result));
+                } else {
+                    return (0 != count($result));
+                }
+        }
+    }
+
+    /**
+     * Report Failure
+     *
+     * @see    Constraint for implementation details
+     * @param  mixed $other CSS selector path
+     * @param  string $description Failure description
+     * @param  object $cannot_be_used Cannot be used, null
+     * @return void
+     * @throws PHPUnit_Framework_ExpectationFailedException
+     * NOTE:
+     * Drastic changes up to PHPUnit 3.5.15 this was:
+     *     public function fail($other, $description, $not = false)
+     * In PHPUnit 3.6.0 they changed the interface into this:
+     *     protected function fail($other, $description, PHPUnit_Framework_ComparisonFailure $comparisonFailure = NULL)
+     * We use the new interface for PHP-strict checking
+     * NOTE 2:
+     * Interface changed again in PHPUnit 4.1.0 because of refactoring to SebastianBergmann\Comparator
+     */
+    public function fail(mixed $other, string $description, ?ComparisonFailure $cannot_be_used = NULL): never
+    {
+        require_once 'Zend/Test/PHPUnit/Constraint/Exception.php';
+        switch ($this->_assertType) {
+            case self::ASSERT_CONTENT_CONTAINS:
+                $failure = 'Failed asserting node denoted by %s CONTAINS content "%s"';
+                if ($this->_negate) {
+                    $failure = 'Failed asserting node DENOTED BY %s DOES NOT CONTAIN content "%s"';
+                }
+                $failure = sprintf($failure, $other, $this->_content);
+                break;
+            case self::ASSERT_CONTENT_REGEX:
+                $failure = 'Failed asserting node denoted by %s CONTAINS content MATCHING "%s"';
+                if ($this->_negate) {
+                    $failure = 'Failed asserting node DENOTED BY %s DOES NOT CONTAIN content MATCHING "%s"';
+                }
+                $failure = sprintf($failure, $other, $this->_content);
+                break;
+            case self::ASSERT_CONTENT_COUNT:
+                $failure = 'Failed asserting node DENOTED BY %s OCCURS EXACTLY %d times';
+                if ($this->_negate) {
+                    $failure = 'Failed asserting node DENOTED BY %s DOES NOT OCCUR EXACTLY %d times';
+                }
+                $failure = sprintf($failure, $other, $this->_content);
+                break;
+            case self::ASSERT_CONTENT_COUNT_MIN:
+                $failure = 'Failed asserting node DENOTED BY %s OCCURS AT LEAST %d times';
+                $failure = sprintf($failure, $other, $this->_content);
+                break;
+            case self::ASSERT_CONTENT_COUNT_MAX:
+                $failure = 'Failed asserting node DENOTED BY %s OCCURS AT MOST %d times';
+                $failure = sprintf($failure, $other, $this->_content);
+                break;
+            case self::ASSERT_QUERY:
+            default:
+                $failure = 'Failed asserting node DENOTED BY %s EXISTS';
+                if ($this->_negate) {
+                    $failure = 'Failed asserting node DENOTED BY %s DOES NOT EXIST';
+                }
+                $failure = sprintf($failure, $other);
+                break;
+        }
+
+        if (!empty($description)) {
+            $failure = $description . "\n" . $failure;
+        }
+
+        throw new Zend_Test_PHPUnit_Constraint_Exception($failure);
+    }
+
+    /**
+     * Complete implementation
+     *
+     * @return string
+     */
+    public function toString(): string
+    {
+        return '';
+    }
+
+    /**
+     * Register XPath namespaces
+     *
+     * @param   array $xpathNamespaces
+     * @return  void
+     */
+    public function registerXpathNamespaces($xpathNamespaces)
+    {
+        $this->_xpathNamespaces = $xpathNamespaces;
+    }
+
+    /**
+     * Check to see if content is matched in selected nodes
+     *
+     * @param  Zend_Dom_Query_Result $result
+     * @param  string $match Content to match
+     * @return bool
+     */
+    protected function _matchContent($result, $match)
+    {
+        $match = (string) $match;
+
+        if (0 == count($result)) {
+            return false;
+        }
+
+        foreach ($result as $node) {
+            $content = $this->_getNodeContent($node);
+            if (strstr($content, $match)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Check to see if content is NOT matched in selected nodes
+     *
+     * @param  Zend_Dom_Query_Result $result
+     * @param  string $match
+     * @return bool
+     */
+    protected function _notMatchContent($result, $match)
+    {
+        if (0 == count($result)) {
+            return true;
+        }
+
+        foreach ($result as $node) {
+            $content = $this->_getNodeContent($node);
+            if (strstr($content, $match)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * Check to see if content is matched by regex in selected nodes
+     *
+     * @param  Zend_Dom_Query_Result $result
+     * @param  string $pattern
+     * @return bool
+     */
+    protected function _regexContent($result, $pattern)
+    {
+        if (0 == count($result)) {
+            return false;
+        }
+
+        foreach ($result as $node) {
+            $content = $this->_getNodeContent($node);
+            if (preg_match($pattern, $content)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Check to see if content is NOT matched by regex in selected nodes
+     *
+     * @param  Zend_Dom_Query_Result $result
+     * @param  string $pattern
+     * @return bool
+     */
+    protected function _notRegexContent($result, $pattern)
+    {
+        if (0 == count($result)) {
+            return true;
+        }
+
+        foreach ($result as $node) {
+            $content = $this->_getNodeContent($node);
+            if (preg_match($pattern, $content)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * Determine if content count matches criteria
+     *
+     * @param  Zend_Dom_Query_Result $result
+     * @param  int $test Value against which to test
+     * @param  string $type assertion type
+     * @return boolean
+     */
+    protected function _countContent($result, $test, $type)
+    {
+        $count = count($result);
+
+        switch ($type) {
+            case self::ASSERT_CONTENT_COUNT:
+                return ($this->_negate)
+                    ? ($test != $count)
+                    : ($test == $count);
+            case self::ASSERT_CONTENT_COUNT_MIN:
+                return ($count >= $test);
+            case self::ASSERT_CONTENT_COUNT_MAX:
+                return ($count <= $test);
+            default:
+                return false;
+        }
+    }
+
+    /**
+     * Get node content, minus node markup tags
+     *
+     * @param  DOMNode $node
+     * @return string
+     */
+    protected function _getNodeContent(DOMNode $node)
+    {
+        if ($node instanceof DOMAttr) {
+            return $node->value;
+        } else {
+            $doc     = $node->ownerDocument;
+            $content = $doc->saveXML($node);
+            $tag     = $node->nodeName;
+            $regex   = '|</?' . $tag . '[^>]*>|';
+            return preg_replace($regex, '', $content);
+        }
+    }
+}

--- a/library/Zend/Test/PHPUnit/Constraint/Exception.php
+++ b/library/Zend/Test/PHPUnit/Constraint/Exception.php
@@ -20,16 +20,22 @@
  * @version    $Id$
  */
 
-/**
- * Zend_Test_PHPUnit_Constraint_Exception
- *
- * @uses       PHPUnit_Framework_ExpectationFailedException
- * @category   Zend
- * @package    Zend_Test
- * @subpackage PHPUnit
- * @copyright  Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
- * @license    http://framework.zend.com/license/new-bsd     New BSD License
- */
-class Zend_Test_PHPUnit_Constraint_Exception extends PHPUnit_Framework_ExpectationFailedException
-{
+if (class_exists('PHPUnit\Runner\Version')) {
+	$id = PHPUnit\Runner\Version::id();
+} elseif (class_exists('PHPUnit_Runner_Version')) {
+	$id = PHPUnit_Runner_Version::id();
+} else {
+	$id = '0.0.0';
+}
+
+if (version_compare($id, '8.0', '>=')) {
+	include(dirname(__FILE__) . DIRECTORY_SEPARATOR . 'Exception80.php');
+
+	class Zend_Test_PHPUnit_Constraint_Exception extends Zend_Test_PHPUnit_Constraint_Exception80
+	{}
+} else {
+	include(dirname(__FILE__) . DIRECTORY_SEPARATOR . 'Exception34.php');
+
+	class Zend_Test_PHPUnit_Constraint_Exception extends Zend_Test_PHPUnit_Constraint_Exception34
+	{}
 }

--- a/library/Zend/Test/PHPUnit/Constraint/Exception.php
+++ b/library/Zend/Test/PHPUnit/Constraint/Exception.php
@@ -28,7 +28,7 @@ if (class_exists('PHPUnit\Runner\Version')) {
 	$id = '0.0.0';
 }
 
-if (version_compare($id, '8.0', '>=')) {
+if (version_compare($id, '6.0', '>=')) {
 	include(dirname(__FILE__) . DIRECTORY_SEPARATOR . 'Exception80.php');
 
 	class Zend_Test_PHPUnit_Constraint_Exception extends Zend_Test_PHPUnit_Constraint_Exception80

--- a/library/Zend/Test/PHPUnit/Constraint/Exception34.php
+++ b/library/Zend/Test/PHPUnit/Constraint/Exception34.php
@@ -20,20 +20,16 @@
  * @version    $Id$
  */
 
-if (class_exists('PHPUnit\Runner\Version')) {
-	$id = PHPUnit\Runner\Version::id();
-} elseif (class_exists('PHPUnit_Runner_Version')) {
-	$id = PHPUnit_Runner_Version::id();
-} else {
-	$id = '0.0.0';
-}
-
-if (version_compare($id, '8.0', '>=')) {
-	include(dirname(__FILE__) . DIRECTORY_SEPARATOR . 'ControllerTestCase80.php');
-	class Zend_Test_PHPUnit_ControllerTestCase extends Zend_Test_PHPUnit_ControllerTestCase80
-	{}
-} else {
-	include(dirname(__FILE__) . DIRECTORY_SEPARATOR . 'ControllerTestCase34.php');
-	class Zend_Test_PHPUnit_ControllerTestCase extends Zend_Test_PHPUnit_ControllerTestCase34
-	{}
+/**
+ * Zend_Test_PHPUnit_Constraint_Exception
+ *
+ * @uses       PHPUnit_Framework_ExpectationFailedException
+ * @category   Zend
+ * @package    Zend_Test
+ * @subpackage PHPUnit
+ * @copyright  Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license    http://framework.zend.com/license/new-bsd     New BSD License
+ */
+class Zend_Test_PHPUnit_Constraint_Exception34 extends PHPUnit_Framework_ExpectationFailedException
+{
 }

--- a/library/Zend/Test/PHPUnit/Constraint/Exception80.php
+++ b/library/Zend/Test/PHPUnit/Constraint/Exception80.php
@@ -20,20 +20,16 @@
  * @version    $Id$
  */
 
-if (class_exists('PHPUnit\Runner\Version')) {
-	$id = PHPUnit\Runner\Version::id();
-} elseif (class_exists('PHPUnit_Runner_Version')) {
-	$id = PHPUnit_Runner_Version::id();
-} else {
-	$id = '0.0.0';
-}
-
-if (version_compare($id, '8.0', '>=')) {
-	include(dirname(__FILE__) . DIRECTORY_SEPARATOR . 'ControllerTestCase80.php');
-	class Zend_Test_PHPUnit_ControllerTestCase extends Zend_Test_PHPUnit_ControllerTestCase80
-	{}
-} else {
-	include(dirname(__FILE__) . DIRECTORY_SEPARATOR . 'ControllerTestCase34.php');
-	class Zend_Test_PHPUnit_ControllerTestCase extends Zend_Test_PHPUnit_ControllerTestCase34
-	{}
+/**
+ * Zend_Test_PHPUnit_Constraint_Exception
+ *
+ * @uses       PHPUnit_Framework_ExpectationFailedException
+ * @category   Zend
+ * @package    Zend_Test
+ * @subpackage PHPUnit
+ * @copyright  Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license    http://framework.zend.com/license/new-bsd     New BSD License
+ */
+class Zend_Test_PHPUnit_Constraint_Exception80 extends PHPUnit\Framework\AssertionFailedError
+{
 }

--- a/library/Zend/Test/PHPUnit/Constraint/Redirect.php
+++ b/library/Zend/Test/PHPUnit/Constraint/Redirect.php
@@ -28,7 +28,7 @@ if (class_exists('PHPUnit\Runner\Version')) {
 	$id = '0.0.0';
 }
 
-if (version_compare($id, '8.0', '>=')) {
+if (version_compare($id, '6.0', '>=')) {
 	include(dirname(__FILE__) . DIRECTORY_SEPARATOR . 'Redirect80.php');
 
 	class Zend_Test_PHPUnit_Constraint_Redirect extends Zend_Test_PHPUnit_Constraint_Redirect80

--- a/library/Zend/Test/PHPUnit/Constraint/Redirect.php
+++ b/library/Zend/Test/PHPUnit/Constraint/Redirect.php
@@ -20,12 +20,25 @@
  * @version    $Id$
  */
 
-if (version_compare(PHPUnit_Runner_Version::id(), '4.1', '>=')) {
+if (class_exists('PHPUnit\Runner\Version')) {
+	$id = PHPUnit\Runner\Version::id();
+} elseif (class_exists('PHPUnit_Runner_Version')) {
+	$id = PHPUnit_Runner_Version::id();
+} else {
+	$id = '0.0.0';
+}
+
+if (version_compare($id, '8.0', '>=')) {
+	include(dirname(__FILE__) . DIRECTORY_SEPARATOR . 'Redirect80.php');
+
+	class Zend_Test_PHPUnit_Constraint_Redirect extends Zend_Test_PHPUnit_Constraint_Redirect80
+	{}
+} elseif (version_compare($id, '4.1', '>=')) {
     include(dirname(__FILE__) . DIRECTORY_SEPARATOR . 'Redirect41.php');
 
     class Zend_Test_PHPUnit_Constraint_Redirect extends Zend_Test_PHPUnit_Constraint_Redirect41
     {}
-} elseif (version_compare(PHPUnit_Runner_Version::id(), '3.5', '>=')) {
+} elseif (version_compare($id, '3.5', '>=')) {
     include(dirname(__FILE__) . DIRECTORY_SEPARATOR . 'Redirect37.php');
 
     class Zend_Test_PHPUnit_Constraint_Redirect extends Zend_Test_PHPUnit_Constraint_Redirect37

--- a/library/Zend/Test/PHPUnit/Constraint/Redirect80.php
+++ b/library/Zend/Test/PHPUnit/Constraint/Redirect80.php
@@ -1,0 +1,320 @@
+<?php
+/**
+ * Zend Framework
+ *
+ * LICENSE
+ *
+ * This source file is subject to the new BSD license that is bundled
+ * with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://framework.zend.com/license/new-bsd
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@zend.com so we can send you a copy immediately.
+ *
+ * @category   Zend
+ * @package    Zend_Test
+ * @subpackage PHPUnit
+ * @copyright  Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license    http://framework.zend.com/license/new-bsd     New BSD License
+ * @version    $Id$
+ */
+
+use PHPUnit\Framework\Constraint\Constraint;
+use SebastianBergmann\Comparator\ComparisonFailure;
+
+/**
+ * Redirection constraints
+ *
+ * @uses       PHPUnit_Framework_Constraint
+ * @category   Zend
+ * @package    Zend_Test
+ * @subpackage PHPUnit
+ * @copyright  Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license    http://framework.zend.com/license/new-bsd     New BSD License
+ */
+class Zend_Test_PHPUnit_Constraint_Redirect80 extends Constraint
+{
+    /**#@+
+     * Assertion type constants
+     */
+    public const ASSERT_REDIRECT       = 'assertRedirect';
+    public const ASSERT_REDIRECT_TO    = 'assertRedirectTo';
+    public const ASSERT_REDIRECT_REGEX = 'assertRedirectRegex';
+    /**#@-*/
+
+    /**
+     * Current assertion type
+     * @var string
+     */
+    protected $_assertType      = null;
+
+    /**
+     * Available assertion types
+     * @var array
+     */
+    protected $_assertTypes     = [
+        self::ASSERT_REDIRECT,
+        self::ASSERT_REDIRECT_TO,
+        self::ASSERT_REDIRECT_REGEX,
+    ];
+
+    /**
+     * Pattern to match against
+     * @var string
+     */
+    protected $_match             = null;
+
+    /**
+     * What is actual redirect
+     */
+    protected $_actual            = null;
+
+    /**
+     * Whether or not assertion is negated
+     * @var bool
+     */
+    protected $_negate            = false;
+
+    /**
+     * Constructor; setup constraint state
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+    }
+
+    /**
+     * Indicate negative match
+     *
+     * @param  bool $flag
+     * @return void
+     */
+    public function setNegate($flag = true)
+    {
+        $this->_negate = $flag;
+    }
+
+    /**
+     * Evaluate an object to see if it fits the constraints
+     *
+     * @param  string $other String to examine
+     * @param  null|string $assertType Assertion type
+     * @return bool
+     * NOTE:
+     * Drastic changes up to PHPUnit 3.5.15 this was:
+     *     public function evaluate($other, $assertType = null)
+     * In PHPUnit 3.6.0 they changed the interface into this:
+     *     public function evaluate($other, $description = '', $returnResult = FALSE)
+     * We use the new interface for PHP-strict checking, but emulate the old one
+     */
+    public function evaluate_compat($other, $assertType = null, $variable = FALSE)
+    {
+        if (!$other instanceof Zend_Controller_Response_Abstract) {
+            require_once 'Zend/Test/PHPUnit/Constraint/Exception.php';
+            throw new Zend_Test_PHPUnit_Constraint_Exception('Redirect constraint assertions require a response object');
+        }
+
+        if (strstr($assertType, 'Not')) {
+            $this->setNegate(true);
+            $assertType = str_replace('Not', '', $assertType);
+        }
+
+        if (!in_array($assertType, $this->_assertTypes)) {
+            require_once 'Zend/Test/PHPUnit/Constraint/Exception.php';
+            throw new Zend_Test_PHPUnit_Constraint_Exception(sprintf('Invalid assertion type "%s" provided to %s constraint', $assertType, __CLASS__));
+        }
+
+        $this->_assertType = $assertType;
+
+        $response = $other;
+        $argv     = func_get_args();
+        $argc     = func_num_args();
+
+        switch ($assertType) {
+            case self::ASSERT_REDIRECT_TO:
+                if (3 > $argc) {
+                    require_once 'Zend/Test/PHPUnit/Constraint/Exception.php';
+                    throw new Zend_Test_PHPUnit_Constraint_Exception('No redirect URL provided against which to match');
+                }
+                $this->_match = $match = $argv[2];
+                return ($this->_negate)
+                    ? $this->_notMatch($response, $match)
+                    : $this->_match($response, $match);
+            case self::ASSERT_REDIRECT_REGEX:
+                if (3 > $argc) {
+                    require_once 'Zend/Test/PHPUnit/Constraint/Exception.php';
+                    throw new Zend_Test_PHPUnit_Constraint_Exception('No pattern provided against which to match redirect');
+                }
+                $this->_match = $match = $argv[2];
+                return ($this->_negate)
+                    ? $this->_notRegex($response, $match)
+                    : $this->_regex($response, $match);
+            case self::ASSERT_REDIRECT:
+            default:
+                $headers  = $response->sendHeaders();
+                if (isset($headers['location'])) {
+                    $redirect = $headers['location'];
+                    $redirect = str_replace('Location: ', '', $redirect);
+                    $this->_actual = $redirect;
+                }
+                return ($this->_negate) ? !$response->isRedirect() : $response->isRedirect();
+        }
+    }
+
+    /**
+     * Report Failure
+     *
+     * @see    PHPUnit_Framework_Constraint for implementation details
+     * @param  mixed $other
+     * @param  string $description Additional message to display
+     * @param  bool $not
+     * @return void
+     * @throws PHPUnit_Framework_ExpectationFailedException
+     * NOTE:
+     * Drastic changes up to PHPUnit 3.5.15 this was:
+     *     public function fail($other, $description, $not = false)
+     * In PHPUnit 3.6.0 they changed the interface into this:
+     *     protected function fail($other, $description, PHPUnit_Framework_ComparisonFailure $comparisonFailure = NULL)
+     * We use the new interface for PHP-strict checking
+     * NOTE 2:
+     * Interface changed again in PHPUnit 4.1.0 because of refactoring to SebastianBergmann\Comparator
+     */
+    public function fail(mixed $other, string $description, ?ComparisonFailure $cannot_be_used = NULL): never
+    {
+        require_once 'Zend/Test/PHPUnit/Constraint/Exception.php';
+        switch ($this->_assertType) {
+            case self::ASSERT_REDIRECT_TO:
+                $failure = 'Failed asserting response redirects to "%s"';
+                if ($this->_negate) {
+                    $failure = 'Failed asserting response DOES NOT redirect to "%s"';
+                }
+                $failure = sprintf($failure, $this->_match);
+                if (!$this->_negate && $this->_actual) {
+                    $failure .= sprintf(PHP_EOL . 'It redirects to "%s".', $this->_actual);
+                }
+                break;
+            case self::ASSERT_REDIRECT_REGEX:
+                $failure = 'Failed asserting response redirects to URL MATCHING "%s"';
+                if ($this->_negate) {
+                    $failure = 'Failed asserting response DOES NOT redirect to URL MATCHING "%s"';
+                }
+                $failure = sprintf($failure, $this->_match);
+                if ($this->_actual) {
+                    $failure .= sprintf(PHP_EOL . 'It redirects to "%s".', $this->_actual);
+                }
+                break;
+            case self::ASSERT_REDIRECT:
+            default:
+                $failure = 'Failed asserting response is a redirect';
+                if ($this->_negate) {
+                    $failure = 'Failed asserting response is NOT a redirect';
+                    if ($this->_actual) {
+                        $failure .= sprintf(PHP_EOL . 'It redirects to "%s"', $this->_actual);
+                    }
+                }
+                break;
+        }
+
+        if (!empty($description)) {
+            $failure = $description . "\n" . $failure;
+        }
+
+        throw new Zend_Test_PHPUnit_Constraint_Exception($failure);
+    }
+
+    /**
+     * Complete implementation
+     *
+     * @return string
+     */
+    public function toString(): string
+    {
+        return '';
+    }
+
+    /**
+     * Check to see if content is matched in selected nodes
+     *
+     * @param  Zend_Controller_Response_HttpTestCase $response
+     * @param  string $match Content to match
+     * @return bool
+     */
+    protected function _match($response, $match)
+    {
+        if (!$response->isRedirect()) {
+            return false;
+        }
+
+        $headers  = $response->sendHeaders();
+        $redirect = $headers['location'];
+        $redirect = str_replace('Location: ', '', $redirect);
+        $this->_actual = $redirect;
+
+        return ($redirect == $match);
+    }
+
+    /**
+     * Check to see if content is NOT matched in selected nodes
+     *
+     * @param  Zend_Controller_Response_HttpTestCase $response
+     * @param  string $match
+     * @return bool
+     */
+    protected function _notMatch($response, $match)
+    {
+        if (!$response->isRedirect()) {
+            return true;
+        }
+
+        $headers  = $response->sendHeaders();
+        $redirect = $headers['location'];
+        $redirect = str_replace('Location: ', '', $redirect);
+        $this->_actual = $redirect;
+
+        return ($redirect != $match);
+    }
+
+    /**
+     * Check to see if content is matched by regex in selected nodes
+     *
+     * @param  Zend_Controller_Response_HttpTestCase $response
+     * @param  string $pattern
+     * @return bool
+     */
+    protected function _regex($response, $pattern)
+    {
+        if (!$response->isRedirect()) {
+            return false;
+        }
+
+        $headers  = $response->sendHeaders();
+        $redirect = $headers['location'];
+        $redirect = str_replace('Location: ', '', $redirect);
+        $this->_actual = $redirect;
+
+        return preg_match($pattern, $redirect);
+    }
+
+    /**
+     * Check to see if content is NOT matched by regex in selected nodes
+     *
+     * @param  Zend_Controller_Response_HttpTestCase $response
+     * @param  string $pattern
+     * @return bool
+     */
+    protected function _notRegex($response, $pattern)
+    {
+        if (!$response->isRedirect()) {
+            return true;
+        }
+
+        $headers  = $response->sendHeaders();
+        $redirect = $headers['location'];
+        $redirect = str_replace('Location: ', '', $redirect);
+        $this->_actual = $redirect;
+
+        return !preg_match($pattern, $redirect);
+    }
+}

--- a/library/Zend/Test/PHPUnit/Constraint/ResponseHeader.php
+++ b/library/Zend/Test/PHPUnit/Constraint/ResponseHeader.php
@@ -28,7 +28,7 @@ if (class_exists('PHPUnit\Runner\Version')) {
 	$id = '0.0.0';
 }
 
-if (version_compare($id, '8.0', '>=')) {
+if (version_compare($id, '6.0', '>=')) {
 	include(dirname(__FILE__) . DIRECTORY_SEPARATOR . 'ResponseHeader80.php');
 
 	class Zend_Test_PHPUnit_Constraint_ResponseHeader extends Zend_Test_PHPUnit_Constraint_ResponseHeader80

--- a/library/Zend/Test/PHPUnit/Constraint/ResponseHeader.php
+++ b/library/Zend/Test/PHPUnit/Constraint/ResponseHeader.php
@@ -20,12 +20,25 @@
  * @version    $Id$
  */
 
-if (version_compare(PHPUnit_Runner_Version::id(), '4.1', '>=')) {
+if (class_exists('PHPUnit\Runner\Version')) {
+	$id = PHPUnit\Runner\Version::id();
+} elseif (class_exists('PHPUnit_Runner_Version')) {
+	$id = PHPUnit_Runner_Version::id();
+} else {
+	$id = '0.0.0';
+}
+
+if (version_compare($id, '8.0', '>=')) {
+	include(dirname(__FILE__) . DIRECTORY_SEPARATOR . 'ResponseHeader80.php');
+
+	class Zend_Test_PHPUnit_Constraint_ResponseHeader extends Zend_Test_PHPUnit_Constraint_ResponseHeader80
+	{}
+} elseif (version_compare($id, '4.1', '>=')) {
     include(dirname(__FILE__) . DIRECTORY_SEPARATOR . 'ResponseHeader41.php');
 
     class Zend_Test_PHPUnit_Constraint_ResponseHeader extends Zend_Test_PHPUnit_Constraint_ResponseHeader41
     {}
-} elseif (version_compare(PHPUnit_Runner_Version::id(), '3.5', '>=')) {
+} elseif (version_compare($id, '3.5', '>=')) {
     include(dirname(__FILE__) . DIRECTORY_SEPARATOR . 'ResponseHeader37.php');
 
     class Zend_Test_PHPUnit_Constraint_ResponseHeader extends Zend_Test_PHPUnit_Constraint_ResponseHeader37

--- a/library/Zend/Test/PHPUnit/Constraint/ResponseHeader80.php
+++ b/library/Zend/Test/PHPUnit/Constraint/ResponseHeader80.php
@@ -1,0 +1,424 @@
+<?php
+/**
+ * Zend Framework
+ *
+ * LICENSE
+ *
+ * This source file is subject to the new BSD license that is bundled
+ * with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://framework.zend.com/license/new-bsd
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@zend.com so we can send you a copy immediately.
+ *
+ * @category   Zend
+ * @package    Zend_Test
+ * @subpackage PHPUnit
+ * @copyright  Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license    http://framework.zend.com/license/new-bsd     New BSD License
+ * @version    $Id$
+ */
+
+use PHPUnit\Framework\Constraint\Constraint;
+use SebastianBergmann\Comparator\ComparisonFailure;
+
+/**
+ * Response header PHPUnit Constraint
+ *
+ * @uses       PHPUnit_Framework_Constraint
+ * @category   Zend
+ * @package    Zend_Test
+ * @subpackage PHPUnit
+ * @copyright  Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license    http://framework.zend.com/license/new-bsd     New BSD License
+ */
+class Zend_Test_PHPUnit_Constraint_ResponseHeader80 extends Constraint
+{
+    /**#@+
+     * Assertion type constants
+     */
+    public const ASSERT_RESPONSE_CODE   = 'assertResponseCode';
+    public const ASSERT_HEADER          = 'assertHeader';
+    public const ASSERT_HEADER_CONTAINS = 'assertHeaderContains';
+    public const ASSERT_HEADER_REGEX    = 'assertHeaderRegex';
+    /**#@-*/
+
+    /**
+     * Current assertion type
+     * @var string
+     */
+    protected $_assertType      = null;
+
+    /**
+     * Available assertion types
+     * @var array
+     */
+    protected $_assertTypes     = [
+        self::ASSERT_RESPONSE_CODE,
+        self::ASSERT_HEADER,
+        self::ASSERT_HEADER_CONTAINS,
+        self::ASSERT_HEADER_REGEX,
+    ];
+
+    /**
+     * @var int Response code
+     */
+    protected $_code              = 200;
+
+    /**
+     * @var int Actual response code
+     */
+    protected $_actualCode        = null;
+
+    /**
+     * @var string Header
+     */
+    protected $_header            = null;
+
+    /**
+     * @var string pattern against which to compare header content
+     */
+    protected $_match             = null;
+
+    /**
+     * Whether or not assertion is negated
+     * @var bool
+     */
+    protected $_negate            = false;
+
+    /**
+     * Constructor; setup constraint state
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+    }
+
+    /**
+     * Indicate negative match
+     *
+     * @param  bool $flag
+     * @return void
+     */
+    public function setNegate($flag = true)
+    {
+        $this->_negate = $flag;
+    }
+
+    /**
+     * Evaluate an object to see if it fits the constraints
+     *
+     * @param  object $response of Zend_Controller_Response_Abstract to be evaluated
+     * @param  null|string $assertType Assertion type
+     * @param  int|string $variable HTTP response code to evaluate against | header string (haystack)
+     * @param  string (optional) match (needle), may be required depending on assertion type
+     * @return bool
+     * NOTE:
+     * Drastic changes up to PHPUnit 3.5.15 this was:
+     *     public function evaluate($other, $assertType = null)
+     * In PHPUnit 3.6.0 they changed the interface into this:
+     *     public function evaluate($other, $description = '', $returnResult = FALSE)
+     * We use the new interface for PHP-strict checking, but emulate the old one
+     */
+    public function evaluate_compat($response, $assertType = '', $variable = FALSE)
+    {
+        if (!$response instanceof Zend_Controller_Response_Abstract) {
+            require_once 'Zend/Test/PHPUnit/Constraint/Exception.php';
+            throw new Zend_Test_PHPUnit_Constraint_Exception('Header constraint assertions require a response object');
+        }
+
+        if (strstr($assertType, 'Not')) {
+            $this->setNegate(true);
+            $assertType = str_replace('Not', '', $assertType);
+        }
+
+        if (!in_array($assertType, $this->_assertTypes)) {
+            require_once 'Zend/Test/PHPUnit/Constraint/Exception.php';
+            throw new Zend_Test_PHPUnit_Constraint_Exception(sprintf('Invalid assertion type "%s" provided to %s constraint', $assertType, __CLASS__));
+        }
+
+        $this->_assertType = $assertType;
+
+        $argv     = func_get_args();
+        $argc     = func_num_args();
+
+        switch ($assertType) {
+            case self::ASSERT_RESPONSE_CODE:
+                if (3 > $argc) {
+                    require_once 'Zend/Test/PHPUnit/Constraint/Exception.php';
+                    throw new Zend_Test_PHPUnit_Constraint_Exception('No response code provided against which to match');
+                }
+                $this->_code = $code = $argv[2];
+                return ($this->_negate)
+                    ? $this->_notCode($response, $code)
+                    : $this->_code($response, $code);
+            case self::ASSERT_HEADER:
+                if (3 > $argc) {
+                    require_once 'Zend/Test/PHPUnit/Constraint/Exception.php';
+                    throw new Zend_Test_PHPUnit_Constraint_Exception('No header provided against which to match');
+                }
+                $this->_header = $header = $argv[2];
+                return ($this->_negate)
+                    ? $this->_notHeader($response, $header)
+                    : $this->_header($response, $header);
+            case self::ASSERT_HEADER_CONTAINS:
+                if (4 > $argc) {
+                    require_once 'Zend/Test/PHPUnit/Constraint/Exception.php';
+                    throw new Zend_Test_PHPUnit_Constraint_Exception('Both a header name and content to match are required for ' . $assertType);
+                }
+                $this->_header = $header = $argv[2];
+                $this->_match  = $match  = $argv[3];
+                return ($this->_negate)
+                    ? $this->_notHeaderContains($response, $header, $match)
+                    : $this->_headerContains($response, $header, $match);
+            case self::ASSERT_HEADER_REGEX:
+                if (4 > $argc) {
+                    require_once 'Zend/Test/PHPUnit/Constraint/Exception.php';
+                    throw new Zend_Test_PHPUnit_Constraint_Exception('Both a header name and content to match are required for ' . $assertType);
+                }
+                $this->_header = $header = $argv[2];
+                $this->_match  = $match  = $argv[3];
+                return ($this->_negate)
+                    ? $this->_notHeaderRegex($response, $header, $match)
+                    : $this->_headerRegex($response, $header, $match);
+            default:
+                require_once 'Zend/Test/PHPUnit/Constraint/Exception.php';
+                throw new Zend_Test_PHPUnit_Constraint_Exception('Invalid assertion type ' . $assertType);
+        }
+    }
+
+    /**
+     * Report Failure
+     *
+     * @see    PHPUnit_Framework_Constraint for implementation details
+     * @param  mixed $other CSS selector path
+     * @param  string $description Failure description
+     * @param  object $cannot_be_used Cannot be used, null
+     * @return void
+     * @throws PHPUnit_Framework_ExpectationFailedException
+     * NOTE:
+     * Drastic changes up to PHPUnit 3.5.15 this was:
+     *     public function fail($other, $description, $not = false)
+     * In PHPUnit 3.6.0 they changed the interface into this:
+     *     protected function fail($other, $description, PHPUnit_Framework_ComparisonFailure $comparisonFailure = NULL)
+     * We use the new interface for PHP-strict checking
+     * NOTE 2:
+     * Interface changed again in PHPUnit 4.1.0 because of refactoring to SebastianBergmann\Comparator
+     */
+    public function fail(mixed $other, string $description, ?ComparisonFailure $cannot_be_used = NULL): never
+    {
+        require_once 'Zend/Test/PHPUnit/Constraint/Exception.php';
+        switch ($this->_assertType) {
+            case self::ASSERT_RESPONSE_CODE:
+                $failure = 'Failed asserting response code "%s"';
+                if ($this->_negate) {
+                    $failure = 'Failed asserting response code IS NOT "%s"';
+                }
+                $failure = sprintf($failure, $this->_code);
+                if (!$this->_negate && $this->_actualCode) {
+                    $failure .= sprintf(PHP_EOL . 'Was "%s"', $this->_actualCode);
+                }
+                break;
+            case self::ASSERT_HEADER:
+                $failure = 'Failed asserting response header "%s" found';
+                if ($this->_negate) {
+                    $failure = 'Failed asserting response response header "%s" WAS NOT found';
+                }
+                $failure = sprintf($failure, $this->_header);
+                break;
+            case self::ASSERT_HEADER_CONTAINS:
+                $failure = 'Failed asserting response header "%s" exists and contains "%s"';
+                if ($this->_negate) {
+                    $failure = 'Failed asserting response header "%s" DOES NOT CONTAIN "%s"';
+                }
+                $failure = sprintf($failure, $this->_header, $this->_match);
+                break;
+            case self::ASSERT_HEADER_REGEX:
+                $failure = 'Failed asserting response header "%s" exists and matches regex "%s"';
+                if ($this->_negate) {
+                    $failure = 'Failed asserting response header "%s" DOES NOT MATCH regex "%s"';
+                }
+                $failure = sprintf($failure, $this->_header, $this->_match);
+                break;
+            default:
+                throw new Zend_Test_PHPUnit_Constraint_Exception('Invalid assertion type ' . __FUNCTION__);
+        }
+
+        if (!empty($description)) {
+            $failure = $description . "\n" . $failure;
+        }
+
+        throw new Zend_Test_PHPUnit_Constraint_Exception($failure);
+    }
+
+    /**
+     * Complete implementation
+     *
+     * @return string
+     */
+    public function toString(): string
+    {
+        return '';
+    }
+
+    /**
+     * Compare response code for positive match
+     *
+     * @param  Zend_Controller_Response_Abstract $response
+     * @param  int $code
+     * @return bool
+     */
+    protected function _code(Zend_Controller_Response_Abstract $response, $code)
+    {
+        $test = $this->_getCode($response);
+        $this->_actualCode = $test;
+        return ($test == $code);
+    }
+
+    /**
+     * Compare response code for negative match
+     *
+     * @param  Zend_Controller_Response_Abstract $response
+     * @param  int $code
+     * @return bool
+     */
+    protected function _notCode(Zend_Controller_Response_Abstract $response, $code)
+    {
+        $test = $this->_getCode($response);
+        return ($test != $code);
+    }
+
+    /**
+     * Retrieve response code
+     *
+     * @param  Zend_Controller_Response_Abstract $response
+     * @return int
+     */
+    protected function _getCode(Zend_Controller_Response_Abstract $response)
+    {
+        $test = $response->getHttpResponseCode();
+        if (null === $test) {
+            $test = 200;
+        }
+        return $test;
+    }
+
+    /**
+     * Positive check for response header presence
+     *
+     * @param  Zend_Controller_Response_Abstract $response
+     * @param  string $header
+     * @return bool
+     */
+    protected function _header(Zend_Controller_Response_Abstract $response, $header)
+    {
+        return (null !== $this->_getHeader($response, $header));
+    }
+
+    /**
+     * Negative check for response header presence
+     *
+     * @param  Zend_Controller_Response_Abstract $response
+     * @param  string $header
+     * @return bool
+     */
+    protected function _notHeader(Zend_Controller_Response_Abstract $response, $header)
+    {
+        return (null === $this->_getHeader($response, $header));
+    }
+
+    /**
+     * Retrieve response header
+     *
+     * @param  Zend_Controller_Response_Abstract $response
+     * @param  string $header
+     * @return string|null
+     */
+    protected function _getHeader(Zend_Controller_Response_Abstract $response, $header)
+    {
+        $headers = $response->sendHeaders();
+        $header  = strtolower($header);
+        if (array_key_exists($header, $headers)) {
+            return $headers[$header];
+        }
+        return null;
+    }
+
+    /**
+     * Positive check for header contents matching pattern
+     *
+     * @param  Zend_Controller_Response_Abstract $response
+     * @param  string $header
+     * @param  string $match
+     * @return bool
+     */
+    protected function _headerContains(Zend_Controller_Response_Abstract $response, $header, $match)
+    {
+        if (null === ($fullHeader = $this->_getHeader($response, $header))) {
+            return false;
+        }
+
+        $contents = str_replace($header . ': ', '', $fullHeader);
+
+        return (strstr($contents, $match) !== false);
+    }
+
+    /**
+     * Negative check for header contents matching pattern
+     *
+     * @param  Zend_Controller_Response_Abstract $response
+     * @param  string $header
+     * @param  string $match
+     * @return bool
+     */
+    protected function _notHeaderContains(Zend_Controller_Response_Abstract $response, $header, $match)
+    {
+        if (null === ($fullHeader = $this->_getHeader($response, $header))) {
+            return true;
+        }
+
+        $contents = str_replace($header . ': ', '', $fullHeader);
+
+        return (strstr($contents, $match) === false);
+    }
+
+    /**
+     * Positive check for header contents matching regex
+     *
+     * @param  Zend_Controller_Response_Abstract $response
+     * @param  string $header
+     * @param  string $pattern
+     * @return bool
+     */
+    protected function _headerRegex(Zend_Controller_Response_Abstract $response, $header, $pattern)
+    {
+        if (null === ($fullHeader = $this->_getHeader($response, $header))) {
+            return false;
+        }
+
+        $contents = str_replace($header . ': ', '', $fullHeader);
+
+        return preg_match($pattern, $contents);
+    }
+
+    /**
+     * Negative check for header contents matching regex
+     *
+     * @param  Zend_Controller_Response_Abstract $response
+     * @param  string $header
+     * @param  string $pattern
+     * @return bool
+     */
+    protected function _notHeaderRegex(Zend_Controller_Response_Abstract $response, $header, $pattern)
+    {
+        if (null === ($fullHeader = $this->_getHeader($response, $header))) {
+            return true;
+        }
+
+        $contents = str_replace($header . ': ', '', $fullHeader);
+
+        return !preg_match($pattern, $contents);
+    }
+}

--- a/library/Zend/Test/PHPUnit/ControllerTestCase.php
+++ b/library/Zend/Test/PHPUnit/ControllerTestCase.php
@@ -28,7 +28,7 @@ if (class_exists('PHPUnit\Runner\Version')) {
 	$id = '0.0.0';
 }
 
-if (version_compare($id, '8.0', '>=')) {
+if (version_compare($id, '6.0', '>=')) {
 	include(dirname(__FILE__) . DIRECTORY_SEPARATOR . 'ControllerTestCase80.php');
 	class Zend_Test_PHPUnit_ControllerTestCase extends Zend_Test_PHPUnit_ControllerTestCase80
 	{}

--- a/library/Zend/Test/PHPUnit/ControllerTestCase34.php
+++ b/library/Zend/Test/PHPUnit/ControllerTestCase34.php
@@ -1,0 +1,1165 @@
+<?php
+/**
+ * Zend Framework
+ *
+ * LICENSE
+ *
+ * This source file is subject to the new BSD license that is bundled
+ * with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://framework.zend.com/license/new-bsd
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@zend.com so we can send you a copy immediately.
+ *
+ * @category   Zend
+ * @package    Zend_Test
+ * @copyright  Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license    http://framework.zend.com/license/new-bsd     New BSD License
+ * @version    $Id$
+ */
+
+/** @see Zend_Controller_Front */
+require_once 'Zend/Controller/Front.php';
+
+/** @see Zend_Controller_Action_HelperBroker */
+require_once 'Zend/Controller/Action/HelperBroker.php';
+
+/** @see Zend_Layout */
+require_once 'Zend/Layout.php';
+
+/** @see Zend_Session */
+require_once 'Zend/Session.php';
+
+/** @see Zend_Registry */
+require_once 'Zend/Registry.php';
+
+/**
+ * Functional testing scaffold for MVC applications
+ *
+ * @uses       PHPUnit_Framework_TestCase
+ * @category   Zend
+ * @package    Zend_Test
+ * @subpackage PHPUnit
+ * @copyright  Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license    http://framework.zend.com/license/new-bsd     New BSD License
+ */
+abstract class Zend_Test_PHPUnit_ControllerTestCase34 extends PHPUnit_Framework_TestCase
+{
+    /**
+     * @var mixed Bootstrap file path or callback
+     */
+    public $bootstrap;
+
+    /**
+     * @var Zend_Controller_Front
+     */
+    protected $_frontController;
+
+    /**
+     * @var Zend_Dom_Query
+     */
+    protected $_query;
+
+    /**
+     * @var Zend_Controller_Request_Abstract
+     */
+    protected $_request;
+
+    /**
+     * @var Zend_Controller_Response_Abstract
+     */
+    protected $_response;
+
+    /**
+     * XPath namespaces
+     * @var array
+     */
+    protected $_xpathNamespaces = [];
+
+    /**
+     * Overloading: prevent overloading to special properties
+     *
+     * @param  string $name
+     * @param  mixed  $value
+     * @throws Zend_Exception
+     */
+    public function __set($name, $value)
+    {
+        if (in_array($name, ['request', 'response', 'frontController'])) {
+            require_once 'Zend/Exception.php';
+            throw new Zend_Exception(sprintf('Setting %s object manually is not allowed', $name));
+        }
+        $this->$name = $value;
+    }
+
+    /**
+     * Overloading for common properties
+     *
+     * Provides overloading for request, response, and frontController objects.
+     *
+     * @param  mixed $name
+     * @return null|Zend_Controller_Front|Zend_Controller_Request_HttpTestCase|Zend_Controller_Response_HttpTestCase
+     */
+    public function __get($name)
+    {
+        switch ($name) {
+            case 'request':
+                return $this->getRequest();
+            case 'response':
+                return $this->getResponse();
+            case 'frontController':
+                return $this->getFrontController();
+        }
+
+        return null;
+    }
+
+    /**
+     * Set up MVC app
+     *
+     * Calls {@link bootstrap()} by default
+     */
+    protected function setUp(): void
+    {
+        $this->bootstrap();
+    }
+
+    /**
+     * Bootstrap the front controller
+     *
+     * Resets the front controller, and then bootstraps it.
+     *
+     * If {@link $bootstrap} is a callback, executes it; if it is a file, it include's
+     * it. When done, sets the test case request and response objects into the
+     * front controller.
+     */
+    final public function bootstrap(): void
+    {
+        $this->reset();
+        if (null !== $this->bootstrap) {
+            if ($this->bootstrap instanceof Zend_Application) {
+                $this->bootstrap->bootstrap();
+                $this->_frontController = $this->bootstrap->getBootstrap()->getResource('frontcontroller');
+            } elseif (is_callable($this->bootstrap)) {
+                call_user_func($this->bootstrap);
+            } elseif (is_string($this->bootstrap)) {
+                require_once 'Zend/Loader.php';
+                if (Zend_Loader::isReadable($this->bootstrap)) {
+                    include $this->bootstrap;
+                }
+            }
+        }
+        $this->frontController
+             ->setRequest($this->getRequest())
+             ->setResponse($this->getResponse());
+    }
+
+    /**
+     * Dispatch the MVC
+     *
+     * If a URL is provided, sets it as the request URI in the request object.
+     * Then sets test case request and response objects in front controller,
+     * disables throwing exceptions, and disables returning the response.
+     * Finally, dispatches the front controller.
+     *
+     * @param string|null $url
+     */
+    public function dispatch($url = null)
+    {
+        // redirector should not exit
+        $redirector = Zend_Controller_Action_HelperBroker::getStaticHelper('redirector');
+        $redirector->setExit(false);
+
+        // json helper should not exit
+        $json = Zend_Controller_Action_HelperBroker::getStaticHelper('json');
+        $json->suppressExit = true;
+
+        $request    = $this->getRequest();
+        if (null !== $url) {
+            $request->setRequestUri($url);
+        }
+        $request->setPathInfo(null);
+
+        $controller = $this->getFrontController();
+        $this->frontController
+             ->setRequest($request)
+             ->setResponse($this->getResponse())
+             ->throwExceptions(false)
+             ->returnResponse(false);
+
+        if ($this->bootstrap instanceof Zend_Application) {
+            $this->bootstrap->run();
+        } else {
+            $this->frontController->dispatch();
+        }
+    }
+
+    /**
+     * Reset MVC state
+     *
+     * Creates new request/response objects, resets the front controller
+     * instance, and resets the action helper broker.
+     *
+     * @todo   Need to update Zend_Layout to add a resetInstance() method
+     */
+    public function reset()
+    {
+        $_SESSION = [];
+        $_GET     = [];
+        $_POST    = [];
+        $_COOKIE  = [];
+        $this->resetRequest();
+        $this->resetResponse();
+        Zend_Layout::resetMvcInstance();
+        Zend_Controller_Action_HelperBroker::resetHelpers();
+        $this->frontController->resetInstance();
+        Zend_Session::$_unitTestEnabled = true;
+    }
+
+    /**
+     * Rest all view placeholders
+     */
+    protected function _resetPlaceholders()
+    {
+        $registry = Zend_Registry::getInstance();
+        $remove   = [];
+        foreach ($registry as $key => $value) {
+            if (strstr($key, '_View_')) {
+                $remove[] = $key;
+            }
+        }
+
+        foreach ($remove as $key) {
+            unset($registry[$key]);
+        }
+    }
+
+    /**
+     * Reset the request object
+     *
+     * Useful for test cases that need to test multiple trips to the server.
+     *
+     * @return Zend_Test_PHPUnit_ControllerTestCase
+     */
+    public function resetRequest()
+    {
+        if ($this->_request instanceof Zend_Controller_Request_HttpTestCase) {
+            $this->_request->clearQuery()
+                           ->clearPost();
+        }
+        $this->_request = null;
+        return $this;
+    }
+
+    /**
+     * Reset the response object
+     *
+     * Useful for test cases that need to test multiple trips to the server.
+     *
+     * @return Zend_Test_PHPUnit_ControllerTestCase
+     */
+    public function resetResponse()
+    {
+        $this->_response = null;
+        $this->_resetPlaceholders();
+        return $this;
+    }
+
+    /**
+     * Assert against DOM selection
+     *
+     * @param string $path CSS selector path
+     * @param string $message
+     */
+    public function assertQuery($path, $message = '')
+    {
+        $this->_incrementAssertionCount();
+        require_once 'Zend/Test/PHPUnit/Constraint/DomQuery.php';
+        $constraint = new Zend_Test_PHPUnit_Constraint_DomQuery($path);
+        $content    = $this->response->outputBody();
+        if (!$constraint->evaluate($content, __FUNCTION__)) {
+            $constraint->fail($path, $message);
+        }
+    }
+
+    /**
+     * Assert against DOM selection
+     *
+     * @param string $path CSS selector path
+     * @param string $message
+     */
+    public function assertNotQuery($path, $message = '')
+    {
+        $this->_incrementAssertionCount();
+        require_once 'Zend/Test/PHPUnit/Constraint/DomQuery.php';
+        $constraint = new Zend_Test_PHPUnit_Constraint_DomQuery($path);
+        $content    = $this->response->outputBody();
+        if (!$constraint->evaluate($content, __FUNCTION__)) {
+            $constraint->fail($path, $message);
+        }
+    }
+
+    /**
+     * Assert against DOM selection; node should contain content
+     *
+     * @param string $path CSS selector path
+     * @param string $match content that should be contained in matched nodes
+     * @param string $message
+     */
+    public function assertQueryContentContains($path, $match, $message = '')
+    {
+        $this->_incrementAssertionCount();
+        require_once 'Zend/Test/PHPUnit/Constraint/DomQuery.php';
+        $constraint = new Zend_Test_PHPUnit_Constraint_DomQuery($path);
+        $content    = $this->response->outputBody();
+        if (!$constraint->evaluate($content, __FUNCTION__, $match)) {
+            $constraint->fail($path, $message);
+        }
+    }
+
+    /**
+     * Assert against DOM selection; node should NOT contain content
+     *
+     * @param string $path CSS selector path
+     * @param string $match content that should NOT be contained in matched nodes
+     * @param string $message
+     */
+    public function assertNotQueryContentContains($path, $match, $message = '')
+    {
+        $this->_incrementAssertionCount();
+        require_once 'Zend/Test/PHPUnit/Constraint/DomQuery.php';
+        $constraint = new Zend_Test_PHPUnit_Constraint_DomQuery($path);
+        $content    = $this->response->outputBody();
+        if (!$constraint->evaluate($content, __FUNCTION__, $match)) {
+            $constraint->fail($path, $message);
+        }
+    }
+
+    /**
+     * Assert against DOM selection; node should match content
+     *
+     * @param string $path CSS selector path
+     * @param string $pattern Pattern that should be contained in matched nodes
+     * @param string $message
+     */
+    public function assertQueryContentRegex($path, $pattern, $message = '')
+    {
+        $this->_incrementAssertionCount();
+        require_once 'Zend/Test/PHPUnit/Constraint/DomQuery.php';
+        $constraint = new Zend_Test_PHPUnit_Constraint_DomQuery($path);
+        $content    = $this->response->outputBody();
+        if (!$constraint->evaluate($content, __FUNCTION__, $pattern)) {
+            $constraint->fail($path, $message);
+        }
+    }
+
+    /**
+     * Assert against DOM selection; node should NOT match content
+     *
+     * @param string $path CSS selector path
+     * @param string $pattern pattern that should NOT be contained in matched nodes
+     * @param string $message
+     */
+    public function assertNotQueryContentRegex($path, $pattern, $message = '')
+    {
+        $this->_incrementAssertionCount();
+        require_once 'Zend/Test/PHPUnit/Constraint/DomQuery.php';
+        $constraint = new Zend_Test_PHPUnit_Constraint_DomQuery($path);
+        $content    = $this->response->outputBody();
+        if (!$constraint->evaluate($content, __FUNCTION__, $pattern)) {
+            $constraint->fail($path, $message);
+        }
+    }
+
+    /**
+     * Assert against DOM selection; should contain exact number of nodes
+     *
+     * @param string $path CSS selector path
+     * @param string $count Number of nodes that should match
+     * @param string $message
+     */
+    public function assertQueryCount($path, $count, $message = '')
+    {
+        $this->_incrementAssertionCount();
+        require_once 'Zend/Test/PHPUnit/Constraint/DomQuery.php';
+        $constraint = new Zend_Test_PHPUnit_Constraint_DomQuery($path);
+        $content    = $this->response->outputBody();
+        if (!$constraint->evaluate($content, __FUNCTION__, $count)) {
+            $constraint->fail($path, $message);
+        }
+    }
+
+    /**
+     * Assert against DOM selection; should NOT contain exact number of nodes
+     *
+     * @param string $path CSS selector path
+     * @param string $count Number of nodes that should NOT match
+     * @param string $message
+     */
+    public function assertNotQueryCount($path, $count, $message = '')
+    {
+        $this->_incrementAssertionCount();
+        require_once 'Zend/Test/PHPUnit/Constraint/DomQuery.php';
+        $constraint = new Zend_Test_PHPUnit_Constraint_DomQuery($path);
+        $content    = $this->response->outputBody();
+        if (!$constraint->evaluate($content, __FUNCTION__, $count)) {
+            $constraint->fail($path, $message);
+        }
+    }
+
+    /**
+     * Assert against DOM selection; should contain at least this number of nodes
+     *
+     * @param string $path CSS selector path
+     * @param string $count Minimum number of nodes that should match
+     * @param string $message
+     */
+    public function assertQueryCountMin($path, $count, $message = '')
+    {
+        $this->_incrementAssertionCount();
+        require_once 'Zend/Test/PHPUnit/Constraint/DomQuery.php';
+        $constraint = new Zend_Test_PHPUnit_Constraint_DomQuery($path);
+        $content    = $this->response->outputBody();
+        if (!$constraint->evaluate($content, __FUNCTION__, $count)) {
+            $constraint->fail($path, $message);
+        }
+    }
+
+    /**
+     * Assert against DOM selection; should contain no more than this number of nodes
+     *
+     * @param string $path CSS selector path
+     * @param string $count Maximum number of nodes that should match
+     * @param string $message
+     */
+    public function assertQueryCountMax($path, $count, $message = '')
+    {
+        $this->_incrementAssertionCount();
+        require_once 'Zend/Test/PHPUnit/Constraint/DomQuery.php';
+        $constraint = new Zend_Test_PHPUnit_Constraint_DomQuery($path);
+        $content    = $this->response->outputBody();
+        if (!$constraint->evaluate($content, __FUNCTION__, $count)) {
+            $constraint->fail($path, $message);
+        }
+    }
+
+    /**
+     * Register XPath namespaces
+     *
+     * @param array $xpathNamespaces
+     */
+    public function registerXpathNamespaces($xpathNamespaces)
+    {
+        $this->_xpathNamespaces = $xpathNamespaces;
+    }
+
+    /**
+     * Assert against XPath selection
+     *
+     * @param string $path XPath path
+     * @param string $message
+     */
+    public function assertXpath($path, $message = '')
+    {
+        $this->_incrementAssertionCount();
+        require_once 'Zend/Test/PHPUnit/Constraint/DomQuery.php';
+        $constraint = new Zend_Test_PHPUnit_Constraint_DomQuery($path);
+        $constraint->registerXpathNamespaces($this->_xpathNamespaces);
+        $content    = $this->response->outputBody();
+        if (!$constraint->evaluate($content, __FUNCTION__)) {
+            $constraint->fail($path, $message);
+        }
+    }
+
+    /**
+     * Assert against XPath selection
+     *
+     * @param string $path XPath path
+     * @param string $message
+     */
+    public function assertNotXpath($path, $message = '')
+    {
+        $this->_incrementAssertionCount();
+        require_once 'Zend/Test/PHPUnit/Constraint/DomQuery.php';
+        $constraint = new Zend_Test_PHPUnit_Constraint_DomQuery($path);
+        $constraint->registerXpathNamespaces($this->_xpathNamespaces);
+        $content    = $this->response->outputBody();
+        if (!$constraint->evaluate($content, __FUNCTION__)) {
+            $constraint->fail($path, $message);
+        }
+    }
+
+    /**
+     * Assert against XPath selection; node should contain content
+     *
+     * @param string $path XPath path
+     * @param string $match content that should be contained in matched nodes
+     * @param string $message
+     */
+    public function assertXpathContentContains($path, $match, $message = '')
+    {
+        $this->_incrementAssertionCount();
+        require_once 'Zend/Test/PHPUnit/Constraint/DomQuery.php';
+        $constraint = new Zend_Test_PHPUnit_Constraint_DomQuery($path);
+        $constraint->registerXpathNamespaces($this->_xpathNamespaces);
+        $content    = $this->response->outputBody();
+        if (!$constraint->evaluate($content, __FUNCTION__, $match)) {
+            $constraint->fail($path, $message);
+        }
+    }
+
+    /**
+     * Assert against XPath selection; node should NOT contain content
+     *
+     * @param string $path XPath path
+     * @param string $match content that should NOT be contained in matched nodes
+     * @param string $message
+     */
+    public function assertNotXpathContentContains($path, $match, $message = '')
+    {
+        $this->_incrementAssertionCount();
+        require_once 'Zend/Test/PHPUnit/Constraint/DomQuery.php';
+        $constraint = new Zend_Test_PHPUnit_Constraint_DomQuery($path);
+        $constraint->registerXpathNamespaces($this->_xpathNamespaces);
+        $content    = $this->response->outputBody();
+        if (!$constraint->evaluate($content, __FUNCTION__, $match)) {
+            $constraint->fail($path, $message);
+        }
+    }
+
+    /**
+     * Assert against XPath selection; node should match content
+     *
+     * @param string $path XPath path
+     * @param string $pattern Pattern that should be contained in matched nodes
+     * @param string $message
+     */
+    public function assertXpathContentRegex($path, $pattern, $message = '')
+    {
+        $this->_incrementAssertionCount();
+        require_once 'Zend/Test/PHPUnit/Constraint/DomQuery.php';
+        $constraint = new Zend_Test_PHPUnit_Constraint_DomQuery($path);
+        $constraint->registerXpathNamespaces($this->_xpathNamespaces);
+        $content    = $this->response->outputBody();
+        if (!$constraint->evaluate($content, __FUNCTION__, $pattern)) {
+            $constraint->fail($path, $message);
+        }
+    }
+
+    /**
+     * Assert against XPath selection; node should NOT match content
+     *
+     * @param string $path XPath path
+     * @param string $pattern pattern that should NOT be contained in matched nodes
+     * @param string $message
+     */
+    public function assertNotXpathContentRegex($path, $pattern, $message = '')
+    {
+        $this->_incrementAssertionCount();
+        require_once 'Zend/Test/PHPUnit/Constraint/DomQuery.php';
+        $constraint = new Zend_Test_PHPUnit_Constraint_DomQuery($path);
+        $constraint->registerXpathNamespaces($this->_xpathNamespaces);
+        $content    = $this->response->outputBody();
+        if (!$constraint->evaluate($content, __FUNCTION__, $pattern)) {
+            $constraint->fail($path, $message);
+        }
+    }
+
+    /**
+     * Assert against XPath selection; should contain exact number of nodes
+     *
+     * @param string $path XPath path
+     * @param string $count Number of nodes that should match
+     * @param string $message
+     */
+    public function assertXpathCount($path, $count, $message = '')
+    {
+        $this->_incrementAssertionCount();
+        require_once 'Zend/Test/PHPUnit/Constraint/DomQuery.php';
+        $constraint = new Zend_Test_PHPUnit_Constraint_DomQuery($path);
+        $constraint->registerXpathNamespaces($this->_xpathNamespaces);
+        $content    = $this->response->outputBody();
+        if (!$constraint->evaluate($content, __FUNCTION__, $count)) {
+            $constraint->fail($path, $message);
+        }
+    }
+
+    /**
+     * Assert against XPath selection; should NOT contain exact number of nodes
+     *
+     * @param string $path XPath path
+     * @param string $count Number of nodes that should NOT match
+     * @param string $message
+     */
+    public function assertNotXpathCount($path, $count, $message = '')
+    {
+        $this->_incrementAssertionCount();
+        require_once 'Zend/Test/PHPUnit/Constraint/DomQuery.php';
+        $constraint = new Zend_Test_PHPUnit_Constraint_DomQuery($path);
+        $constraint->registerXpathNamespaces($this->_xpathNamespaces);
+        $content    = $this->response->outputBody();
+        if (!$constraint->evaluate($content, __FUNCTION__, $count)) {
+            $constraint->fail($path, $message);
+        }
+    }
+
+    /**
+     * Assert against XPath selection; should contain at least this number of nodes
+     *
+     * @param string $path XPath path
+     * @param string $count Minimum number of nodes that should match
+     * @param string $message
+     */
+    public function assertXpathCountMin($path, $count, $message = '')
+    {
+        $this->_incrementAssertionCount();
+        require_once 'Zend/Test/PHPUnit/Constraint/DomQuery.php';
+        $constraint = new Zend_Test_PHPUnit_Constraint_DomQuery($path);
+        $constraint->registerXpathNamespaces($this->_xpathNamespaces);
+        $content    = $this->response->outputBody();
+        if (!$constraint->evaluate($content, __FUNCTION__, $count)) {
+            $constraint->fail($path, $message);
+        }
+    }
+
+    /**
+     * Assert against XPath selection; should contain no more than this number of nodes
+     *
+     * @param string $path XPath path
+     * @param string $count Maximum number of nodes that should match
+     * @param string $message
+     */
+    public function assertXpathCountMax($path, $count, $message = '')
+    {
+        $this->_incrementAssertionCount();
+        require_once 'Zend/Test/PHPUnit/Constraint/DomQuery.php';
+        $constraint = new Zend_Test_PHPUnit_Constraint_DomQuery($path);
+        $constraint->registerXpathNamespaces($this->_xpathNamespaces);
+        $content    = $this->response->outputBody();
+        if (!$constraint->evaluate($content, __FUNCTION__, $count)) {
+            $constraint->fail($path, $message);
+        }
+    }
+
+    /**
+     * Assert that response is a redirect
+     *
+     * @param string $message
+     */
+    public function assertRedirect($message = '')
+    {
+        $this->_incrementAssertionCount();
+        require_once 'Zend/Test/PHPUnit/Constraint/Redirect.php';
+        $constraint = new Zend_Test_PHPUnit_Constraint_Redirect();
+        $response   = $this->response;
+        if (!$constraint->evaluate($response, __FUNCTION__)) {
+            $constraint->fail($response, $message);
+        }
+    }
+
+    /**
+     * Assert that response is NOT a redirect
+     *
+     * @param string $message
+     */
+    public function assertNotRedirect($message = '')
+    {
+        $this->_incrementAssertionCount();
+        require_once 'Zend/Test/PHPUnit/Constraint/Redirect.php';
+        $constraint = new Zend_Test_PHPUnit_Constraint_Redirect();
+        $response   = $this->response;
+        if (!$constraint->evaluate($response, __FUNCTION__)) {
+            $constraint->fail($response, $message);
+        }
+    }
+
+    /**
+     * Assert that response redirects to given URL
+     *
+     * @param string $url
+     * @param string $message
+     */
+    public function assertRedirectTo($url, $message = '')
+    {
+        $this->_incrementAssertionCount();
+        require_once 'Zend/Test/PHPUnit/Constraint/Redirect.php';
+        $constraint = new Zend_Test_PHPUnit_Constraint_Redirect();
+        $response   = $this->response;
+        if (!$constraint->evaluate($response, __FUNCTION__, $url)) {
+            $constraint->fail($response, $message);
+        }
+    }
+
+    /**
+     * Assert that response does not redirect to given URL
+     *
+     * @param string $url
+     * @param string $message
+     */
+    public function assertNotRedirectTo($url, $message = '')
+    {
+        $this->_incrementAssertionCount();
+        require_once 'Zend/Test/PHPUnit/Constraint/Redirect.php';
+        $constraint = new Zend_Test_PHPUnit_Constraint_Redirect();
+        $response   = $this->response;
+        if (!$constraint->evaluate($response, __FUNCTION__, $url)) {
+            $constraint->fail($response, $message);
+        }
+    }
+
+    /**
+     * Assert that redirect location matches pattern
+     *
+     * @param string $pattern
+     * @param string $message
+     */
+    public function assertRedirectRegex($pattern, $message = '')
+    {
+        $this->_incrementAssertionCount();
+        require_once 'Zend/Test/PHPUnit/Constraint/Redirect.php';
+        $constraint = new Zend_Test_PHPUnit_Constraint_Redirect();
+        $response   = $this->response;
+        if (!$constraint->evaluate($response, __FUNCTION__, $pattern)) {
+            $constraint->fail($response, $message);
+        }
+    }
+
+    /**
+     * Assert that redirect location does not match pattern
+     *
+     * @param string $pattern
+     * @param string $message
+     */
+    public function assertNotRedirectRegex($pattern, $message = '')
+    {
+        $this->_incrementAssertionCount();
+        require_once 'Zend/Test/PHPUnit/Constraint/Redirect.php';
+        $constraint = new Zend_Test_PHPUnit_Constraint_Redirect();
+        $response   = $this->response;
+        if (!$constraint->evaluate($response, __FUNCTION__, $pattern)) {
+            $constraint->fail($response, $message);
+        }
+    }
+
+    /**
+     * Assert response code
+     *
+     * @param int $code
+     * @param string $message
+     */
+    public function assertResponseCode($code, $message = '')
+    {
+        $this->_incrementAssertionCount();
+        require_once 'Zend/Test/PHPUnit/Constraint/ResponseHeader.php';
+        $constraint = new Zend_Test_PHPUnit_Constraint_ResponseHeader();
+        $response   = $this->response;
+        if (!$constraint->evaluate($response, __FUNCTION__, $code)) {
+            $constraint->fail($response, $message);
+        }
+    }
+
+    /**
+     * Assert response code
+     *
+     * @param int $code
+     * @param string $message
+     */
+    public function assertNotResponseCode($code, $message = '')
+    {
+        $this->_incrementAssertionCount();
+        require_once 'Zend/Test/PHPUnit/Constraint/ResponseHeader.php';
+        $constraint = new Zend_Test_PHPUnit_Constraint_ResponseHeader();
+        $constraint->setNegate(true);
+        $response   = $this->response;
+        if (!$constraint->evaluate($response, __FUNCTION__, $code)) {
+            $constraint->fail($response, $message);
+        }
+    }
+
+    /**
+     * Assert response header exists
+     *
+     * @param string $header
+     * @param string $message
+     */
+    public function assertHeader($header, $message = '')
+    {
+        $this->_incrementAssertionCount();
+        require_once 'Zend/Test/PHPUnit/Constraint/ResponseHeader.php';
+        $constraint = new Zend_Test_PHPUnit_Constraint_ResponseHeader();
+        $response   = $this->response;
+        if (!$constraint->evaluate($response, __FUNCTION__, $header)) {
+            $constraint->fail($response, $message);
+        }
+    }
+
+    /**
+     * Assert response header does not exist
+     *
+     * @param string $header
+     * @param string $message
+     */
+    public function assertNotHeader($header, $message = '')
+    {
+        $this->_incrementAssertionCount();
+        require_once 'Zend/Test/PHPUnit/Constraint/ResponseHeader.php';
+        $constraint = new Zend_Test_PHPUnit_Constraint_ResponseHeader();
+        $constraint->setNegate(true);
+        $response   = $this->response;
+        if (!$constraint->evaluate($response, __FUNCTION__, $header)) {
+            $constraint->fail($response, $message);
+        }
+    }
+
+    /**
+     * Assert response header exists and contains the given string
+     *
+     * @param string $header
+     * @param string $match
+     * @param string $message
+     */
+    public function assertHeaderContains($header, $match, $message = '')
+    {
+        $this->_incrementAssertionCount();
+        require_once 'Zend/Test/PHPUnit/Constraint/ResponseHeader.php';
+        $constraint = new Zend_Test_PHPUnit_Constraint_ResponseHeader();
+        $response   = $this->response;
+        if (!$constraint->evaluate($response, __FUNCTION__, $header, $match)) {
+            $constraint->fail($response, $message);
+        }
+    }
+
+    /**
+     * Assert response header does not exist and/or does not contain the given string
+     *
+     * @param string $header
+     * @param string $match
+     * @param string $message
+     */
+    public function assertNotHeaderContains($header, $match, $message = '')
+    {
+        $this->_incrementAssertionCount();
+        require_once 'Zend/Test/PHPUnit/Constraint/ResponseHeader.php';
+        $constraint = new Zend_Test_PHPUnit_Constraint_ResponseHeader();
+        $constraint->setNegate(true);
+        $response   = $this->response;
+        if (!$constraint->evaluate($response, __FUNCTION__, $header, $match)) {
+            $constraint->fail($response, $message);
+        }
+    }
+
+    /**
+     * Assert response header exists and matches the given pattern
+     *
+     * @param string $header
+     * @param string $pattern
+     * @param string $message
+     */
+    public function assertHeaderRegex($header, $pattern, $message = '')
+    {
+        $this->_incrementAssertionCount();
+        require_once 'Zend/Test/PHPUnit/Constraint/ResponseHeader.php';
+        $constraint = new Zend_Test_PHPUnit_Constraint_ResponseHeader();
+        $response   = $this->response;
+        if (!$constraint->evaluate($response, __FUNCTION__, $header, $pattern)) {
+            $constraint->fail($response, $message);
+        }
+    }
+
+    /**
+     * Assert response header does not exist and/or does not match the given regex
+     *
+     * @param string $header
+     * @param string $pattern
+     * @param string $message
+     */
+    public function assertNotHeaderRegex($header, $pattern, $message = '')
+    {
+        $this->_incrementAssertionCount();
+        require_once 'Zend/Test/PHPUnit/Constraint/ResponseHeader.php';
+        $constraint = new Zend_Test_PHPUnit_Constraint_ResponseHeader();
+        $constraint->setNegate(true);
+        $response   = $this->response;
+        if (!$constraint->evaluate($response, __FUNCTION__, $header, $pattern)) {
+            $constraint->fail($response, $message);
+        }
+    }
+
+    /**
+     * Assert that the last handled request used the given module
+     *
+     * @param string $module
+     * @param string $message
+     */
+    public function assertModule($module, $message = '')
+    {
+        $this->_incrementAssertionCount();
+        if ($module != $this->request->getModuleName()) {
+            $msg = sprintf('Failed asserting last module used <"%s"> was "%s"',
+                $this->request->getModuleName(),
+                $module
+            );
+            if (!empty($message)) {
+                $msg = $message . "\n" . $msg;
+            }
+            $this->fail($msg);
+        }
+    }
+
+    /**
+     * Assert that the last handled request did NOT use the given module
+     *
+     * @param string $module
+     * @param string $message
+     */
+    public function assertNotModule($module, $message = '')
+    {
+        $this->_incrementAssertionCount();
+        if ($module == $this->request->getModuleName()) {
+            $msg = sprintf('Failed asserting last module used was NOT "%s"', $module);
+            if (!empty($message)) {
+                $msg = $message . "\n" . $msg;
+            }
+            $this->fail($msg);
+        }
+    }
+
+    /**
+     * Assert that the last handled request used the given controller
+     *
+     * @param string $controller
+     * @param string $message
+     */
+    public function assertController($controller, $message = '')
+    {
+        $this->_incrementAssertionCount();
+        if ($controller != $this->request->getControllerName()) {
+            $msg = sprintf('Failed asserting last controller used <"%s"> was "%s"',
+                $this->request->getControllerName(),
+                $controller
+            );
+            if (!empty($message)) {
+                $msg = $message . "\n" . $msg;
+            }
+            $this->fail($msg);
+        }
+    }
+
+    /**
+     * Assert that the last handled request did NOT use the given controller
+     *
+     * @param  string $controller
+     * @param  string $message
+     */
+    public function assertNotController($controller, $message = '')
+    {
+        $this->_incrementAssertionCount();
+        if ($controller == $this->request->getControllerName()) {
+            $msg = sprintf('Failed asserting last controller used <"%s"> was NOT "%s"',
+                $this->request->getControllerName(),
+                $controller
+            );
+            if (!empty($message)) {
+                $msg = $message . "\n" . $msg;
+            }
+            $this->fail($msg);
+        }
+    }
+
+    /**
+     * Assert that the last handled request used the given action
+     *
+     * @param string $action
+     * @param string $message
+     */
+    public function assertAction($action, $message = '')
+    {
+        $this->_incrementAssertionCount();
+        if ($action != $this->request->getActionName()) {
+            $msg = sprintf('Failed asserting last action used <"%s"> was "%s"', $this->request->getActionName(), $action);
+            if (!empty($message)) {
+                $msg = $message . "\n" . $msg;
+            }
+            $this->fail($msg);
+        }
+    }
+
+    /**
+     * Assert that the last handled request did NOT use the given action
+     *
+     * @param string $action
+     * @param string $message
+     */
+    public function assertNotAction($action, $message = '')
+    {
+        $this->_incrementAssertionCount();
+        if ($action == $this->request->getActionName()) {
+            $msg = sprintf('Failed asserting last action used <"%s"> was NOT "%s"', $this->request->getActionName(), $action);
+            if (!empty($message)) {
+                $msg = $message . "\n" . $msg;
+            }
+            $this->fail($msg);
+        }
+    }
+
+    /**
+     * Assert that the specified route was used
+     *
+     * @param string $route
+     * @param string $message
+     */
+    public function assertRoute($route, $message = '')
+    {
+        $this->_incrementAssertionCount();
+        $router = $this->frontController->getRouter();
+        if ($route != $router->getCurrentRouteName()) {
+            $msg = sprintf('Failed asserting matched route was "%s", actual route is %s',
+                $route,
+                $router->getCurrentRouteName()
+            );
+            if (!empty($message)) {
+                $msg = $message . "\n" . $msg;
+            }
+            $this->fail($msg);
+        }
+    }
+
+    /**
+     * Assert that the route matched is NOT as specified
+     *
+     * @param string $route
+     * @param string $message
+     */
+    public function assertNotRoute($route, $message = '')
+    {
+        $this->_incrementAssertionCount();
+        $router = $this->frontController->getRouter();
+        if ($route == $router->getCurrentRouteName()) {
+            $msg = sprintf('Failed asserting route matched was NOT "%s"', $route);
+            if (!empty($message)) {
+                $msg = $message . "\n" . $msg;
+            }
+            $this->fail($msg);
+        }
+    }
+
+    /**
+     * Retrieve front controller instance
+     *
+     * @return Zend_Controller_Front
+     */
+    public function getFrontController()
+    {
+        if (null === $this->_frontController) {
+            $this->_frontController = Zend_Controller_Front::getInstance();
+        }
+        return $this->_frontController;
+    }
+
+    /**
+     * Retrieve test case request object
+     *
+     * @return Zend_Controller_Request_HttpTestCase
+     */
+    public function getRequest()
+    {
+        if (null === $this->_request) {
+            require_once 'Zend/Controller/Request/HttpTestCase.php';
+            $this->_request = new Zend_Controller_Request_HttpTestCase;
+        }
+        return $this->_request;
+    }
+
+    /**
+     * Retrieve test case response object
+     *
+     * @return Zend_Controller_Response_HttpTestCase
+     */
+    public function getResponse()
+    {
+        if (null === $this->_response) {
+            require_once 'Zend/Controller/Response/HttpTestCase.php';
+            $this->_response = new Zend_Controller_Response_HttpTestCase;
+        }
+        return $this->_response;
+    }
+
+    /**
+     * Retrieve DOM query object
+     *
+     * @return Zend_Dom_Query
+     */
+    public function getQuery()
+    {
+        if (null === $this->_query) {
+            require_once 'Zend/Dom/Query.php';
+            $this->_query = new Zend_Dom_Query;
+        }
+        return $this->_query;
+    }
+
+    /**
+     * URL Helper
+     *
+     * @param  array  $urlOptions
+     * @param  string $name
+     * @param  bool   $reset
+     * @param  bool   $encode
+     * @throws Exception
+     * @throws Zend_Controller_Router_Exception
+     * @return string
+     */
+    public function url($urlOptions = [], $name = null, $reset = false, $encode = true)
+    {
+        $frontController = $this->getFrontController();
+        $router = $frontController->getRouter();
+        if (!$router instanceof Zend_Controller_Router_Rewrite) {
+            throw new Exception('This url helper utility function only works when the router is of type Zend_Controller_Router_Rewrite');
+        }
+        if (count($router->getRoutes()) === 0) {
+            $router->addDefaultRoutes();
+        }
+        return $router->assemble($urlOptions, $name, $reset, $encode);
+    }
+
+    /**
+     * Urlize options
+     *
+     * @param  array $urlOptions
+     * @param  bool  $actionControllerModuleOnly
+     * @return array
+     */
+    public function urlizeOptions($urlOptions, $actionControllerModuleOnly = true)
+    {
+        $ccToDash = new Zend_Filter_Word_CamelCaseToDash();
+        foreach ($urlOptions as $n => $v) {
+            if (in_array($n, ['action', 'controller', 'module'])) {
+                $urlOptions[$n] = $ccToDash->filter($v);
+            }
+        }
+        return $urlOptions;
+    }
+
+    /**
+     * Increment assertion count
+     */
+    protected function _incrementAssertionCount()
+    {
+        $stack = debug_backtrace();
+        foreach ($stack as $step) {
+            if (isset($step['object'])
+                && $step['object'] instanceof PHPUnit_Framework_TestCase
+            ) {
+                if (version_compare(PHPUnit_Runner_Version::id(), '3.3.0', 'lt')) {
+                    break;
+                } elseif (version_compare(PHPUnit_Runner_Version::id(), '3.3.3', 'lt')) {
+                    $step['object']->incrementAssertionCounter();
+                } else {
+                    $step['object']->addToAssertionCount(1);
+                }
+                break;
+            }
+        }
+    }
+}

--- a/library/Zend/Test/PHPUnit/ControllerTestCase80.php
+++ b/library/Zend/Test/PHPUnit/ControllerTestCase80.php
@@ -1,0 +1,1166 @@
+<?php
+/**
+ * Zend Framework
+ *
+ * LICENSE
+ *
+ * This source file is subject to the new BSD license that is bundled
+ * with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://framework.zend.com/license/new-bsd
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@zend.com so we can send you a copy immediately.
+ *
+ * @category   Zend
+ * @package    Zend_Test
+ * @copyright  Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license    http://framework.zend.com/license/new-bsd     New BSD License
+ * @version    $Id$
+ */
+
+use PHPUnit\Framework\TestCase;
+/** @see Zend_Controller_Front */
+require_once 'Zend/Controller/Front.php';
+
+/** @see Zend_Controller_Action_HelperBroker */
+require_once 'Zend/Controller/Action/HelperBroker.php';
+
+/** @see Zend_Layout */
+require_once 'Zend/Layout.php';
+
+/** @see Zend_Session */
+require_once 'Zend/Session.php';
+
+/** @see Zend_Registry */
+require_once 'Zend/Registry.php';
+
+/**
+ * Functional testing scaffold for MVC applications
+ *
+ * @uses       PHPUnit_Framework_TestCase
+ * @category   Zend
+ * @package    Zend_Test
+ * @subpackage PHPUnit
+ * @copyright  Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license    http://framework.zend.com/license/new-bsd     New BSD License
+ */
+abstract class Zend_Test_PHPUnit_ControllerTestCase80 extends TestCase
+{
+    /**
+     * @var mixed Bootstrap file path or callback
+     */
+    public $bootstrap;
+
+    /**
+     * @var Zend_Controller_Front
+     */
+    protected $_frontController;
+
+    /**
+     * @var Zend_Dom_Query
+     */
+    protected $_query;
+
+    /**
+     * @var Zend_Controller_Request_Abstract
+     */
+    protected $_request;
+
+    /**
+     * @var Zend_Controller_Response_Abstract
+     */
+    protected $_response;
+
+    /**
+     * XPath namespaces
+     * @var array
+     */
+    protected $_xpathNamespaces = [];
+
+    /**
+     * Overloading: prevent overloading to special properties
+     *
+     * @param  string $name
+     * @param  mixed  $value
+     * @throws Zend_Exception
+     */
+    public function __set($name, $value)
+    {
+        if (in_array($name, ['request', 'response', 'frontController'])) {
+            require_once 'Zend/Exception.php';
+            throw new Zend_Exception(sprintf('Setting %s object manually is not allowed', $name));
+        }
+        $this->$name = $value;
+    }
+
+    /**
+     * Overloading for common properties
+     *
+     * Provides overloading for request, response, and frontController objects.
+     *
+     * @param  mixed $name
+     * @return null|Zend_Controller_Front|Zend_Controller_Request_HttpTestCase|Zend_Controller_Response_HttpTestCase
+     */
+    public function __get($name)
+    {
+        switch ($name) {
+            case 'request':
+                return $this->getRequest();
+            case 'response':
+                return $this->getResponse();
+            case 'frontController':
+                return $this->getFrontController();
+        }
+
+        return null;
+    }
+
+    /**
+     * Set up MVC app
+     *
+     * Calls {@link bootstrap()} by default
+     */
+    protected function setUp(): void
+    {
+        $this->bootstrap();
+    }
+
+    /**
+     * Bootstrap the front controller
+     *
+     * Resets the front controller, and then bootstraps it.
+     *
+     * If {@link $bootstrap} is a callback, executes it; if it is a file, it include's
+     * it. When done, sets the test case request and response objects into the
+     * front controller.
+     */
+    final public function bootstrap(): void
+    {
+        $this->reset();
+        if (null !== $this->bootstrap) {
+            if ($this->bootstrap instanceof Zend_Application) {
+                $this->bootstrap->bootstrap();
+                $this->_frontController = $this->bootstrap->getBootstrap()->getResource('frontcontroller');
+            } elseif (is_callable($this->bootstrap)) {
+                call_user_func($this->bootstrap);
+            } elseif (is_string($this->bootstrap)) {
+                require_once 'Zend/Loader.php';
+                if (Zend_Loader::isReadable($this->bootstrap)) {
+                    include $this->bootstrap;
+                }
+            }
+        }
+        $this->frontController
+             ->setRequest($this->getRequest())
+             ->setResponse($this->getResponse());
+    }
+
+    /**
+     * Dispatch the MVC
+     *
+     * If a URL is provided, sets it as the request URI in the request object.
+     * Then sets test case request and response objects in front controller,
+     * disables throwing exceptions, and disables returning the response.
+     * Finally, dispatches the front controller.
+     *
+     * @param string|null $url
+     */
+    public function dispatch($url = null)
+    {
+        // redirector should not exit
+        $redirector = Zend_Controller_Action_HelperBroker::getStaticHelper('redirector');
+        $redirector->setExit(false);
+
+        // json helper should not exit
+        $json = Zend_Controller_Action_HelperBroker::getStaticHelper('json');
+        $json->suppressExit = true;
+
+        $request    = $this->getRequest();
+        if (null !== $url) {
+            $request->setRequestUri($url);
+        }
+        $request->setPathInfo(null);
+
+        $controller = $this->getFrontController();
+        $this->frontController
+             ->setRequest($request)
+             ->setResponse($this->getResponse())
+             ->throwExceptions(false)
+             ->returnResponse(false);
+
+        if ($this->bootstrap instanceof Zend_Application) {
+            $this->bootstrap->run();
+        } else {
+            $this->frontController->dispatch();
+        }
+    }
+
+    /**
+     * Reset MVC state
+     *
+     * Creates new request/response objects, resets the front controller
+     * instance, and resets the action helper broker.
+     *
+     * @todo   Need to update Zend_Layout to add a resetInstance() method
+     */
+    public function reset()
+    {
+        $_SESSION = [];
+        $_GET     = [];
+        $_POST    = [];
+        $_COOKIE  = [];
+        $this->resetRequest();
+        $this->resetResponse();
+        Zend_Layout::resetMvcInstance();
+        Zend_Controller_Action_HelperBroker::resetHelpers();
+        $this->frontController->resetInstance();
+        Zend_Session::$_unitTestEnabled = true;
+    }
+
+    /**
+     * Rest all view placeholders
+     */
+    protected function _resetPlaceholders()
+    {
+        $registry = Zend_Registry::getInstance();
+        $remove   = [];
+        foreach ($registry as $key => $value) {
+            if (strstr($key, '_View_')) {
+                $remove[] = $key;
+            }
+        }
+
+        foreach ($remove as $key) {
+            unset($registry[$key]);
+        }
+    }
+
+    /**
+     * Reset the request object
+     *
+     * Useful for test cases that need to test multiple trips to the server.
+     *
+     * @return Zend_Test_PHPUnit_ControllerTestCase
+     */
+    public function resetRequest()
+    {
+        if ($this->_request instanceof Zend_Controller_Request_HttpTestCase) {
+            $this->_request->clearQuery()
+                           ->clearPost();
+        }
+        $this->_request = null;
+        return $this;
+    }
+
+    /**
+     * Reset the response object
+     *
+     * Useful for test cases that need to test multiple trips to the server.
+     *
+     * @return Zend_Test_PHPUnit_ControllerTestCase
+     */
+    public function resetResponse()
+    {
+        $this->_response = null;
+        $this->_resetPlaceholders();
+        return $this;
+    }
+
+    /**
+     * Assert against DOM selection
+     *
+     * @param string $path CSS selector path
+     * @param string $message
+     */
+    public function assertQuery($path, $message = '')
+    {
+        $this->_incrementAssertionCount();
+        require_once 'Zend/Test/PHPUnit/Constraint/DomQuery.php';
+        $constraint = new Zend_Test_PHPUnit_Constraint_DomQuery($path);
+        $content    = $this->response->outputBody();
+        if (!$constraint->evaluate_compat($content, __FUNCTION__)) {
+            $constraint->fail($path, $message);
+        }
+    }
+
+    /**
+     * Assert against DOM selection
+     *
+     * @param string $path CSS selector path
+     * @param string $message
+     */
+    public function assertNotQuery($path, $message = '')
+    {
+        $this->_incrementAssertionCount();
+        require_once 'Zend/Test/PHPUnit/Constraint/DomQuery.php';
+        $constraint = new Zend_Test_PHPUnit_Constraint_DomQuery($path);
+        $content    = $this->response->outputBody();
+        if (!$constraint->evaluate_compat($content, __FUNCTION__)) {
+            $constraint->fail($path, $message);
+        }
+    }
+
+    /**
+     * Assert against DOM selection; node should contain content
+     *
+     * @param string $path CSS selector path
+     * @param string $match content that should be contained in matched nodes
+     * @param string $message
+     */
+    public function assertQueryContentContains($path, $match, $message = '')
+    {
+        $this->_incrementAssertionCount();
+        require_once 'Zend/Test/PHPUnit/Constraint/DomQuery.php';
+        $constraint = new Zend_Test_PHPUnit_Constraint_DomQuery($path);
+        $content    = $this->response->outputBody();
+        if (!$constraint->evaluate_compat($content, __FUNCTION__, $match)) {
+            $constraint->fail($path, $message);
+        }
+    }
+
+    /**
+     * Assert against DOM selection; node should NOT contain content
+     *
+     * @param string $path CSS selector path
+     * @param string $match content that should NOT be contained in matched nodes
+     * @param string $message
+     */
+    public function assertNotQueryContentContains($path, $match, $message = '')
+    {
+        $this->_incrementAssertionCount();
+        require_once 'Zend/Test/PHPUnit/Constraint/DomQuery.php';
+        $constraint = new Zend_Test_PHPUnit_Constraint_DomQuery($path);
+        $content    = $this->response->outputBody();
+        if (!$constraint->evaluate_compat($content, __FUNCTION__, $match)) {
+            $constraint->fail($path, $message);
+        }
+    }
+
+    /**
+     * Assert against DOM selection; node should match content
+     *
+     * @param string $path CSS selector path
+     * @param string $pattern Pattern that should be contained in matched nodes
+     * @param string $message
+     */
+    public function assertQueryContentRegex($path, $pattern, $message = '')
+    {
+        $this->_incrementAssertionCount();
+        require_once 'Zend/Test/PHPUnit/Constraint/DomQuery.php';
+        $constraint = new Zend_Test_PHPUnit_Constraint_DomQuery($path);
+        $content    = $this->response->outputBody();
+        if (!$constraint->evaluate_compat($content, __FUNCTION__, $pattern)) {
+            $constraint->fail($path, $message);
+        }
+    }
+
+    /**
+     * Assert against DOM selection; node should NOT match content
+     *
+     * @param string $path CSS selector path
+     * @param string $pattern pattern that should NOT be contained in matched nodes
+     * @param string $message
+     */
+    public function assertNotQueryContentRegex($path, $pattern, $message = '')
+    {
+        $this->_incrementAssertionCount();
+        require_once 'Zend/Test/PHPUnit/Constraint/DomQuery.php';
+        $constraint = new Zend_Test_PHPUnit_Constraint_DomQuery($path);
+        $content    = $this->response->outputBody();
+        if (!$constraint->evaluate_compat($content, __FUNCTION__, $pattern)) {
+            $constraint->fail($path, $message);
+        }
+    }
+
+    /**
+     * Assert against DOM selection; should contain exact number of nodes
+     *
+     * @param string $path CSS selector path
+     * @param string $count Number of nodes that should match
+     * @param string $message
+     */
+    public function assertQueryCount($path, $count, $message = '')
+    {
+        $this->_incrementAssertionCount();
+        require_once 'Zend/Test/PHPUnit/Constraint/DomQuery.php';
+        $constraint = new Zend_Test_PHPUnit_Constraint_DomQuery($path);
+        $content    = $this->response->outputBody();
+        if (!$constraint->evaluate_compat($content, __FUNCTION__, $count)) {
+            $constraint->fail($path, $message);
+        }
+    }
+
+    /**
+     * Assert against DOM selection; should NOT contain exact number of nodes
+     *
+     * @param string $path CSS selector path
+     * @param string $count Number of nodes that should NOT match
+     * @param string $message
+     */
+    public function assertNotQueryCount($path, $count, $message = '')
+    {
+        $this->_incrementAssertionCount();
+        require_once 'Zend/Test/PHPUnit/Constraint/DomQuery.php';
+        $constraint = new Zend_Test_PHPUnit_Constraint_DomQuery($path);
+        $content    = $this->response->outputBody();
+        if (!$constraint->evaluate_compat($content, __FUNCTION__, $count)) {
+            $constraint->fail($path, $message);
+        }
+    }
+
+    /**
+     * Assert against DOM selection; should contain at least this number of nodes
+     *
+     * @param string $path CSS selector path
+     * @param string $count Minimum number of nodes that should match
+     * @param string $message
+     */
+    public function assertQueryCountMin($path, $count, $message = '')
+    {
+        $this->_incrementAssertionCount();
+        require_once 'Zend/Test/PHPUnit/Constraint/DomQuery.php';
+        $constraint = new Zend_Test_PHPUnit_Constraint_DomQuery($path);
+        $content    = $this->response->outputBody();
+        if (!$constraint->evaluate_compat($content, __FUNCTION__, $count)) {
+            $constraint->fail($path, $message);
+        }
+    }
+
+    /**
+     * Assert against DOM selection; should contain no more than this number of nodes
+     *
+     * @param string $path CSS selector path
+     * @param string $count Maximum number of nodes that should match
+     * @param string $message
+     */
+    public function assertQueryCountMax($path, $count, $message = '')
+    {
+        $this->_incrementAssertionCount();
+        require_once 'Zend/Test/PHPUnit/Constraint/DomQuery.php';
+        $constraint = new Zend_Test_PHPUnit_Constraint_DomQuery($path);
+        $content    = $this->response->outputBody();
+        if (!$constraint->evaluate_compat($content, __FUNCTION__, $count)) {
+            $constraint->fail($path, $message);
+        }
+    }
+
+    /**
+     * Register XPath namespaces
+     *
+     * @param array $xpathNamespaces
+     */
+    public function registerXpathNamespaces($xpathNamespaces)
+    {
+        $this->_xpathNamespaces = $xpathNamespaces;
+    }
+
+    /**
+     * Assert against XPath selection
+     *
+     * @param string $path XPath path
+     * @param string $message
+     */
+    public function assertXpath($path, $message = '')
+    {
+        $this->_incrementAssertionCount();
+        require_once 'Zend/Test/PHPUnit/Constraint/DomQuery.php';
+        $constraint = new Zend_Test_PHPUnit_Constraint_DomQuery($path);
+        $constraint->registerXpathNamespaces($this->_xpathNamespaces);
+        $content    = $this->response->outputBody();
+        if (!$constraint->evaluate_compat($content, __FUNCTION__)) {
+            $constraint->fail($path, $message);
+        }
+    }
+
+    /**
+     * Assert against XPath selection
+     *
+     * @param string $path XPath path
+     * @param string $message
+     */
+    public function assertNotXpath($path, $message = '')
+    {
+        $this->_incrementAssertionCount();
+        require_once 'Zend/Test/PHPUnit/Constraint/DomQuery.php';
+        $constraint = new Zend_Test_PHPUnit_Constraint_DomQuery($path);
+        $constraint->registerXpathNamespaces($this->_xpathNamespaces);
+        $content    = $this->response->outputBody();
+        if (!$constraint->evaluate_compat($content, __FUNCTION__)) {
+            $constraint->fail($path, $message);
+        }
+    }
+
+    /**
+     * Assert against XPath selection; node should contain content
+     *
+     * @param string $path XPath path
+     * @param string $match content that should be contained in matched nodes
+     * @param string $message
+     */
+    public function assertXpathContentContains($path, $match, $message = '')
+    {
+        $this->_incrementAssertionCount();
+        require_once 'Zend/Test/PHPUnit/Constraint/DomQuery.php';
+        $constraint = new Zend_Test_PHPUnit_Constraint_DomQuery($path);
+        $constraint->registerXpathNamespaces($this->_xpathNamespaces);
+        $content    = $this->response->outputBody();
+        if (!$constraint->evaluate_compat($content, __FUNCTION__, $match)) {
+            $constraint->fail($path, $message);
+        }
+    }
+
+    /**
+     * Assert against XPath selection; node should NOT contain content
+     *
+     * @param string $path XPath path
+     * @param string $match content that should NOT be contained in matched nodes
+     * @param string $message
+     */
+    public function assertNotXpathContentContains($path, $match, $message = '')
+    {
+        $this->_incrementAssertionCount();
+        require_once 'Zend/Test/PHPUnit/Constraint/DomQuery.php';
+        $constraint = new Zend_Test_PHPUnit_Constraint_DomQuery($path);
+        $constraint->registerXpathNamespaces($this->_xpathNamespaces);
+        $content    = $this->response->outputBody();
+        if (!$constraint->evaluate_compat($content, __FUNCTION__, $match)) {
+            $constraint->fail($path, $message);
+        }
+    }
+
+    /**
+     * Assert against XPath selection; node should match content
+     *
+     * @param string $path XPath path
+     * @param string $pattern Pattern that should be contained in matched nodes
+     * @param string $message
+     */
+    public function assertXpathContentRegex($path, $pattern, $message = '')
+    {
+        $this->_incrementAssertionCount();
+        require_once 'Zend/Test/PHPUnit/Constraint/DomQuery.php';
+        $constraint = new Zend_Test_PHPUnit_Constraint_DomQuery($path);
+        $constraint->registerXpathNamespaces($this->_xpathNamespaces);
+        $content    = $this->response->outputBody();
+        if (!$constraint->evaluate_compat($content, __FUNCTION__, $pattern)) {
+            $constraint->fail($path, $message);
+        }
+    }
+
+    /**
+     * Assert against XPath selection; node should NOT match content
+     *
+     * @param string $path XPath path
+     * @param string $pattern pattern that should NOT be contained in matched nodes
+     * @param string $message
+     */
+    public function assertNotXpathContentRegex($path, $pattern, $message = '')
+    {
+        $this->_incrementAssertionCount();
+        require_once 'Zend/Test/PHPUnit/Constraint/DomQuery.php';
+        $constraint = new Zend_Test_PHPUnit_Constraint_DomQuery($path);
+        $constraint->registerXpathNamespaces($this->_xpathNamespaces);
+        $content    = $this->response->outputBody();
+        if (!$constraint->evaluate_compat($content, __FUNCTION__, $pattern)) {
+            $constraint->fail($path, $message);
+        }
+    }
+
+    /**
+     * Assert against XPath selection; should contain exact number of nodes
+     *
+     * @param string $path XPath path
+     * @param string $count Number of nodes that should match
+     * @param string $message
+     */
+    public function assertXpathCount($path, $count, $message = '')
+    {
+        $this->_incrementAssertionCount();
+        require_once 'Zend/Test/PHPUnit/Constraint/DomQuery.php';
+        $constraint = new Zend_Test_PHPUnit_Constraint_DomQuery($path);
+        $constraint->registerXpathNamespaces($this->_xpathNamespaces);
+        $content    = $this->response->outputBody();
+        if (!$constraint->evaluate_compat($content, __FUNCTION__, $count)) {
+            $constraint->fail($path, $message);
+        }
+    }
+
+    /**
+     * Assert against XPath selection; should NOT contain exact number of nodes
+     *
+     * @param string $path XPath path
+     * @param string $count Number of nodes that should NOT match
+     * @param string $message
+     */
+    public function assertNotXpathCount($path, $count, $message = '')
+    {
+        $this->_incrementAssertionCount();
+        require_once 'Zend/Test/PHPUnit/Constraint/DomQuery.php';
+        $constraint = new Zend_Test_PHPUnit_Constraint_DomQuery($path);
+        $constraint->registerXpathNamespaces($this->_xpathNamespaces);
+        $content    = $this->response->outputBody();
+        if (!$constraint->evaluate_compat($content, __FUNCTION__, $count)) {
+            $constraint->fail($path, $message);
+        }
+    }
+
+    /**
+     * Assert against XPath selection; should contain at least this number of nodes
+     *
+     * @param string $path XPath path
+     * @param string $count Minimum number of nodes that should match
+     * @param string $message
+     */
+    public function assertXpathCountMin($path, $count, $message = '')
+    {
+        $this->_incrementAssertionCount();
+        require_once 'Zend/Test/PHPUnit/Constraint/DomQuery.php';
+        $constraint = new Zend_Test_PHPUnit_Constraint_DomQuery($path);
+        $constraint->registerXpathNamespaces($this->_xpathNamespaces);
+        $content    = $this->response->outputBody();
+        if (!$constraint->evaluate_compat($content, __FUNCTION__, $count)) {
+            $constraint->fail($path, $message);
+        }
+    }
+
+    /**
+     * Assert against XPath selection; should contain no more than this number of nodes
+     *
+     * @param string $path XPath path
+     * @param string $count Maximum number of nodes that should match
+     * @param string $message
+     */
+    public function assertXpathCountMax($path, $count, $message = '')
+    {
+        $this->_incrementAssertionCount();
+        require_once 'Zend/Test/PHPUnit/Constraint/DomQuery.php';
+        $constraint = new Zend_Test_PHPUnit_Constraint_DomQuery($path);
+        $constraint->registerXpathNamespaces($this->_xpathNamespaces);
+        $content    = $this->response->outputBody();
+        if (!$constraint->evaluate_compat($content, __FUNCTION__, $count)) {
+            $constraint->fail($path, $message);
+        }
+    }
+
+    /**
+     * Assert that response is a redirect
+     *
+     * @param string $message
+     */
+    public function assertRedirect($message = '')
+    {
+        $this->_incrementAssertionCount();
+        require_once 'Zend/Test/PHPUnit/Constraint/Redirect.php';
+        $constraint = new Zend_Test_PHPUnit_Constraint_Redirect();
+        $response   = $this->response;
+        if (!$constraint->evaluate_compat($response, __FUNCTION__)) {
+            $constraint->fail($response, $message);
+        }
+    }
+
+    /**
+     * Assert that response is NOT a redirect
+     *
+     * @param string $message
+     */
+    public function assertNotRedirect($message = '')
+    {
+        $this->_incrementAssertionCount();
+        require_once 'Zend/Test/PHPUnit/Constraint/Redirect.php';
+        $constraint = new Zend_Test_PHPUnit_Constraint_Redirect();
+        $response   = $this->response;
+        if (!$constraint->evaluate_compat($response, __FUNCTION__)) {
+            $constraint->fail($response, $message);
+        }
+    }
+
+    /**
+     * Assert that response redirects to given URL
+     *
+     * @param string $url
+     * @param string $message
+     */
+    public function assertRedirectTo($url, $message = '')
+    {
+        $this->_incrementAssertionCount();
+        require_once 'Zend/Test/PHPUnit/Constraint/Redirect.php';
+        $constraint = new Zend_Test_PHPUnit_Constraint_Redirect();
+        $response   = $this->response;
+        if (!$constraint->evaluate_compat($response, __FUNCTION__, $url)) {
+            $constraint->fail($response, $message);
+        }
+    }
+
+    /**
+     * Assert that response does not redirect to given URL
+     *
+     * @param string $url
+     * @param string $message
+     */
+    public function assertNotRedirectTo($url, $message = '')
+    {
+        $this->_incrementAssertionCount();
+        require_once 'Zend/Test/PHPUnit/Constraint/Redirect.php';
+        $constraint = new Zend_Test_PHPUnit_Constraint_Redirect();
+        $response   = $this->response;
+        if (!$constraint->evaluate_compat($response, __FUNCTION__, $url)) {
+            $constraint->fail($response, $message);
+        }
+    }
+
+    /**
+     * Assert that redirect location matches pattern
+     *
+     * @param string $pattern
+     * @param string $message
+     */
+    public function assertRedirectRegex($pattern, $message = '')
+    {
+        $this->_incrementAssertionCount();
+        require_once 'Zend/Test/PHPUnit/Constraint/Redirect.php';
+        $constraint = new Zend_Test_PHPUnit_Constraint_Redirect();
+        $response   = $this->response;
+        if (!$constraint->evaluate_compat($response, __FUNCTION__, $pattern)) {
+            $constraint->fail($response, $message);
+        }
+    }
+
+    /**
+     * Assert that redirect location does not match pattern
+     *
+     * @param string $pattern
+     * @param string $message
+     */
+    public function assertNotRedirectRegex($pattern, $message = '')
+    {
+        $this->_incrementAssertionCount();
+        require_once 'Zend/Test/PHPUnit/Constraint/Redirect.php';
+        $constraint = new Zend_Test_PHPUnit_Constraint_Redirect();
+        $response   = $this->response;
+        if (!$constraint->evaluate_compat($response, __FUNCTION__, $pattern)) {
+            $constraint->fail($response, $message);
+        }
+    }
+
+    /**
+     * Assert response code
+     *
+     * @param int $code
+     * @param string $message
+     */
+    public function assertResponseCode($code, $message = '')
+    {
+        $this->_incrementAssertionCount();
+        require_once 'Zend/Test/PHPUnit/Constraint/ResponseHeader.php';
+        $constraint = new Zend_Test_PHPUnit_Constraint_ResponseHeader();
+        $response   = $this->response;
+        if (!$constraint->evaluate_compat($response, __FUNCTION__, $code)) {
+            $constraint->fail($response, $message);
+        }
+    }
+
+    /**
+     * Assert response code
+     *
+     * @param int $code
+     * @param string $message
+     */
+    public function assertNotResponseCode($code, $message = '')
+    {
+        $this->_incrementAssertionCount();
+        require_once 'Zend/Test/PHPUnit/Constraint/ResponseHeader.php';
+        $constraint = new Zend_Test_PHPUnit_Constraint_ResponseHeader();
+        $constraint->setNegate(true);
+        $response   = $this->response;
+        if (!$constraint->evaluate_compat($response, __FUNCTION__, $code)) {
+            $constraint->fail($response, $message);
+        }
+    }
+
+    /**
+     * Assert response header exists
+     *
+     * @param string $header
+     * @param string $message
+     */
+    public function assertHeader($header, $message = '')
+    {
+        $this->_incrementAssertionCount();
+        require_once 'Zend/Test/PHPUnit/Constraint/ResponseHeader.php';
+        $constraint = new Zend_Test_PHPUnit_Constraint_ResponseHeader();
+        $response   = $this->response;
+        if (!$constraint->evaluate_compat($response, __FUNCTION__, $header)) {
+            $constraint->fail($response, $message);
+        }
+    }
+
+    /**
+     * Assert response header does not exist
+     *
+     * @param string $header
+     * @param string $message
+     */
+    public function assertNotHeader($header, $message = '')
+    {
+        $this->_incrementAssertionCount();
+        require_once 'Zend/Test/PHPUnit/Constraint/ResponseHeader.php';
+        $constraint = new Zend_Test_PHPUnit_Constraint_ResponseHeader();
+        $constraint->setNegate(true);
+        $response   = $this->response;
+        if (!$constraint->evaluate_compat($response, __FUNCTION__, $header)) {
+            $constraint->fail($response, $message);
+        }
+    }
+
+    /**
+     * Assert response header exists and contains the given string
+     *
+     * @param string $header
+     * @param string $match
+     * @param string $message
+     */
+    public function assertHeaderContains($header, $match, $message = '')
+    {
+        $this->_incrementAssertionCount();
+        require_once 'Zend/Test/PHPUnit/Constraint/ResponseHeader.php';
+        $constraint = new Zend_Test_PHPUnit_Constraint_ResponseHeader();
+        $response   = $this->response;
+        if (!$constraint->evaluate_compat($response, __FUNCTION__, $header, $match)) {
+            $constraint->fail($response, $message);
+        }
+    }
+
+    /**
+     * Assert response header does not exist and/or does not contain the given string
+     *
+     * @param string $header
+     * @param string $match
+     * @param string $message
+     */
+    public function assertNotHeaderContains($header, $match, $message = '')
+    {
+        $this->_incrementAssertionCount();
+        require_once 'Zend/Test/PHPUnit/Constraint/ResponseHeader.php';
+        $constraint = new Zend_Test_PHPUnit_Constraint_ResponseHeader();
+        $constraint->setNegate(true);
+        $response   = $this->response;
+        if (!$constraint->evaluate_compat($response, __FUNCTION__, $header, $match)) {
+            $constraint->fail($response, $message);
+        }
+    }
+
+    /**
+     * Assert response header exists and matches the given pattern
+     *
+     * @param string $header
+     * @param string $pattern
+     * @param string $message
+     */
+    public function assertHeaderRegex($header, $pattern, $message = '')
+    {
+        $this->_incrementAssertionCount();
+        require_once 'Zend/Test/PHPUnit/Constraint/ResponseHeader.php';
+        $constraint = new Zend_Test_PHPUnit_Constraint_ResponseHeader();
+        $response   = $this->response;
+        if (!$constraint->evaluate_compat($response, __FUNCTION__, $header, $pattern)) {
+            $constraint->fail($response, $message);
+        }
+    }
+
+    /**
+     * Assert response header does not exist and/or does not match the given regex
+     *
+     * @param string $header
+     * @param string $pattern
+     * @param string $message
+     */
+    public function assertNotHeaderRegex($header, $pattern, $message = '')
+    {
+        $this->_incrementAssertionCount();
+        require_once 'Zend/Test/PHPUnit/Constraint/ResponseHeader.php';
+        $constraint = new Zend_Test_PHPUnit_Constraint_ResponseHeader();
+        $constraint->setNegate(true);
+        $response   = $this->response;
+        if (!$constraint->evaluate_compat($response, __FUNCTION__, $header, $pattern)) {
+            $constraint->fail($response, $message);
+        }
+    }
+
+    /**
+     * Assert that the last handled request used the given module
+     *
+     * @param string $module
+     * @param string $message
+     */
+    public function assertModule($module, $message = '')
+    {
+        $this->_incrementAssertionCount();
+        if ($module != $this->request->getModuleName()) {
+            $msg = sprintf('Failed asserting last module used <"%s"> was "%s"',
+                $this->request->getModuleName(),
+                $module
+            );
+            if (!empty($message)) {
+                $msg = $message . "\n" . $msg;
+            }
+            $this->fail($msg);
+        }
+    }
+
+    /**
+     * Assert that the last handled request did NOT use the given module
+     *
+     * @param string $module
+     * @param string $message
+     */
+    public function assertNotModule($module, $message = '')
+    {
+        $this->_incrementAssertionCount();
+        if ($module == $this->request->getModuleName()) {
+            $msg = sprintf('Failed asserting last module used was NOT "%s"', $module);
+            if (!empty($message)) {
+                $msg = $message . "\n" . $msg;
+            }
+            $this->fail($msg);
+        }
+    }
+
+    /**
+     * Assert that the last handled request used the given controller
+     *
+     * @param string $controller
+     * @param string $message
+     */
+    public function assertController($controller, $message = '')
+    {
+        $this->_incrementAssertionCount();
+        if ($controller != $this->request->getControllerName()) {
+            $msg = sprintf('Failed asserting last controller used <"%s"> was "%s"',
+                $this->request->getControllerName(),
+                $controller
+            );
+            if (!empty($message)) {
+                $msg = $message . "\n" . $msg;
+            }
+            $this->fail($msg);
+        }
+    }
+
+    /**
+     * Assert that the last handled request did NOT use the given controller
+     *
+     * @param  string $controller
+     * @param  string $message
+     */
+    public function assertNotController($controller, $message = '')
+    {
+        $this->_incrementAssertionCount();
+        if ($controller == $this->request->getControllerName()) {
+            $msg = sprintf('Failed asserting last controller used <"%s"> was NOT "%s"',
+                $this->request->getControllerName(),
+                $controller
+            );
+            if (!empty($message)) {
+                $msg = $message . "\n" . $msg;
+            }
+            $this->fail($msg);
+        }
+    }
+
+    /**
+     * Assert that the last handled request used the given action
+     *
+     * @param string $action
+     * @param string $message
+     */
+    public function assertAction($action, $message = '')
+    {
+        $this->_incrementAssertionCount();
+        if ($action != $this->request->getActionName()) {
+            $msg = sprintf('Failed asserting last action used <"%s"> was "%s"', $this->request->getActionName(), $action);
+            if (!empty($message)) {
+                $msg = $message . "\n" . $msg;
+            }
+            $this->fail($msg);
+        }
+    }
+
+    /**
+     * Assert that the last handled request did NOT use the given action
+     *
+     * @param string $action
+     * @param string $message
+     */
+    public function assertNotAction($action, $message = '')
+    {
+        $this->_incrementAssertionCount();
+        if ($action == $this->request->getActionName()) {
+            $msg = sprintf('Failed asserting last action used <"%s"> was NOT "%s"', $this->request->getActionName(), $action);
+            if (!empty($message)) {
+                $msg = $message . "\n" . $msg;
+            }
+            $this->fail($msg);
+        }
+    }
+
+    /**
+     * Assert that the specified route was used
+     *
+     * @param string $route
+     * @param string $message
+     */
+    public function assertRoute($route, $message = '')
+    {
+        $this->_incrementAssertionCount();
+        $router = $this->frontController->getRouter();
+        if ($route != $router->getCurrentRouteName()) {
+            $msg = sprintf('Failed asserting matched route was "%s", actual route is %s',
+                $route,
+                $router->getCurrentRouteName()
+            );
+            if (!empty($message)) {
+                $msg = $message . "\n" . $msg;
+            }
+            $this->fail($msg);
+        }
+    }
+
+    /**
+     * Assert that the route matched is NOT as specified
+     *
+     * @param string $route
+     * @param string $message
+     */
+    public function assertNotRoute($route, $message = '')
+    {
+        $this->_incrementAssertionCount();
+        $router = $this->frontController->getRouter();
+        if ($route == $router->getCurrentRouteName()) {
+            $msg = sprintf('Failed asserting route matched was NOT "%s"', $route);
+            if (!empty($message)) {
+                $msg = $message . "\n" . $msg;
+            }
+            $this->fail($msg);
+        }
+    }
+
+    /**
+     * Retrieve front controller instance
+     *
+     * @return Zend_Controller_Front
+     */
+    public function getFrontController()
+    {
+        if (null === $this->_frontController) {
+            $this->_frontController = Zend_Controller_Front::getInstance();
+        }
+        return $this->_frontController;
+    }
+
+    /**
+     * Retrieve test case request object
+     *
+     * @return Zend_Controller_Request_HttpTestCase
+     */
+    public function getRequest()
+    {
+        if (null === $this->_request) {
+            require_once 'Zend/Controller/Request/HttpTestCase.php';
+            $this->_request = new Zend_Controller_Request_HttpTestCase;
+        }
+        return $this->_request;
+    }
+
+    /**
+     * Retrieve test case response object
+     *
+     * @return Zend_Controller_Response_HttpTestCase
+     */
+    public function getResponse()
+    {
+        if (null === $this->_response) {
+            require_once 'Zend/Controller/Response/HttpTestCase.php';
+            $this->_response = new Zend_Controller_Response_HttpTestCase;
+        }
+        return $this->_response;
+    }
+
+    /**
+     * Retrieve DOM query object
+     *
+     * @return Zend_Dom_Query
+     */
+    public function getQuery()
+    {
+        if (null === $this->_query) {
+            require_once 'Zend/Dom/Query.php';
+            $this->_query = new Zend_Dom_Query;
+        }
+        return $this->_query;
+    }
+
+    /**
+     * URL Helper
+     *
+     * @param  array  $urlOptions
+     * @param  string $name
+     * @param  bool   $reset
+     * @param  bool   $encode
+     * @throws Exception
+     * @throws Zend_Controller_Router_Exception
+     * @return string
+     */
+    public function url($urlOptions = [], $name = null, $reset = false, $encode = true)
+    {
+        $frontController = $this->getFrontController();
+        $router = $frontController->getRouter();
+        if (!$router instanceof Zend_Controller_Router_Rewrite) {
+            throw new Exception('This url helper utility function only works when the router is of type Zend_Controller_Router_Rewrite');
+        }
+        if (count($router->getRoutes()) === 0) {
+            $router->addDefaultRoutes();
+        }
+        return $router->assemble($urlOptions, $name, $reset, $encode);
+    }
+
+    /**
+     * Urlize options
+     *
+     * @param  array $urlOptions
+     * @param  bool  $actionControllerModuleOnly
+     * @return array
+     */
+    public function urlizeOptions($urlOptions, $actionControllerModuleOnly = true)
+    {
+        $ccToDash = new Zend_Filter_Word_CamelCaseToDash();
+        foreach ($urlOptions as $n => $v) {
+            if (in_array($n, ['action', 'controller', 'module'])) {
+                $urlOptions[$n] = $ccToDash->filter($v);
+            }
+        }
+        return $urlOptions;
+    }
+
+    /**
+     * Increment assertion count
+     */
+    protected function _incrementAssertionCount()
+    {
+        $stack = debug_backtrace();
+        foreach ($stack as $step) {
+            if (isset($step['object'])
+                && $step['object'] instanceof PHPUnit\Framework\TestCase
+            ) {
+                if (version_compare(PHPUnit\Runner\Version::id(), '3.3.0', 'lt')) {
+                    break;
+                } elseif (version_compare(PHPUnit\Runner\Version::id(), '3.3.3', 'lt')) {
+                    $step['object']->incrementAssertionCounter();
+                } else {
+                    $step['object']->addToAssertionCount(1);
+                }
+                break;
+            }
+        }
+    }
+}


### PR DESCRIPTION
This patch adds compatibility with recent versions of PHPUnit starting with version 6 up to the current version (13 at the time of this writing). Backwards compatibility with earlier versions is maintained, although these early versions are no longer available on github and the usual package repositories, and would probably raise all sorts of other compatibility issues.

Use requires either autoloading of classes to be enabled, or including the necessary classes manually before including the respective Zend/Test/PHPUnit files.

Although the patch looks relatively big, most of it is just renaming classes and files, so that different versions can be loaded depending on the PHPUnit version.