### PR TITLE
Include missing Zend_Session_SaveHandler_SessionHandlerInterfaceAdapter in Session.php

### DIFF
--- a/library/Zend/Session.php
+++ b/library/Zend/Session.php
@@ -37,6 +37,10 @@ require_once 'Zend/Session/Namespace.php';
  */
 require_once 'Zend/Session/SaveHandler/Interface.php';
 
+/**
+ * @see Zend_Session_SaveHandler_SessionHandlerInterfaceAdapter
+ */
+require_once 'Zend/Session/SaveHandler/SaveHandlerInterfaceAdapter.php';
 
 /**
  * Zend_Session


### PR DESCRIPTION
Added missing require statement for Zend_Session_SaveHandler_SessionHandlerInterfaceAdapter which is used in Session without being required that causes error.