### PR TITLE
Fix Zend_Session::start() false-positive on PHP 8.x (SID constant persists after session_write_close)

### DIFF
--- a/library/Zend/Session.php
+++ b/library/Zend/Session.php
@@ -467,8 +467,10 @@ class Zend_Session extends Zend_Session_Abstract
                . " output started in {$filename}/{$linenum}");
         }
 
-        // See http://www.php.net/manual/en/ref.session.php for explanation
-        if (!self::$_unitTestEnabled && defined('SID')) {
+        // Use session_status() instead of defined('SID'): in PHP 8.x the SID constant remains
+        // defined after session_write_close(), so the old check incorrectly reports that a session
+        // is already active on the next request when it is not. session_status() is authoritative.
+        if (!self::$_unitTestEnabled && session_status() === PHP_SESSION_ACTIVE) {
             /** @see Zend_Session_Exception */
             require_once 'Zend/Session/Exception.php';
             throw new Zend_Session_Exception('session has already been started by session.auto-start or session_start()');
@@ -675,7 +677,7 @@ class Zend_Session extends Zend_Session_Abstract
      */
     public static function setId($id)
     {
-        if (!self::$_unitTestEnabled && defined('SID')) {
+        if (!self::$_unitTestEnabled && session_status() === PHP_SESSION_ACTIVE) {
             /** @see Zend_Session_Exception */
             require_once 'Zend/Session/Exception.php';
             throw new Zend_Session_Exception('The session has already been started.  The session id must be set first.');


### PR DESCRIPTION
## Problem

On PHP 8.x (confirmed on 8.3), `Zend_Session::start()` throws:

```
Zend_Session_Exception: session has already been started by session.auto-start or session_start()
```

on normal page requests, making the framework unusable.

## Root cause

`Zend_Session::start()` (and `setId()`) guard against double-starts with:

```php
if (!self::$_unitTestEnabled && defined('SID')) {
    throw new Zend_Session_Exception('session has already been started...');
}
```

`defined('SID')` was a PHP 4/5 idiom: PHP defines the `SID` constant when `session_start()` is first called in a process. The assumption was that `SID` being defined meant a session was already running.

**This assumption breaks in PHP 8.x.** After `session_write_close()` is called (e.g. at the end of a request under mod_php or a persistent php-fpm worker), `session_status()` correctly returns `PHP_SESSION_NONE` — but `SID` **remains defined** for the lifetime of the process. On the next request handled by the same worker, `defined('SID')` returns `true` even though no session is active, triggering the false exception.

Verified with a test script under Apache/mod_php on PHP 8.3:
```
Post-close:  status=1 (PHP_SESSION_NONE)  SID_defined=true
```

## Fix

Replace both `defined('SID')` checks with `session_status() === PHP_SESSION_ACTIVE`.

`session_status()` was introduced in PHP 5.4 and is the authoritative way to determine whether a session is currently active. It correctly returns `PHP_SESSION_NONE` after `session_write_close()`, regardless of whether `SID` is defined.

```php
// Before
if (!self::$_unitTestEnabled && defined('SID')) {

// After
if (!self::$_unitTestEnabled && session_status() === PHP_SESSION_ACTIVE) {
```

Two occurrences changed: one in `start()` and one in `setId()`.