### PR TITLE
PHP 8.5 compatibility fixes

### DIFF
--- a/library/Zend/Barcode/Renderer/Image.php
+++ b/library/Zend/Barcode/Renderer/Image.php
@@ -348,7 +348,9 @@ class Zend_Barcode_Renderer_Image extends Zend_Barcode_Renderer_RendererAbstract
         header("Content-Type: image/" . $this->_imageType);
         $functionName = 'image' . $this->_imageType;
         call_user_func($functionName, $this->_resource);
-        @imagedestroy($this->_resource);
+        if (PHP_VERSION_ID < 80000) {
+            @imagedestroy($this->_resource);
+        }
     }
 
     /**

--- a/library/Zend/Captcha/Image.php
+++ b/library/Zend/Captcha/Image.php
@@ -583,8 +583,10 @@ class Zend_Captcha_Image extends Zend_Captcha_Word
         }
 
         imagepng($img2, $img_file);
-        imagedestroy($img);
-        imagedestroy($img2);
+        if (PHP_VERSION_ID < 80000) {
+            imagedestroy($img);
+            imagedestroy($img2);
+        }
     }
 
     /**

--- a/library/Zend/CodeGenerator/Php/Property/DefaultValue.php
+++ b/library/Zend/CodeGenerator/Php/Property/DefaultValue.php
@@ -228,6 +228,32 @@ class Zend_CodeGenerator_Php_Property_DefaultValue extends Zend_CodeGenerator_Ph
     }
 
     /**
+     * Wraps each array element in a DefaultValue instance for code generation.
+     *
+     * Replaces the old RecursiveArrayIterator approach, which under PHP 8.5
+     * mutated values via offsetSet during iteration and called
+     * new ArrayIterator($object) when descending (deprecated in 8.5).
+     *
+     * @param  array $array
+     * @param  int   $depth
+     * @return array
+     */
+    protected function _prepareArrayValue(array $array, $depth)
+    {
+        $result = [];
+        foreach ($array as $key => $value) {
+            if (is_array($value)) {
+                $value = new self(['value' => $this->_prepareArrayValue($value, $depth + 1)]);
+            } elseif (!$value instanceof self) {
+                $value = new self(['value' => $value]);
+            }
+            $value->setArrayDepth($depth);
+            $result[$key] = $value;
+        }
+        return $result;
+    }
+
+    /**
      * generate()
      *
      * @return string
@@ -246,18 +272,7 @@ class Zend_CodeGenerator_Php_Property_DefaultValue extends Zend_CodeGenerator_Ph
             $type = $this->_getAutoDeterminedType($value);
 
             if ($type == self::TYPE_ARRAY) {
-                $rii = new RecursiveIteratorIterator(
-                    $it = new RecursiveArrayIterator($value),
-                    RecursiveIteratorIterator::SELF_FIRST
-                    );
-                foreach ($rii as $curKey => $curValue) {
-                    if (!$curValue instanceof Zend_CodeGenerator_Php_Property_DefaultValue) {
-                        $curValue = new self(['value' => $curValue]);
-                        $rii->getSubIterator()->offsetSet($curKey, $curValue);
-                    }
-                    $curValue->setArrayDepth($rii->getDepth());
-                }
-                $value = $rii->getSubIterator()->getArrayCopy();
+                $value = $this->_prepareArrayValue((array) $value, 0);
             }
 
         }

--- a/library/Zend/Db/Select.php
+++ b/library/Zend/Db/Select.php
@@ -332,7 +332,7 @@ class Zend_Db_Select
             $correlationName = current($correlationNameKeys);
         }
 
-        if (!array_key_exists($correlationName, $this->_parts[self::FROM])) {
+        if (!array_key_exists($correlationName ?? '', $this->_parts[self::FROM])) {
             /**
              * @see Zend_Db_Select_Exception
              */

