### PR TITLE
Zend_Service_Amazon_S3::removeObject() can issue DeleteBucket for a slash-less object name

### DIFF
--- a/library/Zend/Service/Amazon/S3.php
+++ b/library/Zend/Service/Amazon/S3.php
@@ -551,6 +551,21 @@ class Zend_Service_Amazon_S3 extends Zend_Service_Amazon_Abstract
     public function removeObject($object)
     {
         $object = $this->_fixupObjectName($object);
+
+        /**
+         * An object name containing no '/' resolves to a bare bucket name, and S3 reads
+         * DELETE <bucket> as DeleteBucket. A caller that composes "$bucket/$path" therefore
+         * asks to delete the BUCKET whenever $path is empty, which succeeds silently on an
+         * empty bucket. Refuse it; use removeBucket() to remove a bucket.
+         */
+        if (strpos($object, '/') === false) {
+            require_once 'Zend/Service/Amazon/S3/Exception.php';
+            throw new Zend_Service_Amazon_S3_Exception(
+                "Object name \"$object\" resolves to a bucket, not an object;"
+                . " use removeBucket() to remove a bucket"
+            );
+        }
+
         $response = $this->_makeRequest('DELETE', $object);
 
         // Look for a 204 No Content response


### PR DESCRIPTION
`removeObject()` passes its argument through `_fixupObjectName()`, which returns a **bare bucket name** when the path contains no `/`:

```php
$nameparts = explode('/', $object);
$this->_validBucketName($nameparts[0]);
$firstpart = array_shift($nameparts);

if (count($nameparts) === 0) {
    return $firstpart;          // <- just the bucket
}
```

`removeObject()` then issues `DELETE <bucket>`, which S3 interprets as **DeleteBucket**, not DeleteObject.

Any caller composing a path like `"$bucket/$key"` therefore asks to delete the *bucket* whenever `$key` is empty — an easy state to reach from a null database column or an unset array key.

The failure is silent. The request succeeds on an empty bucket and returns 409 on a non-empty one, so nothing surfaces until the bucket in question happens to be empty — at which point it is gone.

We hit this in production: several hundred such calls over ten days, a few of them against a primary storage bucket. Nothing was lost only because those buckets were non-empty at the time.

### The fix

Refuse the call when the resolved name has no `/`, and point the caller at `removeBucket()`.

It throws `Zend_Service_Amazon_S3_Exception`, matching how `setEndpoint()` and `_validBucketName()` reject invalid input elsewhere in this class.

`removeObject()` is the only method where this is destructive — the other `_fixupObjectName()` callers (`isObjectAvailable`, `getInfo`, `getObject`, `getObjectStream`, `putObject`, `copyObject`) issue HEAD, GET or PUT, which are harmless against a bucket path.

### Compatibility

This turns a silent no-op into an exception for code that passes a slash-less name. That is a behaviour change, but only on a call path that could never have deleted an object and could delete a bucket — so anything relying on the old behaviour was already relying on a bug.

Happy to switch it to `return false` with a `trigger_error()` instead if you would rather keep it strictly non-throwing.
