### PR TITLE
Fix implicit float to int deprecation in S3/Sqs retry backoff

### DIFF
--- a/library/Zend/Service/Amazon/S3.php
+++ b/library/Zend/Service/Amazon/S3.php
@@ -698,7 +698,7 @@ class Zend_Service_Amazon_S3 extends Zend_Service_Amazon_Abstract
             if ($response_code >= 500 && $response_code < 600 && $retry_count <= 5) {
                 $retry = true;
                 $retry_count++;
-                sleep($retry_count / 4 * $retry_count);
+                sleep((int) ($retry_count / 4 * $retry_count));
             }
             else if ($response_code == 307) {
                 // Need to redirect, new S3 endpoint given

--- a/library/Zend/Service/Amazon/Sqs.php
+++ b/library/Zend/Service/Amazon/Sqs.php
@@ -456,7 +456,7 @@ class Zend_Service_Amazon_Sqs extends Zend_Service_Amazon_Abstract
             if ($response_code >= 500 && $response_code < 600 && $retry_count <= 5) {
                 $retry = true;
                 $retry_count++;
-                sleep($retry_count / 4 * $retry_count);
+                sleep((int) ($retry_count / 4 * $retry_count));
             }
         } while ($retry);
 

--- a/tests/Zend/Service/Amazon/S3/OfflineTest.php
+++ b/tests/Zend/Service/Amazon/S3/OfflineTest.php
@@ -22,6 +22,10 @@ use Yoast\PHPUnitPolyfills\TestCases\TestCase;
  * @license    http://framework.zend.com/license/new-bsd     New BSD License
  * @version    $Id$
  */
+
+require_once 'Zend/Service/Amazon/S3.php';
+require_once 'Zend/Http/Client/Adapter/Test.php';
+
 /**
  * @category   Zend
  * @package    Zend_Service_Amazon_S3
@@ -34,15 +38,55 @@ use Yoast\PHPUnitPolyfills\TestCases\TestCase;
  */
 class Zend_Service_Amazon_S3_OfflineTest extends TestCase
 {
-    protected function set_up()
-    {
-        $this->markTestSkipped('No offline tests for Zend_Service_Amazon_S3');
-    }
+    /**
+     * Reference to Amazon service consumer object
+     *
+     * @var Zend_Service_Amazon_S3
+     */
+    protected $_amazon;
 
     /**
-     * @doesNotPerformAssertions
+     * Test based HTTP client adapter
+     *
+     * @var Zend_Http_Client_Adapter_Test
      */
-    public function testNothing()
+    protected $_httpClientAdapterTest;
+
+    protected function set_up()
     {
+        $this->_amazon = new Zend_Service_Amazon_S3('test', 'test');
+
+        $this->_httpClientAdapterTest = new Zend_Http_Client_Adapter_Test();
+
+        $this->_amazon->getHttpClient()
+                      ->setAdapter($this->_httpClientAdapterTest);
+    }
+
+    public function testRetryAfter5xxResponseDoesNotTriggerImplicitFloatToIntDeprecation()
+    {
+        $this->_httpClientAdapterTest->setResponse("HTTP/1.1 500 Internal Server Error\r\n\r\n");
+        $this->_httpClientAdapterTest->addResponse("HTTP/1.1 200 OK\r\n\r\n");
+
+        $deprecations = [];
+        set_error_handler(
+            static function ($errno, $errstr) use (&$deprecations) {
+                $deprecations[] = $errstr;
+                return true;
+            },
+            E_DEPRECATED
+        );
+
+        try {
+            // First response is 500 (triggers one retry -> sleep(1/4*1)), second is 200.
+            $this->_amazon->isBucketAvailable('test-bucket');
+        } finally {
+            restore_error_handler();
+        }
+
+        $this->assertSame(
+            [],
+            $deprecations,
+            'Retrying an S3 request after a 5xx response must not trigger an E_DEPRECATED notice'
+        );
     }
 }

--- a/tests/Zend/Service/Amazon/Sqs/OfflineTest.php
+++ b/tests/Zend/Service/Amazon/Sqs/OfflineTest.php
@@ -96,4 +96,35 @@ class Zend_Service_Amazon_Sqs_OfflineTest extends TestCase
                                      'ap-northeast-1' => 'sqs.ap-northeast-1.amazonaws.com'];
         $this->assertEquals($this->_amazon->getEndpoints(), $endPoints);
     }
+
+    public function testRetryAfter5xxResponseDoesNotTriggerImplicitFloatToIntDeprecation()
+    {
+        $this->_httpClientAdapterTest->setResponse("HTTP/1.1 500 Internal Server Error\r\n\r\n");
+        $this->_httpClientAdapterTest->addResponse("HTTP/1.1 200 OK\r\n\r\n<ListQueuesResponse></ListQueuesResponse>");
+
+        $reflection = new ReflectionMethod(Zend_Service_Amazon_Sqs::class, '_makeRequest');
+        $reflection->setAccessible(true);
+
+        $deprecations = [];
+        set_error_handler(
+            static function ($errno, $errstr) use (&$deprecations) {
+                $deprecations[] = $errstr;
+                return true;
+            },
+            E_DEPRECATED
+        );
+
+        try {
+            // First response is 500 (triggers one retry -> sleep(1/4*1)), second is 200.
+            $reflection->invoke($this->_amazon, null, 'ListQueues');
+        } finally {
+            restore_error_handler();
+        }
+
+        $this->assertSame(
+            [],
+            $deprecations,
+            'Retrying an SQS request after a 5xx response must not trigger an E_DEPRECATED notice'
+        );
+    }
 }


### PR DESCRIPTION
## Problem

`Zend_Service_Amazon_S3::_makeRequest()` and `Zend_Service_Amazon_Sqs::_makeRequest()` both retry on a 5xx response using:

```php
sleep($retry_count / 4 * $retry_count);
```

For most values of `$retry_count` this evaluates to a float with a fractional part (e.g. `1/4*1 = 0.25`). Since PHP 8.1, passing a non-integral float to `sleep()` (which type-hints `int`) raises:

```
E_DEPRECATED: Implicit conversion from float 0.25 to int loses precision
```

This surfaces as noisy deprecation warnings/log noise for any consumer running PHP 8.1+ whose S3/SQS requests hit a transient 5xx and retry.

## Fix

Cast the computed backoff to `(int)` before calling `sleep()` in both places. This preserves the previous behavior (PHP already silently truncated the float when passed to a native function expecting `int`), it just removes the deprecation notice.

## Tests

Added regression tests to the existing offline test suites for both services (`tests/Zend/Service/Amazon/S3/OfflineTest.php`, `tests/Zend/Service/Amazon/Sqs/OfflineTest.php`). Each queues a `500` response followed by a `200` via `Zend_Http_Client_Adapter_Test` (triggering exactly one retry iteration) and asserts no `E_DEPRECATED` notice is raised. Both tests fail with the exact message above against the unfixed code and pass after the `(int)` cast.

(The S3 offline test class previously only contained a skipped placeholder test — `markTestSkipped('No offline tests for Zend_Service_Amazon_S3')` — so it's now wired up the same way `Sqs/OfflineTest.php` already was, using `Zend_Http_Client_Adapter_Test`.)