--- a/library/Zend/Db/Statement.php
+++ b/library/Zend/Db/Statement.php
@@ -176,6 +176,7 @@ abstract class Zend_Db_Statement implements Zend_Db_Statement_Interface
      */
     protected function _stripQuoted($sql)
     {
+        $sql = (string) $sql;
 
         // get the character for value quoting
         // this should be '
@@ -191,13 +192,13 @@ abstract class Zend_Db_Statement implements Zend_Db_Statement_Interface
         if (!empty($q)) {
             $escapeChar = preg_quote($escapeChar);
             // this segfaults only after 65,000 characters instead of 9,000
-            $sql = preg_replace("/$q([^$q{$escapeChar}]*|($qe)*)*$q/s", '', (string) $sql);
+            $sql = preg_replace("/$q([^$q{$escapeChar}]*|($qe)*)*$q/s", '', $sql) ?? $sql;
         }
 
         // get a version of the SQL statement with all quoted
         // values and delimited identifiers stripped out
         // remove "foo\"bar"
-        $sql = preg_replace("/\"(\\\\\"|[^\"])*\"/Us", '', (string) $sql);
+        $sql = preg_replace("/\"(\\\\\"|[^\"])*\"/Us", '', $sql) ?? $sql;
 
         // get the character for delimited id quotes,
         // this is usually " but in MySQL is `
@@ -209,7 +210,7 @@ abstract class Zend_Db_Statement implements Zend_Db_Statement_Interface
         $de = substr($de, 1, 2);
         $de = preg_quote($de);
         // Note: $de and $d where never used..., now they are:
-        $sql = preg_replace("/$d($de|\\\\{2}|[^$d])*$d/Us", '', (string) $sql);
+        $sql = preg_replace("/$d($de|\\\\{2}|[^$d])*$d/Us", '', $sql) ?? $sql;
         return $sql;
     }
 

--- a/library/Zend/Feed/Atom.php
+++ b/library/Zend/Feed/Atom.php
@@ -98,7 +98,7 @@ class Zend_Feed_Atom extends Zend_Feed_Abstract
             }
 
             $doc = new DOMDocument($this->_element->version,
-                                   $this->_element->actualEncoding);
+                                   $this->_element->encoding);
             $feed = $doc->appendChild($doc->createElement('feed'));
             $feed->appendChild($doc->importNode($element, true));
             $element = $feed;
@@ -360,7 +360,7 @@ class Zend_Feed_Atom extends Zend_Feed_Abstract
     {
         // Return a complete document including XML prologue.
         $doc = new DOMDocument($this->_element->ownerDocument->version,
-                               $this->_element->ownerDocument->actualEncoding);
+                               $this->_element->ownerDocument->encoding);
         $doc->appendChild($doc->importNode($this->_element, true));
         $doc->formatOutput = true;
 
@@ -383,7 +383,7 @@ class Zend_Feed_Atom extends Zend_Feed_Abstract
             throw new Zend_Feed_Exception('Cannot send ATOM because headers have already been sent.');
         }
 
-        header('Content-Type: application/atom+xml; charset=' . $this->_element->ownerDocument->actualEncoding);
+        header('Content-Type: application/atom+xml; charset=' . $this->_element->ownerDocument->encoding);
 
         echo $this->saveXml();
     }

--- a/library/Zend/Feed/Element.php
+++ b/library/Zend/Feed/Element.php
@@ -135,7 +135,7 @@ class Zend_Feed_Element implements ArrayAccess
     {
         // Return a complete document including XML prologue.
         $doc = new DOMDocument((string) $this->_element->ownerDocument->version,
-                               (string) $this->_element->ownerDocument->actualEncoding);
+                               (string) $this->_element->ownerDocument->encoding);
         $doc->appendChild($doc->importNode($this->_element, true));
         return $doc->saveXML();
     }

--- a/library/Zend/Feed/Rss.php
+++ b/library/Zend/Feed/Rss.php
@@ -487,7 +487,7 @@ class Zend_Feed_Rss extends Zend_Feed_Abstract
     {
         // Return a complete document including XML prologue.
         $doc = new DOMDocument($this->_element->ownerDocument->version,
-                               $this->_element->ownerDocument->actualEncoding);
+                               $this->_element->ownerDocument->encoding);
         $root = $doc->createElement('rss');
 
         // Use rss version 2.0
@@ -522,7 +522,7 @@ class Zend_Feed_Rss extends Zend_Feed_Abstract
             throw new Zend_Feed_Exception('Cannot send RSS because headers have already been sent.');
         }
 
-        header('Content-Type: application/rss+xml; charset=' . $this->_element->ownerDocument->actualEncoding);
+        header('Content-Type: application/rss+xml; charset=' . $this->_element->ownerDocument->encoding);
 
         echo $this->saveXml();
     }

