### PR TITLE
Fix Maximum Length Vulnerability in StringLength Validator

### DIFF
--- a/library/Zend/Validate/StringLength.php
+++ b/library/Zend/Validate/StringLength.php
@@ -237,6 +237,11 @@ class Zend_Validate_StringLength extends Zend_Validate_Abstract
             $length = iconv_strlen($value);
         }
 
+        if ($length === false) {
+            $this->_error(self::INVALID);
+            return false;
+        }
+
         if ($length < $this->_min) {
             $this->_error(self::TOO_SHORT);
         }


### PR DESCRIPTION
# FIX STRINGLENGTH VALIDATOR

This fix for `Zend_Validate_StringLength` is being submitted simultaneously to *ZF1-Future* and *zf1s* via regular pull requests, since neither project's repo has a defined security policy.

A maximum length check can presently be defeated by inserting a malformed byte sequence (*"illegal character"*) into the input string.  I tracked this down after one of my web forms got exploited with arbitrarily long strings.

## THE PROBLEM

The `isValid()` method calculates string length using `iconv_strlen()`, which returns *"**false** if an error occurs during the encoding"*.

Since boolean FALSE is not strictly checked for, it gets interpreted as a string length of **zero (0)** and passes the maximum length check, regardless of the actual length of the input.

It is worth noting that this vulnerability does not affect validators that have also set a **minimum length** of 1 or greater, as it relies upon a zero-length string passing as valid.

## THE FIX

My fix simply adds a strict check for boolean FALSE that can produce a `self::INVALID` error after `iconv_strlen()` is called.

(It can be argued that the current message -- *"Invalid type given. String expected"* -- is not technically correct for an encoding failure, but my intention is to submit a minimal fix and leave it to the discretion of the individual project maintainers if this warrants adding another error message to the class.)

## EXAMPLE CODE

The following code can be used to test the flaw and the fix:
```php
# UTF-8 STRING CONTAINING BAD SEQUENCE: \xe9
$value = "I?t?rn?ti?n\xe9?liz?ti?n";

# ATTEMPT TO VALIDATE AGAINST MAXIMUM LENGTH OF 1
$validator = new Zend_Validate_StringLength;
$validator->setMax(1);
$isValid = $validator->isValid($value);
var_dump($isValid);
```

The malformed string above is taken from an example posted by "hfuecks" in the PHP Manual: https://www.php.net/manual/en/function.iconv-strlen.php#62320