--- a/library/Zend/File/Transfer/Adapter/Http.php
+++ b/library/Zend/File/Transfer/Adapter/Http.php
@@ -135,7 +135,8 @@ class Zend_File_Transfer_Adapter_Http extends Zend_File_Transfer_Adapter_Abstrac
                 $files = current($files);
             }
 
-            $temp = [$files => [
+            $fileKey = $files ?? '';
+            $temp = [$fileKey => [
                 'name'  => $files,
                 'error' => 1]];
             $validator = $this->_validators['Zend_Validate_File_Upload'];

--- a/library/Zend/Filter/Input.php
+++ b/library/Zend/Filter/Input.php
@@ -852,7 +852,7 @@ class Zend_Filter_Input
 
                     if (is_array($rule)) {
                         $keys      = array_keys($rule);
-                        $classKey  = array_shift($keys);
+                        $classKey  = array_shift($keys) ?? '';
                         if (isset($rule[$classKey])) {
                             $ruleClass = $rule[$classKey];
                             if ($ruleClass === 'NotEmpty') {

--- a/library/Zend/Form.php
+++ b/library/Zend/Form.php
@@ -2123,6 +2123,7 @@ class Zend_Form implements Iterator, Countable, Zend_Validate_Interface
      */
     protected function _dissolveArrayValue($value, $arrayPath)
     {
+        $arrayPath = $arrayPath ?? '';
         // As long as we have more levels
         while ($arrayPos = strpos((string) $arrayPath, '[')) {
             // Get the next key in the path
@@ -2181,6 +2182,7 @@ class Zend_Form implements Iterator, Countable, Zend_Validate_Interface
      */
     protected function _attachToArray($value, $arrayPath)
     {
+        $arrayPath = $arrayPath ?? '';
         // As long as we have more levels
         while ($arrayPos = strrpos($arrayPath, '[')) {
             // Get the next key in the path

--- a/library/Zend/Http/Client.php
+++ b/library/Zend/Http/Client.php
@@ -538,6 +538,7 @@ class Zend_Http_Client
      */
     protected function _setParameter($type, $name, $value)
     {
+        $name = $name ?? '';
         $parray = [];
         $type = strtolower($type);
         switch ($type) {

--- a/library/Zend/Navigation/Container.php
+++ b/library/Zend/Navigation/Container.php
@@ -512,7 +512,7 @@ abstract class Zend_Navigation_Container implements RecursiveIterator, Countable
     {
         $this->_sort();
         current($this->_index);
-        $hash = key($this->_index);
+        $hash = key($this->_index) ?? '';
 
         if (isset($this->_pages[$hash])) {
             return $this->_pages[$hash];
@@ -598,7 +598,7 @@ abstract class Zend_Navigation_Container implements RecursiveIterator, Countable
      */
     public function getChildren(): ?\RecursiveIterator
     {
-        $hash = key($this->_index);
+        $hash = key($this->_index) ?? '';
 
         if (isset($this->_pages[$hash])) {
             return $this->_pages[$hash];

--- a/library/Zend/Search/Lucene/Document/Xlsx.php
+++ b/library/Zend/Search/Lucene/Document/Xlsx.php
@@ -194,7 +194,7 @@ class Zend_Search_Lucene_Document_Xlsx extends Zend_Search_Lucene_Document_OpenX
                             if (is_numeric($value) && $dataType != 's') {
                                 if ($value == (int)$value) $value = (int)$value;
                                 elseif ($value == (float)$value) $value = (float)$value;
-                                elseif ($value == (double)$value) $value = (double)$value;
+                                elseif ($value == (float)$value) $value = (float)$value;
                             }
                     }
 

--- a/library/Zend/TimeSync.php
+++ b/library/Zend/TimeSync.php
@@ -300,6 +300,6 @@ class Zend_TimeSync implements IteratorAggregate
         }
         $timeServerObj = new $className($adress, $port);
 
-        $this->_timeservers[$alias] = $timeServerObj;
+        $this->_timeservers[$alias ?? ''] = $timeServerObj;
     }
 }

--- a/library/Zend/Translate/Adapter/Tmx.php
+++ b/library/Zend/Translate/Adapter/Tmx.php
@@ -194,8 +194,10 @@ class Zend_Translate_Adapter_Tmx extends Zend_Translate_Adapter {
                         $this->_tu = $this->_content;
                     }
 
-                    if (!empty($this->_content) || (!isset($this->_data[$this->_tuv][$this->_tu]))) {
-                        $this->_data[$this->_tuv][$this->_tu] = $this->_content;
+                    $tuv = $this->_tuv ?? '';
+                    $tu  = $this->_tu ?? '';
+                    if (!empty($this->_content) || (!isset($this->_data[$tuv][$tu]))) {
+                        $this->_data[$tuv][$tu] = $this->_content;
                     }
                     break;
                 default:

--- a/library/Zend/Wildfire/Plugin/FirePhp.php
+++ b/library/Zend/Wildfire/Plugin/FirePhp.php
@@ -722,7 +722,7 @@ class Zend_Wildfire_Plugin_FirePhp implements Zend_Wildfire_Plugin_Interface
                         $return[$name] = $this->_encodeObject($members[$raw_name], $objectDepth + 1, 1);
 
                     } else {
-                        if (method_exists($property,'setAccessible')) {
+                        if (PHP_VERSION_ID < 80100 && method_exists($property,'setAccessible')) {
                             $property->setAccessible(true);
                             $return[$name] = $this->_encodeObject($property->getValue($object), $objectDepth + 1, 1);
                         } else


### PR DESCRIPTION
## Summary

Resolves PHP 8.5 deprecations still present on `master`. Each category below was confirmed to emit a deprecation on PHP 8.5 before fixing; every changed file passes `php -l`.

| Fix | Deprecation (PHP 8.5) | Files |
|---|---|---|
| `DOMDocument::$actualEncoding` → `->encoding` | property removed in 8.1; fatal in 8.5 | `Zend/Feed/Rss.php`, `Atom.php`, `Element.php` |
| `?? ''` guards for null array offsets / `array_key_exists()` keys | "Using null as an array offset is deprecated" | `Db/Select.php`, `Http/Client.php`, `Form.php`, `Filter/Input.php`, `Navigation/Container.php`, `File/Transfer/Adapter/Http.php`, `TimeSync.php`, `Translate/Adapter/Tmx.php` |
| `preg_replace(...) ?? $sql` so a PCRE-limit failure can't pass `null` to `preg_split()` | "Passing null to parameter #2 ($subject) ... is deprecated" — **fixes #520** | `Db/Statement.php` |
| `imagedestroy()` called only on `PHP_VERSION_ID < 80000` | "deprecated since 8.5, as it has no effect since 8.0" | `Captcha/Image.php`, `Barcode/Renderer/Image.php` |
| `ReflectionProperty::setAccessible()` called only on `PHP_VERSION_ID < 80100` | "deprecated since 8.5, as it has no effect since 8.1" | `Wildfire/Plugin/FirePhp.php` |
| Non-canonical cast alias `(double)` → `(float)` | "Non-canonical cast ... is deprecated" | `Search/Lucene/Document/Xlsx.php` |
| `CodeGenerator` default-value arrays: `RecursiveArrayIterator` + `offsetSet`-during-iteration (which calls `new ArrayIterator($object)`) replaced with an explicit recursive helper | `new ArrayIterator($object)` deprecated in 8.5 | `CodeGenerator/Php/Property/DefaultValue.php` |

Closes #520.

Notes:
- The cast-alias change was located with PHP's **tokenizer** (`token_get_all`), so only the real cast operator is changed — `(boolean)`/`(integer)` appearing in doc comments is intentionally left untouched.
- The **case-statement-semicolon** deprecation (`case X;` → `case X:`) is already fixed on this fork's master, so it is not part of this PR.

## Attribution

These fixes draw on the parallel PHP 8.5 work in the [`zf1s/zf1`](https://github.com/zf1s/zf1) fork — specifically [PR #227](https://github.com/zf1s/zf1/pull/227) (null-as-array-offset guards) and [PR #225](https://github.com/zf1s/zf1/pull/225) (the broader 8.5 sweep). Credit to their authors; this PR ports the equivalent changes to this fork's layout and to what `master` here still needs. The `Db/Statement.php` fix follows the approach proposed in #520.

## Testing

- `php -l` clean on all 17 changed files (PHP 8.5.7).
- The cast and case-semicolon detection re-runs report 0 remaining (idempotent).
- The `CodeGenerator` refactor produces valid output for nested arrays with 0 deprecations.
